### PR TITLE
add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 ngi-nix
+Copyright (c) 2023 NGIpkgs contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
another option would have been MPL 2.0, which is generally preferable in terms of the NGI program: to ensure that public money keeps translating into public code.

the decision for MIT is purely practical: to ease migrating the code into Nixpkgs, the place where the software project supported through NGI will most likely be found and put to use in a broader context.

there was no feedback from Nixpkgs maintainers on the topic: https://discourse.nixos.org/t/per-file-license-notes-in-nixpkgs/32390