### PR TITLE
init: atomic-browser at 0.37.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,6 +42,24 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1702900294,
@@ -71,6 +89,27 @@
         "owner": "NixOS",
         "ref": "release-23.05",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pnpm2nix-nzbr": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1706694632,
+        "narHash": "sha256-ytyTwNPiUR8aq74QlxFI+Wv3MyvXz5POO1xZxQIoi0c=",
+        "owner": "nzbr",
+        "repo": "pnpm2nix-nzbr",
+        "rev": "0366b7344171accc2522525710e52a8abbf03579",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nzbr",
+        "repo": "pnpm2nix-nzbr",
         "type": "github"
       }
     },
@@ -118,9 +157,10 @@
         "dream2nix": "dream2nix",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
+        "pnpm2nix-nzbr": "pnpm2nix-nzbr",
         "rust-overlay": "rust-overlay",
         "sops-nix": "sops-nix",
-        "systems": "systems",
+        "systems": "systems_2",
         "treefmt-nix": "treefmt-nix"
       }
     },
@@ -191,6 +231,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1680978846,
         "narHash": "sha256-Gtqg8b/v49BFDpDetjclCYXm8mAnTrUzR0JnE2nv5aw=",

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,8 @@
   inputs.rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
   inputs.dream2nix.url = "github:nix-community/dream2nix";
   inputs.dream2nix.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.pnpm2nix-nzbr.url = "github:nzbr/pnpm2nix-nzbr";
+  inputs.pnpm2nix-nzbr.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs = {
     self,
@@ -26,6 +28,7 @@
     sops-nix,
     rust-overlay,
     dream2nix,
+    pnpm2nix-nzbr,
     ...
   }: let
     inherit
@@ -72,6 +75,7 @@
 
       pkgsByName = import ./pkgs/by-name {
         inherit (pkgs) lib;
+        inherit (pkgs) mkPnpmPackage;
         inherit callPackage dream2nix pkgs;
       };
 
@@ -105,7 +109,10 @@
       rawNixosConfigs;
 
     eachDefaultSystemOutputs = flake-utils.lib.eachDefaultSystem (system: let
-      pkgs = importNixpkgs system [rust-overlay.overlays.default];
+      pkgs = importNixpkgs system [
+        rust-overlay.overlays.default
+        pnpm2nix-nzbr.overlays.default
+      ];
       treefmtEval = loadTreefmt pkgs;
       toplevel = name: config: nameValuePair "nixosConfigs/${name}" config.config.system.build.toplevel;
     in {

--- a/pkgs/by-name/atomic-browser/package.nix
+++ b/pkgs/by-name/atomic-browser/package.nix
@@ -1,0 +1,36 @@
+{
+  fetchFromGitHub,
+  lib,
+  mkPnpmPackage,
+}: let
+  inherit
+    (lib)
+    licenses
+    maintainers
+    ;
+in
+mkPnpmPackage rec {
+  pname = "atomic-browser";
+  version = "v0.37.0";
+
+  monorepoSrc = fetchFromGitHub {
+    owner = "atomicdata-dev";
+    repo = "atomic-server";
+    rev = "v0.37.0";
+    hash = "sha256-+Lk2MvkTj+B+G6cNbWAbPrN5ECiyMJ4HSiiLzBLd74g=";
+  };
+
+  src = "${monorepoSrc}/browser";
+
+  # These 2 options are needed to work with pnpm workspaces, which atomic-browser is using
+  # https://github.com/nzbr/pnpm2nix-nzbr/issues/29#issuecomment-1918811838
+  installInPlace = true;
+  distDir = ".";
+
+  meta = {
+    description = "Create, share, fetch and model linked Atomic Data! There are three components: a javascript / typescript library, a react library, and a complete GUI: Atomic-Data Browser.";
+    homepage = "https://github.com/atomicdata-dev/atomic-server/tree/develop/browser";
+    license = licenses.mit;
+    maintainers = with maintainers; [];
+  };
+}

--- a/pkgs/by-name/default.nix
+++ b/pkgs/by-name/default.nix
@@ -2,6 +2,7 @@
   lib,
   callPackage,
   dream2nix,
+  mkPnpmPackage,
   pkgs,
 }: let
   baseDirectory = ./.;


### PR DESCRIPTION
The next step of https://github.com/ngi-nix/ngipkgs/issues/15

- Use pnpm2nix-nzbr which supports pnpm version 6 lockfiles.
- Because atomic-browser is using pnpm workspaces, `installInPlace` and `distDir="."`

A follow up PR will create a module for this

Co-authored-by: Anish Lakhwara <anish+git@lakhwara.com>