### PR TITLE
Add `.mob` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 result
 .tmp
+
+# Configuration file for `mob` CLI (see <https://mob.sh>)
+# with contents varying per mob.
+.mob


### PR DESCRIPTION
During Summer of Nix 2023, multiple mobs will work on various packages in this repository. They might all want to configure `mob` differently using a configuration file.