### PR TITLE
flarum: init module at 1.8.0

### DIFF
--- a/configs/all-configurations.nix
+++ b/configs/all-configurations.nix
@@ -2,7 +2,9 @@
   # LiberaForms is intentionally disabled.
   # Refer to <https://github.com/ngi-nix/ngipkgs/issues/40>.
   #liberaforms-container = import ./liberaforms/container.nix;
-
+  flarum = {
+    imports = [./flarum];
+  };
   pretalx-postgresql = {
     imports = [
       ./pretalx/pretalx.nix

--- a/configs/flarum/default.nix
+++ b/configs/flarum/default.nix
@@ -1,0 +1,14 @@
+{
+  boot.isContainer = true;
+  networking.hostName = "test-flarum";
+
+  # Allow nginx through the firewall
+  networking.firewall.allowedTCPPorts = [80];
+
+  services.nginx.enable = true;
+  nixpkgs.hostPlatform = "x86_64-linux";
+  services.flarum = {
+    enable = true;
+    domain = "10.233.2.2";
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -42,15 +42,16 @@
         "flake-parts": "flake-parts"
       },
       "locked": {
-        "lastModified": 1693994164,
-        "narHash": "sha256-BtVCeCp5TInZ40bQtOAgT/0ghKWY+fW5EORFelFtcP4=",
+        "lastModified": 1691252882,
+        "narHash": "sha256-kCiFl72gV/OzDPCrw2CeHM6VEtVGFj57gaF8ZKD9LWI=",
         "owner": "loophp",
         "repo": "nix-php-composer-builder",
-        "rev": "600bc67c1adce95675d6c3487ba61ae5fab4dc25",
+        "rev": "0caf5a60753397cfa959a74fc9ea0562556573c1",
         "type": "github"
       },
       "original": {
         "owner": "loophp",
+        "ref": "0caf5a60753397cfa959a74fc9ea0562556573c1",
         "repo": "nix-php-composer-builder",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "NgiPkgs";
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-  inputs.nix-php-composer-builder.url = "github:loophp/nix-php-composer-builder";
+  inputs.nix-php-composer-builder.url = "github:loophp/nix-php-composer-builder?ref=0caf5a60753397cfa959a74fc9ea0562556573c1";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   # Set default system to `x86_64-linux`,
   # as we currently only support Linux.
@@ -112,7 +112,7 @@
           // {
             # The default module adds the default overlay on top of nixpkgs.
             # This is so that `ngipkgs` can be used alongside `nixpkgs` in a configuration.
-            default.nixpkgs.overlays = [self.overlays.default];
+            default.nixpkgs.overlays = [self.overlays.default nix-php-composer-builder.overlays.default];
           };
 
         # Overlays a package set (e.g. nixpkgs) with the packages defined in this flake.

--- a/modules/all-modules.nix
+++ b/modules/all-modules.nix
@@ -3,4 +3,5 @@
   # Refer to <https://github.com/ngi-nix/ngipkgs/issues/40>.
   #liberaforms = import ./liberaforms.nix;
   pretalx = import ./pretalx.nix;
+  flarum = import ./flarum.nix;
 }

--- a/modules/flarum.nix
+++ b/modules/flarum.nix
@@ -1,0 +1,217 @@
+{
+  config,
+  lib,
+  pkgs,
+  self,
+  utils,
+  ...
+}:
+with builtins;
+with lib; let
+  cfg = config.services.flarum;
+  opt = options.services.flarum;
+
+  flarumInstallConfig = pkgs.writeText "config.json" (builtins.toJSON {
+    debug = false;
+    offline = false;
+
+    baseUrl = cfg.baseUrl;
+    databaseConfiguration = cfg.database;
+    adminUser = {
+      username = cfg.adminUser;
+      password = cfg.initialAdminPassword;
+      email = cfg.adminEmail;
+    };
+    settings = {forum_title = cfg.forumTitle;};
+  });
+in {
+  options = {
+    services.flarum = with types; {
+      enable = mkEnableOption "Flarum discussion platform";
+
+      package = mkPackageOption pkgs "flarum" {};
+
+      forumTitle = mkOption {
+        type = types.str;
+        default = "A Flarum Forum on NixOS";
+        description = "Title of the forum.";
+      };
+
+      domain = mkOption {
+        type = types.str;
+        default = "localhost";
+        example = "forum.example.com";
+        description = "Domain to serve on.";
+      };
+
+      baseUrl = mkOption {
+        type = types.str;
+        default = "https://${cfg.domain}";
+        example = "https://forum.example.com";
+        description = "Change `domain` instead.";
+      };
+
+      adminUser = mkOption {
+        type = types.str;
+        default = "flarum";
+        description = "Username for first web application administrator";
+      };
+
+      adminEmail = mkOption {
+        type = types.str;
+        default = "admin@example.com";
+        description = "Email for first web application administrator";
+      };
+
+      initialAdminPassword = mkOption {
+        type = types.str;
+        default = "flarum";
+        description = "Initial password for the adminUser";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "flarum";
+        description = "System user to run Flarum";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "flarum";
+        description = "System group to run Flarum";
+      };
+
+      stateDir = mkOption {
+        type = types.path;
+        default = "/var/lib/flarum";
+        description = "Home directory for writable storage";
+      };
+
+      database = mkOption rec {
+        type = with types; attrsOf (oneOf [str bool int]);
+        description = "MySQL database parameters";
+        default = {
+          # the database driver; i.e. MySQL; MariaDB...
+          driver = "mysql";
+          # the host of the connection; localhost in most cases unless using an external service
+          host = "localhost";
+          # the name of the database in the instance
+          database = "flarum";
+          # database username
+          username = "flarum";
+          # database password
+          password = "";
+          # the prefix for the tables; useful if you are sharing the same database with another service
+          prefix = "";
+          # the port of the connection; defaults to 3306 with MySQL
+          port = 3306;
+          strict = false;
+        };
+      };
+
+      createDatabaseLocally = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Create the database and database user locally, and run installation.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      home = cfg.stateDir;
+      createHome = true;
+      group = cfg.group;
+    };
+    users.groups.${cfg.group} = {};
+
+    services.phpfpm.pools.flarum = {
+      user = cfg.user;
+      settings = {
+        "listen.owner" = config.services.nginx.user;
+        "listen.group" = config.services.nginx.group;
+        "listen.mode" = "0600";
+        "pm" = mkDefault "dynamic";
+        "pm.max_children" = mkDefault 10;
+        "pm.max_requests" = mkDefault 500;
+        "pm.start_servers" = mkDefault 2;
+        "pm.min_spare_servers" = mkDefault 1;
+        "pm.max_spare_servers" = mkDefault 3;
+      };
+      phpOptions = ''
+        error_log = syslog
+        log_errors = on
+      '';
+    };
+
+    services.nginx = {
+      enable = true;
+      virtualHosts."${cfg.domain}" = {
+        root = "${cfg.stateDir}/public";
+        locations."~ \.php$".extraConfig = ''
+          fastcgi_pass unix:${config.services.phpfpm.pools.flarum.socket};
+          fastcgi_index site.php;
+        '';
+        extraConfig = ''
+          index index.php
+          include ${cfg.package}/build/.nginx.conf;
+        '';
+      };
+    };
+
+    services.mysql = mkIf cfg.enable {
+      enable = true;
+      package = pkgs.mysql;
+      ensureDatabases = [cfg.database.database];
+      ensureUsers = [
+        {
+          name = cfg.database.username;
+          ensurePermissions = {
+            "${cfg.database.database}.*" = "ALL PRIVILEGES";
+          };
+        }
+      ];
+    };
+
+    assertions = [
+      {
+        assertion = !cfg.createDatabaseLocally || cfg.database.driver == "mysql";
+        message = "Flarum can only be automatically installed in MySQL/MariaDB.";
+      }
+    ];
+
+    systemd.services.flarum-install = {
+      description = "Flarum installation";
+      requiredBy = ["phpfpm-flarum.service"];
+      before = ["phpfpm-flarum.service"];
+      requires = ["mysql.service"];
+      after = ["mysql.service"];
+      serviceConfig = {
+        Type = "oneshot";
+        User = cfg.user;
+        Group = cfg.group;
+      };
+      path = [config.services.phpfpm.phpPackage];
+      script =
+        ''
+          mkdir -p ${cfg.stateDir}/{extensions,public/assets/avatars}
+          mkdir -p ${cfg.stateDir}/storage/{formatter,sessions,views}
+          cd ${cfg.stateDir}
+          cp -f ${cfg.package}/build/{extend.php,site.php,flarum} .
+          ln -sf ${cfg.package}/build/vendor .
+          ln -sf ${cfg.package}/build/public/index.php public/
+          chmod a+x . public
+          chmod +x site.php extend.php flarum
+        ''
+        + lib.optionalString
+        (cfg.createDatabaseLocally && cfg.database.driver == "mysql") ''
+          if [ ! -f config.php ]; then
+             php flarum install --file=${flarumInstallConfig}
+          fi
+          php flarum migrate
+          # php flarum cache:clear
+        '';
+    };
+  };
+}


### PR DESCRIPTION
Closes https://github.com/ngi-nix/ngipkgs/issues/10

- add a module definition for flarum, copied/inspired by this closed PR from a few years ago https://github.com/NixOS/nixpkgs/pull/96869/files#diff-d694d99e5b93515b9aeb968b1335e30f9349a205780f0f558d131988c7913dec
  - We commented out most of the module and added pieces back one by one, following the instructions at https://docs.flarum.org/install/
  - A key realization (which was already in the original PR) was that we could pass in a configuration file to `php flarum install` https://discuss.flarum.org/d/22187-command-line-install-via-php-flarum-install-no-interaction/5

- Add https://github.com/loophp/nix-php-composer-builder/ as an input to the module because it's used in packaging
  - We are pinning it to 0caf5a60753397cfa959a74fc9ea0562556573c1 because that's what we developed against. Currently the latest version puts build artifacts in directories that are not compatible with our module definition. We will look into pointing to the latest of that repo or use the upstreamed version introduced in https://github.com/NixOS/nixpkgs/pull/248184

- add a default configuration for flarum


Future work:
- as mentioned previous, update the php-composer-builder to a newer SHA or use the upstream version
- add testing using nixos tests pattern that pretalx introduced

Co-authored-by: Jason Odoom <jasonodoom@gmail.com>
Co-authored-by: Anish Lakhwara <anish+git@lakhwara.com>
Co-authored-by: Dominic Mills <dominic.millz27@gmail.com>
Co-authored-by: Albert Chae <albertchae@users.noreply.github.com>
Co-authored-by: Jack Leightcap <jack@leightcap.com>