### PR TITLE
librecast: package lcsync

### DIFF
--- a/all-packages.nix
+++ b/all-packages.nix
@@ -4,6 +4,7 @@
     gnunet-messenger-cli = callPackage ./pkgs/gnunet-messenger-cli {};
     kikit = callPackage ./pkgs/kikit {};
     lcrq = callPackage ./pkgs/lcrq {};
+    lcsync = callPackage ./pkgs/lcsync {inherit lcrq librecast;};
     liberaforms = callPackage ./pkgs/liberaforms {};
     liberaforms-env = callPackage ./pkgs/liberaforms/env.nix {};
     libgnunetchat = callPackage ./pkgs/libgnunetchat {};

--- a/pkgs/lcrq/default.nix
+++ b/pkgs/lcrq/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://librecast.net/lcrq.html";
-    changelog = "https://codeberg.org/librecast/lcrq/src/branch/main/CHANGELOG.md";
+    changelog = "https://codeberg.org/librecast/lcrq/src/tag/v${version}/CHANGELOG.md";
     description = "Librecast RaptorQ library.";
     license = [licenses.gpl2 licenses.gpl3];
   };

--- a/pkgs/lcsync/default.nix
+++ b/pkgs/lcsync/default.nix
@@ -1,0 +1,32 @@
+{
+  stdenv,
+  pkgs,
+  fetchFromGitea,
+  lcrq,
+  librecast,
+  lib,
+  ...
+}:
+stdenv.mkDerivation rec {
+  name = "lcsync";
+  version = "0.2.1";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "librecast";
+    repo = "lcsync";
+    rev = "v${version}";
+    sha256 = "sha256-RVfa0EmCPPT7ndy94YwD24S9pj7L11ztISaKHGcbTS8=";
+  };
+  buildInputs = [lcrq librecast pkgs.libsodium];
+  configureFlags = ["SETCAP_PROGRAM=true"];
+  installFlags = ["PREFIX=$(out)"];
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://librecast.net/lcsync.html";
+    changelog = "https://codeberg.org/librecast/lcsync/src/tag/v${version}/CHANGELOG.md";
+    description = "Librecast File and Syncing Tool";
+    license = [licenses.gpl2 licenses.gpl3];
+  };
+}

--- a/pkgs/librecast/default.nix
+++ b/pkgs/librecast/default.nix
@@ -3,19 +3,27 @@
   pkgs,
   fetchFromGitea,
   lcrq,
+  lib,
   ...
 }:
 stdenv.mkDerivation rec {
   name = "librecast";
-  version = "0.6.1";
+  version = "0.7-RC3";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "librecast";
     repo = "librecast";
     rev = "v${version}";
-    sha256 = "sha256-o7ZPczQOw45kAAyu0fHCTKTUC78W0gkuL2Qge0+1Pc4=";
+    sha256 = "sha256-AD3MpWg8Lp+VkizwYTuuS2YWM8e0xaMEavVIvwhSZRo=";
   };
   buildInputs = [lcrq pkgs.libsodium];
   installFlags = ["PREFIX=$(out)"];
+
+  meta = with lib; {
+    homepage = "https://librecast.net/librecast.html";
+    changelog = "https://codeberg.org/librecast/librecast/src/tag/v${version}/CHANGELOG.md";
+    description = "IPv6 multicast library";
+    license = [licenses.gpl2 licenses.gpl3];
+  };
 }


### PR DESCRIPTION
Towards #3.

This PR packages `lcsync`. We previously packaged its 2 dependencies [`lcrq`](https://github.com/ngi-nix/ngipkgs/pull/35) and [`librecast`](https://github.com/ngi-nix/ngipkgs/pull/36).

According to [this comment by @cleeyv](https://github.com/ngi-nix/ngi/issues/122#issuecomment-1591866588), these 3 packages were the main targets. We will now reach out to Librecast maintainers for guidance on any other packages in their project that we should work on.

Co-authored-by: Jason Odoom <jasonodoom@gmail.com>
Co-authored-by: Anish Lakhwara <anish+git@lakhwara.com>
Co-authored-by: Dominic Mills <dominic.millz27@gmail.com>
Co-authored-by: Albert Chae <albertchae@users.noreply.github.com>
Co-authored-by: Jack Leightcap <jack@leightcap.com>
Signed-off-by: Jack Leightcap <jack@leightcap.com>