### PR TITLE
ci: Enable debugging on request

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -15,4 +15,4 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@main
         with:
           upstream-cache: https://ngi.cachix.org/
-      - run: nix flake check
+      - run: nix ${{ runner.debug && '--debug --print-build-logs' }} flake check

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -16,4 +16,5 @@ jobs:
         with:
           name: ngi
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - run: nix flake check
+      - run: nix ${{ runner.debug && '--debug --print-build-logs' }} flake check
+


### PR DESCRIPTION
Motivated by commits like ba1baa4649d8cbfac5b886f8236dea46e18cca16

With this change, we'll be able to toggle debugging via GitHub's "enable debug logging" feature:

![62ad606](https://github.com/ngi-nix/ngipkgs/assets/542154/5103168a-637a-43bf-be8a-35220cf602da)

Check the differences in output here:

<table class="tg">
<thead>
  <tr>
    <th class="tg-0pky">Workflow</th>
    <th class="tg-c3ow">Debug</th>
    <th class="tg-c3ow">Run</th>
    <th class="tg-c3ow">Attempt</th>
  </tr>
</thead>
<tbody>
  <tr>
    <td class="tg-0pky" rowspan="2">push</td>
    <td class="tg-0pky">no<br></td>
    <td class="tg-c3ow" rowspan="2">6904674009</td>
    <td class="tg-0pky"><a href="https://github.com/ngi-nix/ngipkgs/actions/runs/6904674009/attempts/1?pr=94" target="_blank" rel="noopener noreferrer">1</a></td>
  </tr>
  <tr>
    <td class="tg-0pky">yes<br></td>
    <td class="tg-0pky"><a href="https://github.com/ngi-nix/ngipkgs/actions/runs/6904674009/attempts/2?pr=94" target="_blank" rel="noopener noreferrer">2</a></td>
  </tr>
  <tr>
    <td class="tg-0pky" rowspan="2">pull_request</td>
    <td class="tg-0pky">no<br></td>
    <td class="tg-0pky" rowspan="2">6904737156</td>
    <td class="tg-0pky"><a href="https://github.com/ngi-nix/ngipkgs/actions/runs/6904737156/attempts/1?pr=94" target="_blank" rel="noopener noreferrer">1</a></td>
  </tr>
  <tr>
    <td class="tg-0pky">yes<br></td>
    <td class="tg-0pky"><a href="https://github.com/ngi-nix/ngipkgs/actions/runs/6904737156/attempts/2?pr=94" target="_blank" rel="noopener noreferrer">2</a></td>
  </tr>
</tbody>
</table>