### PR TITLE
flarum: update buildComposerProject and fix some module bugs

### DIFF
--- a/configs/flarum/default.nix
+++ b/configs/flarum/default.nix
@@ -7,8 +7,9 @@
 
   services.nginx.enable = true;
   nixpkgs.hostPlatform = "x86_64-linux";
-  services.flarum = {
+  services.flarum = rec {
     enable = true;
-    domain = "10.233.2.2";
+    # domain = "localhost"; # Default, Set this to whatever your local container IP address is
+    # baseUrl = "https://{domain}" # Default, if you need http override manually
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,22 +1,5 @@
 {
   "nodes": {
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1690933134,
-        "narHash": "sha256-ab989mN63fQZBFrkk4Q8bYxQCktuHmBIBqUG1jl6/FQ=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "59cf3f1447cfc75087e7273b04b31e689a8599fb",
-        "type": "github"
-      },
-      "original": {
-        "id": "flake-parts",
-        "type": "indirect"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": [
@@ -37,55 +20,18 @@
         "type": "github"
       }
     },
-    "nix-php-composer-builder": {
-      "inputs": {
-        "flake-parts": "flake-parts"
-      },
-      "locked": {
-        "lastModified": 1693994164,
-        "narHash": "sha256-BtVCeCp5TInZ40bQtOAgT/0ghKWY+fW5EORFelFtcP4=",
-        "owner": "loophp",
-        "repo": "nix-php-composer-builder",
-        "rev": "600bc67c1adce95675d6c3487ba61ae5fab4dc25",
-        "type": "github"
-      },
-      "original": {
-        "owner": "loophp",
-        "ref": "0caf5a60753397cfa959a74fc9ea0562556573c1",
-        "repo": "nix-php-composer-builder",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694593561,
-        "narHash": "sha256-WSaIQZ5s9N9bDFkEMTw6P9eaZ9bv39ZhsiW12GtTNM0=",
+        "lastModified": 1694948089,
+        "narHash": "sha256-d2B282GmQ9o8klc22/Rbbbj6r99EnELQpOQjWMyv0rU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1697b7d480449b01111e352021f46e5879e47643",
+        "rev": "5148520bfab61f99fd25fb9ff7bfbb50dad3c9db",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib": {
-      "locked": {
-        "dir": "lib",
-        "lastModified": 1690881714,
-        "narHash": "sha256-h/nXluEqdiQHs1oSgkOOWF+j8gcJMWhwnZ9PFabN6q0=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "9e1960bc196baf6881340d53dccb203a951745a2",
-        "type": "github"
-      },
-      "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -109,7 +55,6 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nix-php-composer-builder": "nix-php-composer-builder",
         "nixpkgs": "nixpkgs",
         "sops-nix": "sops-nix",
         "systems": "systems",

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,6 @@
   description = "NgiPkgs";
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-  inputs.nix-php-composer-builder.url = "github:loophp/nix-php-composer-builder?ref=0caf5a60753397cfa959a74fc9ea0562556573c1";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   # Set default system to `x86_64-linux`,
   # as we currently only support Linux.
@@ -17,7 +16,6 @@
   outputs = {
     self,
     nixpkgs,
-    nix-php-composer-builder,
     flake-utils,
     treefmt-nix,
     sops-nix,
@@ -47,9 +45,7 @@
 
       # Compute outputs that are invariant in the system architecture.
       allSystemsOutputs = system: let
-        pkgs = importNixpkgs system [
-          nix-php-composer-builder.overlays.default
-        ];
+        pkgs = importNixpkgs system [];
         treefmtEval = loadTreefmt pkgs;
       in {
         packages = importPackages pkgs;
@@ -112,7 +108,7 @@
           // {
             # The default module adds the default overlay on top of nixpkgs.
             # This is so that `ngipkgs` can be used alongside `nixpkgs` in a configuration.
-            default.nixpkgs.overlays = [self.overlays.default nix-php-composer-builder.overlays.default];
+            default.nixpkgs.overlays = [self.overlays.default];
           };
 
         # Overlays a package set (e.g. nixpkgs) with the packages defined in this flake.

--- a/modules/flarum.nix
+++ b/modules/flarum.nix
@@ -154,7 +154,7 @@ in {
           fastcgi_index site.php;
         '';
         extraConfig = ''
-          index index.php
+          index index.php;
           include ${cfg.package}/share/php/flarum/.nginx.conf;
         '';
       };
@@ -196,7 +196,7 @@ in {
       script =
         ''
           mkdir -p ${cfg.stateDir}/{extensions,public/assets/avatars}
-          mkdir -p ${cfg.stateDir}/storage/{formatter,sessions,views}
+          mkdir -p ${cfg.stateDir}/storage/{cache,formatter,sessions,views}
           cd ${cfg.stateDir}
           cp -f ${cfg.package}/share/php/flarum/{extend.php,site.php,flarum} .
           ln -sf ${cfg.package}/share/php/flarum/vendor .
@@ -210,7 +210,7 @@ in {
              php flarum install --file=${flarumInstallConfig}
           fi
           php flarum migrate
-          # php flarum cache:clear
+          php flarum cache:clear
         '';
     };
   };

--- a/modules/flarum.nix
+++ b/modules/flarum.nix
@@ -155,7 +155,7 @@ in {
         '';
         extraConfig = ''
           index index.php
-          include ${cfg.package}/build/.nginx.conf;
+          include ${cfg.package}/share/php/flarum/.nginx.conf;
         '';
       };
     };
@@ -198,9 +198,9 @@ in {
           mkdir -p ${cfg.stateDir}/{extensions,public/assets/avatars}
           mkdir -p ${cfg.stateDir}/storage/{formatter,sessions,views}
           cd ${cfg.stateDir}
-          cp -f ${cfg.package}/build/{extend.php,site.php,flarum} .
-          ln -sf ${cfg.package}/build/vendor .
-          ln -sf ${cfg.package}/build/public/index.php public/
+          cp -f ${cfg.package}/share/php/flarum/{extend.php,site.php,flarum} .
+          ln -sf ${cfg.package}/share/php/flarum/vendor .
+          ln -sf ${cfg.package}/share/php/flarum/public/index.php public/
           chmod a+x . public
           chmod +x site.php extend.php flarum
         ''

--- a/pkgs/flarum/default.nix
+++ b/pkgs/flarum/default.nix
@@ -2,9 +2,9 @@
   fetchFromGitHub,
   fetchurl,
   lib,
-  pkgs,
+  php,
 }:
-pkgs.api.buildComposerProject (finalAttrs: {
+php.buildComposerProject (finalAttrs: {
   pname = "flarum";
   version = "1.8.0";
 


### PR DESCRIPTION
- flarum: Use upstreamed `buildComposerProject` instead of external flake
  - Run `nix flake update` to update `nixpkgs-unstable` so we have
  `buildComposerProject` available

  - Remove any references to external flake `buildComposerProject`

  - Use `buildComposerProject` from `php` input

  - The updated `buildComposerProject` moved build outputs from `./build` to `./share/php/flarum`, so update our module definition accordingly.

- flarum: various fixes
  - Uncomment `php flarum cache:clear`, which didn't work if `storage/cache` directory was missing
  - API calls to flarum were failing due to bad nginx routing, this is
    because a missing semicolon was causing flarum nginx.conf not to be
    included properly

Co-authored-by: Jason Odoom <jasonodoom@gmail.com>
Co-authored-by: Anish Lakhwara <anish+git@lakhwara.com>
Co-authored-by: Dominic Mills <dominic.millz27@gmail.com>
Co-authored-by: Albert Chae <albertchae@users.noreply.github.com>
Co-authored-by: Jack Leightcap <jack@leightcap.com>
