### PR TITLE
librecast: package lcrq

### DIFF
--- a/all-packages.nix
+++ b/all-packages.nix
@@ -3,6 +3,7 @@
     flarum = callPackage ./pkgs/flarum {};
     gnunet-messenger-cli = callPackage ./pkgs/gnunet-messenger-cli {};
     kikit = callPackage ./pkgs/kikit {};
+    lcrq = callPackage ./pkgs/lcrq {};
     liberaforms = callPackage ./pkgs/liberaforms {};
     liberaforms-env = callPackage ./pkgs/liberaforms/env.nix {};
     libgnunetchat = callPackage ./pkgs/libgnunetchat {};

--- a/pkgs/lcrq/default.nix
+++ b/pkgs/lcrq/default.nix
@@ -1,0 +1,27 @@
+{
+  stdenv,
+  fetchFromGitea,
+  lib,
+  ...
+}:
+stdenv.mkDerivation rec {
+  name = "lcrq";
+  version = "0.1.0";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "librecast";
+    repo = "lcrq";
+    rev = "v${version}";
+    sha256 = "sha256-s8+uTF6GQ76wG1zoAxqCaVT1J5Rd7vxPKX4zbQx6ro4=";
+  };
+
+  installFlags = ["PREFIX=$(out)"];
+
+  meta = with lib; {
+    homepage = "https://librecast.net/lcrq.html";
+    changelog = "https://codeberg.org/librecast/lcrq/src/branch/main/CHANGELOG.md";
+    description = "Librecast RaptorQ library.";
+    license = [licenses.gpl2 licenses.gpl3];
+  };
+}


### PR DESCRIPTION
Towards #3.

Package https://codeberg.org/librecast/lcrq, direct dependency of https://codeberg.org/librecast/librecast.