### PR TITLE
update: atomic-server to 0.37.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -134,11 +134,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702952173,
-        "narHash": "sha256-24kUnTZgXP5B/fs1/f61tJuHyFrJ8824rn1B/0hL1og=",
+        "lastModified": 1708913568,
+        "narHash": "sha256-76PGANC2ADf0h7fe0w2nWpfdGN+bemFs2rvW2EdU/ZY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "20fd62b0891707a1db8117d09fc3e65a1cd0f6d7",
+        "rev": "cbdf3e5bb205ff2ca165fe661fbd6d885cbd0106",
         "type": "github"
       },
       "original": {

--- a/pkgs/by-name/atomic-server/package.nix
+++ b/pkgs/by-name/atomic-server/package.nix
@@ -21,14 +21,14 @@
 in
   rustPlatform.buildRustPackage rec {
     pname = "atomic-server";
-    version = "0.34.5";
+    version = "0.37.0";
 
     src = fetchCrate {
       inherit pname version;
-      hash = "sha256-X7G/EYhs7CBRZ+7oVKyQRk5WDyFKnQmi8aLbi/KIwgI=";
+      hash = "sha256-/OKYac0HA9EWDQ5qNyMPITN5iUdLM9SAVmOm6PVIFOk=";
     };
 
-    cargoHash = "sha256-mox1MdWgCgzytjqAPu1xHKWP8D5oRnXvMyqRbZXM9Pc=";
+    cargoHash = "sha256-LwSyK/7EEoTf1x7KGtebPxYTqH3SCjXGONNMxcmdEv0=";
 
     doCheck = false; # TODO(jl): broken upstream
 


### PR DESCRIPTION
Also needed to update `rust-overlay` to use at least `rustc` 1.75

Other than that, updated the hashes. 

Tested doCheck and it still failed, presuming upstream failure. 