### PR TITLE
projects: create a default interactive configuration for NixOS tests

### DIFF
--- a/projects/Kbin/test.nix
+++ b/projects/Kbin/test.nix
@@ -55,31 +55,4 @@ in {
         server.wait_for_unit("nginx.service")
         server.succeed("curl --fail --connect-timeout 10 http://localhost/u/admin")
   '';
-
-  # NOTE: Below configuration is for "interactive" (=developing/debugging) only.
-  interactive.nodes = let
-    tools = {pkgs, ...}: {
-      environment.systemPackages = with pkgs; [vim tmux jq];
-    };
-
-    # Use kmscon <https://www.freedesktop.org/wiki/Software/kmscon/>
-    # to provide a slightly nicer console, and while we're at it,
-    # also use a nice font.
-    # With kmscon, we can for example zoom in/out using [Ctrl] + [+]
-    # and [Ctrl] + [-]
-    niceConsoleAndAutologin = {pkgs, ...}: {
-      services.kmscon = {
-        enable = true;
-        autologinUser = "root";
-        fonts = [
-          {
-            name = "Fira Code";
-            package = pkgs.fira-code;
-          }
-        ];
-      };
-    };
-  in {
-    server.imports = [niceConsoleAndAutologin tools];
-  };
 }

--- a/projects/Rosenpass/tests/default.nix
+++ b/projects/Rosenpass/tests/default.nix
@@ -181,26 +181,4 @@ in {
         for machine in [server, client]:
             machine.wait_until_succeeds("wg show all preshared-keys | grep --invert-match none", timeout=5)
   '';
-
-  # NOTE: Below configuration is for "interactive" (=developing/debugging) only.
-  interactive.nodes = let
-    # Use kmscon <https://www.freedesktop.org/wiki/Software/kmscon/>
-    # to provide a slightly nicer console, and while we're at it,
-    # also use a nice font.
-    # With kmscon, we can for example zoom in/out using [Ctrl] + [+]
-    # and [Ctrl] + [-]
-    niceConsoleAndAutologin.services.kmscon = {
-      enable = true;
-      autologinUser = "root";
-      fonts = [
-        {
-          name = "Fira Code";
-          package = pkgs.fira-code;
-        }
-      ];
-    };
-  in {
-    server = niceConsoleAndAutologin;
-    client = niceConsoleAndAutologin;
-  };
 }

--- a/projects/Vula/test.nix
+++ b/projects/Vula/test.nix
@@ -18,25 +18,4 @@
   testScript = {nodes, ...}: ''
     start_all()
   '';
-
-  # NOTE: Below configuration is for "interactive" (=developing/debugging) only.
-  interactive.nodes = let
-    # Use kmscon <https://www.freedesktop.org/wiki/Software/kmscon/>
-    # to provide a slightly nicer console, and while we're at it,
-    # also use a nice font.
-    # With kmscon, we can for example zoom in/out using [Ctrl] + [+]
-    # and [Ctrl] + [-]
-    niceConsoleAndAutologin.services.kmscon = {
-      enable = true;
-      autologinUser = "root";
-      fonts = [
-        {
-          name = "Fira Code";
-          package = pkgs.fira-code;
-        }
-      ];
-    };
-  in {
-    server = niceConsoleAndAutologin;
-  };
 }

--- a/projects/default.nix
+++ b/projects/default.nix
@@ -28,10 +28,39 @@
     then assert elem name allowedFiles; false
     else true;
 
+  nixosTest = test: let
+    tools = {pkgs, ...}: {
+      environment.systemPackages = with pkgs; [vim tmux jq];
+    };
+
+    # Use kmscon <https://www.freedesktop.org/wiki/Software/kmscon/>
+    # to provide a slightly nicer console, and while we're at it,
+    # also use a nice font.
+    # With kmscon, we can for example zoom in/out using [Ctrl] + [+]
+    # and [Ctrl] + [-]
+    niceConsoleAndAutologin = {pkgs, ...}: {
+      services.kmscon = {
+        enable = true;
+        autologinUser = "root";
+        fonts = [
+          {
+            name = "Fira Code";
+            package = pkgs.fira-code;
+          }
+        ];
+      };
+    };
+  in
+    pkgs.nixosTest ({
+        # NOTE: Below configuration is for "interactive" (=developing/debugging) only.
+        interactive.nodes = mapAttrs (_: _: {imports = [niceConsoleAndAutologin tools];}) test.nodes;
+      }
+      // test);
+
   hydrate = project:
     recursiveUpdate
     project
-    {nixos.tests = mapAttrs (_: pkgs.nixosTest) project.nixos.tests or {};};
+    {nixos.tests = mapAttrs (_: nixosTest) project.nixos.tests or {};};
 in
   mapAttrs (
     name: type: let


### PR DESCRIPTION
`interactive.nodes` looks pretty much the same in all NixOS tests, so why not make a default one.