### PR TITLE
weekly dependency bumps

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -2,7 +2,7 @@ name: nix flake update
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * */3' # https://crontab.guru/#0_0_*_*_*/3
+    - cron: '0 0 * * MON' # https://crontab.guru/#0_0_*_*_MON
 
 jobs:
   lockfile:


### PR DESCRIPTION
automatic update PRs require attention, which is limited. and we're
currently more concerned with having regular updates at all, and
optimising the workflow, rather than catching security updates quickly.

@lorenzleutgeb