### PR TITLE
Static Site

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,39 @@
+name: overview
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            experimental-features = no-url-literals
+      - uses: cachix/cachix-action@v10
+        with:
+          name: ngi
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix ${{ runner.debug && '--debug --print-build-logs' }} build .#overview
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: result
+
+  deploy:
+    runs-on: ubuntu-22.04
+    needs: build
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/overview/default.nix
+++ b/overview/default.nix
@@ -1,0 +1,158 @@
+{
+  options,
+  pkgs,
+  projects,
+  self,
+}: let
+  inherit
+    (builtins)
+    any
+    attrValues
+    concatStringsSep
+    filter
+    isList
+    mapAttrs
+    match
+    readFile
+    substring
+    toJSON
+    toString
+    ;
+
+  inherit
+    (pkgs.lib)
+    concatLines
+    mapAttrsToList
+    optionalString
+    unique
+    ;
+
+  empty = xs: assert isList xs; xs == [];
+  heading = i: text: "<h${toString i}>${text}</h${toString i}>";
+
+  lastModified = let
+    sub = start: len: substring start len self.lastModifiedDate;
+  in "${sub 0 4}-${sub 4 2}-${sub 6 2}T${sub 8 2}:${sub 10 2}:${sub 12 2}Z";
+
+  version =
+    if self ? rev
+    then "[`${self.shortRev}`](https://github.com/ngi-nix/ngipkgs/tree/${self.rev})"
+    else self.dirtyRev;
+
+  pick = {
+    options = project: let
+      spec = unique (attrValues (mapAttrs (_: v: v.options or null) (project.nixos.modules or {})));
+    in
+      filter
+      (option: any (x: null != match x (concatStringsSep "." option.loc)) spec)
+      (attrValues options);
+    configurations = project: attrValues (project.nixos.configurations or {});
+    packages = project: attrValues (project.packages or {});
+  };
+
+  render = {
+    options = rec {
+      one = value: let
+        dottedName = concatStringsSep "." value.loc;
+        maybeDefault = optionalString (value ? default.text) "`${value.default.text}`";
+      in ''
+        <dt>`${dottedName}`</dt>
+        <dd>
+          <table>
+            <tr>
+              <td>Description:</td>
+              <td>${value.description}</td>
+            </tr>
+            <tr>
+              <td>Type:</td>
+              <td>`${value.type}`</td>
+            </tr>
+            <tr>
+              <td>Default:</td>
+              <td>${maybeDefault}</td>
+            </tr>
+          </table>
+        </dd>
+      '';
+      many = projectOptions:
+        optionalString (!empty projectOptions)
+        ''
+          <section><details><summary>${heading 3 "Options"}</summary><dl>
+          ${concatLines (map one projectOptions)}
+          </dl></details></section>
+        '';
+    };
+
+    packages = rec {
+      one = package: ''
+        <dt>`${package.name}`</dt>
+        <dd>
+          <table>
+            <tr>
+              <td>Version:</td>
+              <td>${package.version}</td>
+            </tr>
+          </table>
+        </dd>
+      '';
+      many = packages:
+        optionalString (!empty packages)
+        ''
+          <section><details><summary>${heading 3 "Packages"}</summary><dl>
+          ${concatLines (map one packages)}
+          </dl></details></section>
+        '';
+    };
+
+    configurations = rec {
+      one = configuration: ''
+        <li>
+          <p>${configuration.description}</p>
+          ```nix
+        ${readFile configuration.path}
+          ```
+        </li>
+      '';
+      many = configurations:
+        optionalString (!empty configurations)
+        ''
+          <section><details><summary>${heading 3 "Configurations"}</summary><ul>
+          ${concatLines (map one configurations)}
+          </ul></details></section>
+        '';
+    };
+
+    projects = rec {
+      one = name: project: ''
+        <section><details><summary>${heading 2 name}</summary>
+        <https://nlnet.nl/project/${name}>
+
+        ${render.packages.many (pick.packages project)}
+        ${render.options.many (pick.options project)}
+        ${render.configurations.many (pick.configurations project)}
+        </details></section>
+      '';
+      many = projects: concatLines (mapAttrsToList one projects);
+    };
+  };
+
+  metadata = pkgs.writeText "metadata.json" (toJSON (import ./metadata.nix {
+    date = lastModified;
+  }));
+
+  content = pkgs.writeText "overview.html" ''
+    ${render.projects.many projects}
+
+    <hr>
+    <footer>Version: ${version}, Last Modified: ${lastModified}</footer>
+  '';
+in
+  pkgs.runCommand "overview" {
+    nativeBuildInputs = with pkgs; [jq pandoc validator-nu gnused];
+  } ''
+    mkdir -v $out
+    cp -v ${./style.css} $out/style.css
+    pandoc --from=markdown+raw_html --to=html --standalone --css="style.css" --metadata-file=${metadata} --output=$out/index.html ${content}
+    sed --file=${./fixup.sed} --in-place $out/index.html
+    vnu -Werror --format json $out/*.html 2>&1 | jq
+  ''

--- a/overview/fixup.sed
+++ b/overview/fixup.sed
@@ -1,0 +1,4 @@
+# vnu complains about self-closing tags `<meta ... />` and `<link ... />`
+# in pandoc's output. See <https://github.com/jgm/pandoc/discussions/9345>.
+# Use sed to rewrite those tags.
+s#<\(link\|meta\) \(.*\) />#<\1 \2>#

--- a/overview/metadata.nix
+++ b/overview/metadata.nix
@@ -1,0 +1,6 @@
+{date}: {
+  inherit date;
+  title = "NGIpkgs Overview";
+  lang = "en";
+  dir = "ltr";
+}

--- a/overview/style.css
+++ b/overview/style.css
@@ -1,0 +1,9 @@
+body {
+	font-family: sans-serif;
+}
+body > section {
+	padding: 0.5cm 0 0.5cm 0;
+}
+details > summary > h2, details > summary > h3 {
+	display: inline;
+}

--- a/projects/Flarum/default.nix
+++ b/projects/Flarum/default.nix
@@ -1,4 +1,7 @@
 {pkgs, ...}: {
   packages = {inherit (pkgs) flarum;};
-  nixos.module.service = ./service.nix;
+  nixos.modules.service = {
+    path = ./service.nix;
+    options = "services\\.flarum\\..*";
+  };
 }

--- a/projects/Kbin/default.nix
+++ b/projects/Kbin/default.nix
@@ -5,7 +5,10 @@
 } @ args: {
   packages = {inherit (pkgs) kbin kbin-frontend kbin-backend;};
   nixos = {
-    modules.service = ./service.nix;
+    modules.service = {
+      path = ./service.nix;
+      options = "services\\.kbin\\..*";
+    };
     configurations = {
       base = {
         path = ./configuration.nix;

--- a/projects/Pretalx/default.nix
+++ b/projects/Pretalx/default.nix
@@ -9,7 +9,10 @@
 
   nixos = {
     modules = {
-      service = ./service.nix;
+      service = {
+        path = ./service.nix;
+        options = "services\\.ngi-pretalx\\..*";
+      };
     };
     tests = {
       pretalx = import ./test args;

--- a/projects/Rosenpass/default.nix
+++ b/projects/Rosenpass/default.nix
@@ -5,7 +5,7 @@
 } @ args: {
   packages = {inherit (pkgs) rosenpass rosenpass-tools;};
   nixos = {
-    modules = {};
+    modules.service.options = "services\\.rosenpass\\..*";
     tests.rosenpass = import ./tests args;
   };
 }

--- a/projects/default.nix
+++ b/projects/default.nix
@@ -40,6 +40,6 @@ in
       };
     in
       if isMarkedBroken project
-      then trace "Project '${name}' marked as broken (for system '${pkgs.system or "undefined"}'). Skipping." {}
+      then trace "Skipping project '${name}' which is marked as broken for system '${pkgs.system or "undefined"}'." {}
       else hydrate project
   ) (filterAttrs filter (readDir baseDirectory))

--- a/projects/mCaptcha/default.nix
+++ b/projects/mCaptcha/default.nix
@@ -5,7 +5,10 @@
 } @ args: {
   packages = {inherit (pkgs) mcaptcha mcaptcha-cache;};
   nixos = {
-    modules.service = ./service.nix;
+    modules.service = {
+      path = ./service.nix;
+      options = "services\\.mcaptcha\\..*";
+    };
     tests = {
       create-locally = import ./tests/create-locally.nix args;
       bring-your-own-services = import ./tests/bring-your-own-services.nix args;


### PR DESCRIPTION
Fixes #165

Comments:
 - Code to generate a (quite large) list/dump of options is in `flake.nix`, all details regarding the static site is in `overview/*`.
 - Since there's currently no straightforward way to query the module system about which options are defined in a given module, I had to add `nixos.modules.<name>.options` to the schema for `projects/*/default.nix` which is a regex that describes the names of the options that the module at `nixos.modules.<name>.path` defines. I don't particularly like this, but it's the best solution I can think of at the moment. I did briefly consult with the module system maintainers on Matrix.
 - Uses Pandoc to generate the HTML.
 - Uses the v.Nu HTML checker to ensure that our generated HTML is sane.
 - Also pipes through configurations with syntax highlighting (powered by Pandoc or whatever it depends on for syntax highlighting).