### PR TITLE
ci: Use Cachix instead of Magic Nix Cache for push

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,0 +1,18 @@
+name: nix flake check
+
+on:
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            experimental-features = no-url-literals
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          upstream-cache: https://ngi.cachix.org/
+      - run: nix flake check

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,8 +1,7 @@
-name: CI
+name: nix flake check
 
 on:
   push:
-  pull_request:
 
 jobs:
   check:
@@ -13,5 +12,8 @@ jobs:
         with:
           extra-conf: |
             experimental-features = no-url-literals
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: cachix/cachix-action@v10
+        with:
+          name: ngi
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix flake check


### PR DESCRIPTION
Builds are taking longer and longer, [e.g. >2h for pretalx](https://github.com/ngi-nix/ngipkgs/actions/runs/6197704469/job/16826773062). By using Cachix, we could warm the cache locally (`cachix watch-store ngi`) which would then speed up GitHub actions.

Since pushes to Cachix should not be allowed for external PRs, I split the workflows in two. The workflow for pull requests will use Magic Nix Cache, falling back to Cachix.