### PR TITLE
flarum: use independent php module builder flake

### DIFF
--- a/all-packages.nix
+++ b/all-packages.nix
@@ -1,10 +1,6 @@
-{
-  newScope,
-  php-newScope,
-  ...
-}: let
+{newScope, ...}: let
   self = rec {
-    flarum = php-callPackage ./pkgs/flarum {};
+    flarum = callPackage ./pkgs/flarum {};
     gnunet-messenger-cli = callPackage ./pkgs/gnunet-messenger-cli {};
     kikit = callPackage ./pkgs/kikit {};
     liberaforms = callPackage ./pkgs/liberaforms {};
@@ -20,6 +16,5 @@
   };
 
   callPackage = newScope (self // nixpkgs-candidates // {inherit callPackage;});
-  php-callPackage = php-newScope (self // nixpkgs-candidates // {inherit callPackage;});
 in
   self

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1690933134,
+        "narHash": "sha256-ab989mN63fQZBFrkk4Q8bYxQCktuHmBIBqUG1jl6/FQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "59cf3f1447cfc75087e7273b04b31e689a8599fb",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-parts",
+        "type": "indirect"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": [
@@ -20,6 +37,24 @@
         "type": "github"
       }
     },
+    "nix-php-composer-builder": {
+      "inputs": {
+        "flake-parts": "flake-parts"
+      },
+      "locked": {
+        "lastModified": 1691252882,
+        "narHash": "sha256-kCiFl72gV/OzDPCrw2CeHM6VEtVGFj57gaF8ZKD9LWI=",
+        "owner": "loophp",
+        "repo": "nix-php-composer-builder",
+        "rev": "0caf5a60753397cfa959a74fc9ea0562556573c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "loophp",
+        "repo": "nix-php-composer-builder",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1689752456,
@@ -36,18 +71,20 @@
         "type": "github"
       }
     },
-    "php-nixpkgs": {
+    "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1689687631,
-        "narHash": "sha256-TxLnLoxc7GjnZqxeFH06GzuxReOvaweDHew5btAlqvs=",
-        "owner": "drupol",
+        "dir": "lib",
+        "lastModified": 1690881714,
+        "narHash": "sha256-h/nXluEqdiQHs1oSgkOOWF+j8gcJMWhwnZ9PFabN6q0=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "af638ea89a7aeef9fe6c1c674165314c09f02395",
+        "rev": "9e1960bc196baf6881340d53dccb203a951745a2",
         "type": "github"
       },
       "original": {
-        "owner": "drupol",
-        "ref": "php/add-new-builder",
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -55,10 +92,10 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "nix-php-composer-builder": "nix-php-composer-builder",
         "nixpkgs": "nixpkgs",
         "systems": "systems",
-        "treefmt-nix": "treefmt-nix",
-        "php-nixpkgs": "php-nixpkgs"
+        "treefmt-nix": "treefmt-nix"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "NgiPkgs";
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-  inputs.php-nixpkgs.url = "github:drupol/nixpkgs?ref=php/add-new-builder";
+  inputs.nix-php-composer-builder.url = "github:loophp/nix-php-composer-builder";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   # Set the defaultSystem list for flake-utils to only x86_64-linux
   inputs.systems.url = "github:nix-systems/x86_64-linux";
@@ -13,19 +13,22 @@
   outputs = {
     self,
     nixpkgs,
-    php-nixpkgs,
+    nix-php-composer-builder,
     flake-utils,
     treefmt-nix,
     ...
   }: let
     buildOutputs = system: let
-      pkgs = nixpkgs.legacyPackages.${system};
-      php-pkgs = php-nixpkgs.legacyPackages.${system};
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [
+          nix-php-composer-builder.overlays.default
+        ];
+      };
       treefmtEval = treefmt-nix.lib.evalModule pkgs ./treefmt.nix;
     in {
       packages = import ./all-packages.nix {
         inherit (pkgs) newScope;
-        php-newScope = php-pkgs.newScope;
       };
       nixosModules = {
         modules = import ./modules/all-modules.nix;

--- a/pkgs/flarum/default.nix
+++ b/pkgs/flarum/default.nix
@@ -2,9 +2,9 @@
   fetchFromGitHub,
   fetchurl,
   lib,
-  php,
+  pkgs,
 }:
-php.buildComposerProject (finalAttrs: {
+pkgs.api.buildComposerProject (finalAttrs: {
   pname = "flarum";
   version = "1.8.0";
 
@@ -16,7 +16,7 @@ php.buildComposerProject (finalAttrs: {
   };
 
   composerLock = ./composer.lock;
-  vendorHash = "sha256-KXC0kVuBXTqLlddWGEisSDChWE74nRNdUr+fieFTG1M=";
+  vendorHash = "sha256-G/EPHcvcppuyAC0MAzE11ZjlOSTlphQrHnO3yS4+j5g=";
 
   meta = {
     changelog = "https://github.com/flarum/framework/blob/main/CHANGELOG.md";


### PR DESCRIPTION
Per https://github.com/ngi-nix/ngipkgs/pull/33, the upstream PHP builder is currently a draft. Instead, we're using the separate PHP builder flake. This should be more stable in general, with a `nix flake update` should stay ahead of stable changes on upstream nixpkgs.