### PR TITLE
taler sync: init at 0.9.3

### DIFF
--- a/pkgs/by-name/sync/generic.nix
+++ b/pkgs/by-name/sync/generic.nix
@@ -1,0 +1,49 @@
+{ lib, stdenv, libgcrypt, curl, gnutls, pkg-config, libiconv, libintl, version, src, meta ? {}, fetchpatch }:
+
+let
+  meta_ = meta;
+in
+
+stdenv.mkDerivation rec {
+  pname = "libmicrohttpd";
+  inherit version src;
+
+  patches = lib.optionals (lib.versionOlder version "0.9.76") [
+    (fetchpatch {
+      name = "CVE-2023-27371.patch";
+      url = "https://git.gnunet.org/libmicrohttpd.git/patch/?id=e0754d1638c602382384f1eface30854b1defeec";
+      hash = "sha256-vzrq9HPysGpc13rFEk6zLPgpUqp/ST4q/Wp30Dam97k=";
+      excludes = [
+        "ChangeLog"
+      ];
+    })
+  ];
+
+  outputs = [ "out" "dev" "devdoc" "info" ];
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libgcrypt curl gnutls libiconv libintl ];
+
+  preCheck = ''
+    # Since `localhost' can't be resolved in a chroot, work around it.
+    sed -ie 's/localhost/127.0.0.1/g' src/test*/*.[ch]
+  '';
+
+  # Disabled because the tests can time-out.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Embeddable HTTP server library";
+
+    longDescription = ''
+      GNU libmicrohttpd is a small C library that is supposed to make
+      it easy to run an HTTP server as part of another application.
+    '';
+
+    license = licenses.lgpl2Plus;
+
+    homepage = "https://www.gnu.org/software/libmicrohttpd/";
+
+    maintainers = with maintainers; [ eelco vrthra fpletz ];
+    platforms = platforms.unix;
+  } // meta_;
+}

--- a/pkgs/by-name/sync/libmicrohttpd.nix
+++ b/pkgs/by-name/sync/libmicrohttpd.nix
@@ -1,0 +1,10 @@
+{ callPackage, fetchurl }:
+
+callPackage ./generic.nix ( rec {
+  version = "0.9.74";
+
+  src = fetchurl {
+    url = "mirror://gnu/libmicrohttpd/libmicrohttpd-${version}.tar.gz";
+    sha256 = "sha256-QgNdAmE3MyS/tDQBj0q4klFLECU9GvIy5BtMwsEeZQs=";
+  };
+})

--- a/pkgs/by-name/sync/package.nix
+++ b/pkgs/by-name/sync/package.nix
@@ -1,0 +1,39 @@
+{
+  stdenv,
+  fetchgit,
+  autoreconfHook,
+  curl,
+  gnunet,
+  jansson,
+  libgcrypt,
+  libmicrohttpd,
+  libsodium,
+  pkg-config,
+  postgresql,
+  taler-exchange,
+}: let
+  version = "0.9.3";
+in
+  stdenv.mkDerivation {
+    name = "sync";
+    inherit version;
+
+    src = fetchgit {
+      url = "https://git.taler.net/sync.git";
+      rev = "v${version}";
+      hash = "sha256-u4oR9zCBpBSqKFIhm+pLTH83tPLvYULt8FhDyTsP7m4=";
+    };
+
+    nativeBuildInputs = [
+      autoreconfHook
+      curl
+      taler-exchange
+      gnunet
+      jansson
+      libgcrypt
+      libmicrohttpd
+      libsodium
+      pkg-config
+      postgresql
+    ];
+  }

--- a/pkgs/by-name/sync/package.nix
+++ b/pkgs/by-name/sync/package.nix
@@ -1,4 +1,7 @@
+# Upstream packages contain a bug, fixed by Enzime at https://github.com/Enzime/nixpkgs/update/taler
+# Once Enzime's patch is fixed, taler-exchange and taler-merchant can be callpackaged from nixpkgs again.
 {
+  lib,
   stdenv,
   fetchgit,
   autoreconfHook,
@@ -10,9 +13,20 @@
   libsodium,
   pkg-config,
   postgresql,
-  taler-exchange,
+  # taler-exchange,
+  # taler-merchant,
+  callPackage,
 }: let
   version = "0.9.3";
+
+  fixedExchangePkgs = import (fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/635096691eb96290fa415b28a57ec91383c767ae.tar.gz"; # Enzime/nixpkgs/update/taler
+    sha256 = "0nksic7ywy23r2gnxzb59pkk432jflbv5jd0259b93c1ilg38nwf";
+  }) {system = "x86_64-linux";};
+
+  taler = callPackage ./taler.nix {libmicrohttpd_0_9_74 = callPackage ./libmicrohttpd.nix {};};
+  taler-exchange = taler.taler-exchange;
+  taler-merchant = taler.taler-merchant;
 in
   stdenv.mkDerivation {
     name = "sync";
@@ -28,6 +42,7 @@ in
       autoreconfHook
       curl
       taler-exchange
+      taler-merchant
       gnunet
       jansson
       libgcrypt
@@ -36,4 +51,13 @@ in
       pkg-config
       postgresql
     ];
+
+    # Tests run with `make check`.
+    doCheck = false; # `test_sync_api` looks like an integration test
+
+    meta = {
+      homepage = "https://git.taler.net/sync.git";
+      description = "Backup and synchronization service.";
+      license = lib.licenses.agpl3Plus;
+    };
   }

--- a/pkgs/by-name/sync/taler.nix
+++ b/pkgs/by-name/sync/taler.nix
@@ -1,0 +1,155 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  curl,
+  gnunet,
+  jansson,
+  libgcrypt,
+  libmicrohttpd_0_9_74,
+  qrencode,
+  libsodium,
+  libtool,
+  libunistring,
+  pkg-config,
+  postgresql,
+  autoreconfHook,
+  python39,
+  recutils,
+  wget,
+  jq,
+  gettext,
+  texinfo,
+}: let
+  version = "0.9.3";
+
+  taler-wallet-core = fetchgit {
+    url = "https://git.taler.net/wallet-core.git";
+    rev = "v${version}";
+    sha256 = "sha256-uwbgIzSjLN+KQCY134VfnCuBEtvCO3a6mEw++HoZDHs=";
+  };
+in rec {
+  taler-exchange = stdenv.mkDerivation rec {
+    pname = "taler-exchange";
+    inherit version;
+
+    src = fetchgit {
+      url = "https://git.taler.net/exchange.git";
+      rev = "v${version}";
+      # REMOVEME: this should only be a problem for specifically v0.9.3
+      # When fetching submodules without deep clone we get the following error:
+      # "Server does not allow request for unadvertised object"
+      deepClone = true;
+      fetchSubmodules = true;
+      sha256 = "sha256-x+RUVVo7Q4ZxKo4tHcEMBvLq9do2yp2vcOWdmUgpRdM=";
+    };
+
+    nativeBuildInputs = [
+      autoreconfHook
+      pkg-config
+    ];
+    buildInputs = [
+      libgcrypt
+      libmicrohttpd_0_9_74
+      jansson
+      libsodium
+      postgresql
+      curl
+      recutils
+      gettext
+      texinfo # Fix 'makeinfo' is missing on your system.
+      libunistring
+      python39.pkgs.jinja2
+      # jq is necessary for some tests and is checked by configure script
+      jq
+    ];
+    propagatedBuildInputs = [gnunet];
+
+    preConfigure = ''
+      ./contrib/gana-generate.sh
+    '';
+
+    enableParallelBuilding = true;
+
+    nativeCheckInputs = [wget curl];
+    doInstallCheck = true;
+    checkTarget = "check";
+
+    meta = with lib; {
+      description = ''
+        Taler is an electronic payment system providing the ability to pay
+        anonymously using digital cash.  Taler consists of a network protocol
+        definition (using a RESTful API over HTTP), a Exchange (which creates
+        digital coins), a Wallet (which allows customers to manage, store and
+        spend digital coins), and a Merchant website which allows customers to
+        spend their digital coins.  Naturally, each Merchant is different, but
+        Taler includes code examples to help Merchants integrate Taler as a
+        payment system.
+      '';
+      homepage = "https://taler.net/";
+      license = licenses.agpl3Plus;
+      maintainers = with maintainers; [astro];
+      platforms = platforms.linux;
+    };
+  };
+
+  taler-merchant = stdenv.mkDerivation rec {
+    pname = "taler-merchant";
+    inherit version;
+
+    src = fetchgit {
+      url = "https://git.taler.net/merchant.git";
+      rev = "v${version}";
+      fetchSubmodules = true;
+      sha256 = "sha256-HewCqyO/7nnIQY9Tgva0k1nTk2LuwLyGK/UUxvx9BG0=";
+    };
+    postUnpack = ''
+      ln -s ${taler-wallet-core}/spa.html $sourceRoot/contrib/
+    '';
+
+    nativeBuildInputs = [pkg-config autoreconfHook];
+    buildInputs =
+      taler-exchange.buildInputs
+      ++ [
+        qrencode
+        taler-exchange
+        # for ltdl.h
+        libtool
+      ];
+    propagatedBuildInputs = [gnunet];
+
+    # From ./bootstrap
+    preAutoreconf = ''
+      cd contrib
+      find wallet-core/backoffice/ -type f -printf '  %p \\\n' | sort > Makefile.am.ext
+      truncate -s -2 Makefile.am.ext
+      cat Makefile.am.in Makefile.am.ext >> Makefile.am
+      cd ..
+    '';
+    configureFlags = [
+      "--with-gnunet=${gnunet}"
+      "--with-exchange=${taler-exchange}"
+    ];
+
+    enableParallelBuilding = true;
+
+    nativeCheckInputs = [jq];
+    doInstallCheck = true;
+    checkTarget = "check";
+
+    meta = with lib; {
+      description = ''
+        This is the GNU Taler merchant backend. It provides the logic that should run
+        at every GNU Taler merchant.  The GNU Taler merchant is a RESTful backend that
+        can be used to setup orders and process payments.  This component allows
+        merchants to receive payments without invading the customers' privacy. Of
+        course, this applies mostly for digital goods, as the merchant does not need
+        to know the customer's physical address.
+      '';
+      homepage = "https://taler.net/";
+      license = licenses.agpl3Plus;
+      maintainers = with maintainers; [astro];
+      platforms = platforms.linux;
+    };
+  };
+}


### PR DESCRIPTION
Before creating this PR, I tried updating nixpkgs input and pulling `taler-exchange` and `taler-merchante` from upstream nixpkgs.

This resulted in the following error:
```
error: hash mismatch in fixed-output derivation '/nix/store/rkh7wnvvpp3n1fsn84q9nalqhcbc4qr1-exchange.drv':
         specified: sha256-txWwW5vqTblNgVIXdDkpNNZOXpY0udMaz4Wog1GobzE=
            got:    sha256-+3LiwB25b9DuRBcsjaeDUWJTkhk4LpCjaKosb7u8mTY=
```

Therefore, I'll deal with that issue in an upstream PR and then update the package definition and the flake lock to clean up the code.