### PR TITLE
lcrq,lcsync,librecast,sync: name -> pname

### DIFF
--- a/pkgs/by-name/lcrq/package.nix
+++ b/pkgs/by-name/lcrq/package.nix
@@ -10,7 +10,7 @@
     ;
 in
   stdenv.mkDerivation rec {
-    name = "lcrq";
+    pname = "lcrq";
     version = "0.1.0";
 
     src = fetchFromGitea {

--- a/pkgs/by-name/lcsync/package.nix
+++ b/pkgs/by-name/lcsync/package.nix
@@ -13,7 +13,7 @@
     ;
 in
   stdenv.mkDerivation rec {
-    name = "lcsync";
+    pname = "lcsync";
     version = "0.2.1";
 
     src = fetchFromGitea {

--- a/pkgs/by-name/librecast/package.nix
+++ b/pkgs/by-name/librecast/package.nix
@@ -12,7 +12,7 @@
     ;
 in
   stdenv.mkDerivation rec {
-    name = "librecast";
+    pname = "librecast";
     version = "0.7-RC3";
 
     src = fetchFromGitea {

--- a/pkgs/by-name/sync/package.nix
+++ b/pkgs/by-name/sync/package.nix
@@ -18,7 +18,7 @@
   version = "0.9.3";
 in
   stdenv.mkDerivation {
-    name = "sync";
+    pname = "sync";
     inherit version;
 
     src = fetchgit {


### PR DESCRIPTION
AFAIK, `name == "{pname}-{version}"` in mkDerivation. These projects override the `name` attribute, which causes the name to be generated without version.

There are still some packages with missing version in `nix flake show`.
- `kbin` uses pname, so I do not understand why it does not include a version in its name
- `autobase` uses dream2nix which currently does not support it: https://github.com/nix-community/dream2nix/issues/766