### PR TITLE
Update: atomic-cli to 0.37.0

### DIFF
--- a/pkgs/by-name/atomic-cli/package.nix
+++ b/pkgs/by-name/atomic-cli/package.nix
@@ -12,14 +12,14 @@
 in
   rustPlatform.buildRustPackage rec {
     pname = "atomic-cli";
-    version = "0.34.5";
+    version = "0.37.0";
 
     src = fetchCrate {
       inherit pname version;
-      hash = "sha256-97JltSMuNETcgm5jfb2tOjwgw87J0u8qs+TIViT0PBo=";
+      hash = "sha256-yKYqxja2XFrQmLZYiWJAJDfGDdnr4eNdAwZNKn4FseU=";
     };
 
-    cargoHash = "sha256-NehXV26PBOD+V1KZo8I2EQ7Hp32ccT6e51v5qESj+l4=";
+    cargoHash = "sha256-a/mkZ9LFItlc3fBNCSZntbZfBJnhiFWUDIjLfBO6H74=";
 
     doCheck = false; # TODO(jl): broken upstream
 


### PR DESCRIPTION
Only had to change hashes. 

Depends on updated flake.lock from https://github.com/ngi-nix/ngipkgs/pull/161