### PR TITLE
Init atomic-server module

### DIFF
--- a/projects/AtomicData/default.nix
+++ b/projects/AtomicData/default.nix
@@ -1,0 +1,13 @@
+{pkgs, ...} @ args: {
+  packages = {inherit (pkgs) atomic-server;};
+  nixos = {
+    modules.services.atomic-server = ./service.nix;
+    examples = {
+      base = {
+        path = ./example.nix;
+        description = "Basic configuration, mainly used for testing purposes.";
+      };
+    };
+    tests.atomic-server = import ./test.nix args;
+  };
+}

--- a/projects/AtomicData/example.nix
+++ b/projects/AtomicData/example.nix
@@ -1,0 +1,9 @@
+{...}: {
+  networking.firewall.allowedTCPPorts = [80];
+
+  services = {
+    atomic-server = {
+      enable = true;
+    };
+  };
+}

--- a/projects/AtomicData/service.nix
+++ b/projects/AtomicData/service.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.services.atomic-server;
+  # We need to add these for DirectoriesRS to pick up
+  # Since it doesn't pick up the ones set by systemd
+  envFile = pkgs.writeText ".env" ''
+    ATOMIC_CONFIG_DIR=/var/lib/atomic-server
+    ATOMIC_DATA_DIR=/var/lib/atomic-server
+    XDG_CACHE_HOME=/var/cache/atomic-server
+    ${generators.toINIWithGlobalSection {} {globalSection = cfg.settings;}}
+  '';
+in {
+  options = {
+    services.atomic-server = {
+      enable = mkEnableOption "Enable Atomic Server";
+      settings = mkOption {
+        default = {};
+        description = ''
+          Atomic Server configuration. Refer to <https://docs.atomicdata.dev/atomicserver/installation#atomicserver-cli-options--env-vars>
+          for details on supported values.
+          ATOMIC_CONFIG_DIR and ATOMIC_DATA_DIR are set automatically to work with NixOS Modules.
+        '';
+        example = literalExpression ''
+          {
+            "ATOMIC_INITALIZE" = "true";
+            "ATOMIC_DOMAIN" = "localhost";
+            "ATOMIC_REBUILD_INDEX" = "false";
+            "ATOMIC_PORT" = "9883";
+          }
+        '';
+      };
+    };
+  };
+  config = mkIf cfg.enable {
+    users.users.atomic-server = {
+      isSystemUser = true;
+      group = "atomic-server";
+    };
+    users.groups.atomic-server = {};
+    systemd.services.atomic-server = {
+      description = "Atomic Server";
+      after = ["network.target"];
+      wantedBy = ["multi-user.target"];
+      serviceConfig = {
+        ExecStart = "${pkgs.atomic-server}/bin/atomic-server";
+        User = "atomic-server";
+        EnvironmentFile = envFile;
+        StateDirectory = "atomic-server";
+        CacheDirectory = "atomic-server";
+        RuntimeDirectory = "atomic-server";
+        RootDirectory = "/run/atomic-server";
+        ReadWritePaths = "/var/lib/atomic-server";
+        BindReadOnlyPaths = [
+          builtins.storeDir
+        ];
+        CapabilityBoundingSet = "";
+        RestrictAddressFamilies = ["AF_UNIX" "AF_INET" "AF_INET6"];
+      };
+    };
+  };
+
+  meta.maintainers = [];
+}

--- a/projects/AtomicData/test.nix
+++ b/projects/AtomicData/test.nix
@@ -1,0 +1,37 @@
+{
+  sources,
+  lib,
+  ...
+}: let
+  inherit
+    (lib)
+    mkForce
+    ;
+in {
+  name = "atomic-server";
+
+  nodes = {
+    server = {
+      config,
+      lib,
+      ...
+    }: {
+      imports = [
+        sources.modules.default
+        sources.modules."services.atomic-server"
+        sources.modules.unbootable
+        sources.examples."AtomicData/base"
+      ];
+
+      unbootable = mkForce false;
+    };
+  };
+
+  testScript = {nodes, ...}: ''
+    start_all()
+
+    with subtest("atomic"):
+        server.wait_for_unit("atomic-server.service")
+        server.succeed("curl --fail --connect-timeout 10 http://localhost:9883/setup")
+  '';
+}


### PR DESCRIPTION
Building on work done in https://github.com/ngi-nix/ngipkgs/pull/170 (but not requiring it), this PR inits a module for atomic-server.
It's not ready for review but tested locally. 