### PR TITLE
overview: Add to checks

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -184,6 +184,7 @@
         # `nix flake check` only evaluates packages and does not build them.
         (mapAttrs' (name: check: nameValuePair "packages/${name}" check) nonBrokenPkgs)
         // {
+          inherit (self.packages.${system}) overview;
           formatting = treefmtEval.config.build.check self;
         };
 


### PR DESCRIPTION
Building the overview website is not very expensive (a lot cheaper than NixOS tests) but can catch some errors since it evals all modules.