### PR TITLE
rosenpass test module networking.useNetworkd

### DIFF
--- a/tests/rosenpass/default.nix
+++ b/tests/rosenpass/default.nix
@@ -70,6 +70,8 @@ in {
 
       networking.firewall.allowedUDPPorts = [9999];
 
+      networking.useNetworkd = true;
+
       systemd = {
         network = {
           enable = true;


### PR DESCRIPTION
closes #127
