### PR TITLE
ci: Set environment `NIX_ABORT_ON_WARN=true`

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,4 +1,4 @@
-name: nix flake check
+name: nix flake
 
 on:
   push:
@@ -8,6 +8,18 @@ on:
   workflow_dispatch:
 
 jobs:
+  eval:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            experimental-features = no-url-literals
+      - run: nix ${{ runner.debug && '--debug' }} flake check --impure --no-build --show-trace
+        env:
+          NIX_ABORT_ON_WARN: true
+
   check:
     runs-on: ubuntu-22.04
     steps:

--- a/flake.nix
+++ b/flake.nix
@@ -139,6 +139,8 @@
                     domain = "invalid";
                     hostName = "options";
                   };
+
+                  system.stateVersion = "23.05";
                 }
               ]
               ++ attrValues self.nixosModules;

--- a/pkgs/by-name/mcaptcha/frontend-package.json
+++ b/pkgs/by-name/mcaptcha/frontend-package.json
@@ -2,7 +2,7 @@
   "name": "vanilla",
   "main": "index.js",
   "version": "1.0.0",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-or-later",
   "scripts": {
     "build": "webpack --mode production",
     "lint": "yarn run eslint templates",


### PR DESCRIPTION
Resolves ngi-nix/ngipkgs#155

See [`lib/trivial.nix`](https://github.com/NixOS/nixpkgs/blob/203fac824e2fdfed2e3a832b8123d9a64ee58b43/lib/trivial.nix#L700-L703).

Since this requires impure evaluation, and we want our flake to be pure in principle, split this into two separate evaluations, and also two jobs to hopefully save some time by parallelization. Caching the impure evaluation doesn't really make sense anyway.