### PR TITLE
flake.nix: drop non-existent follows

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,6 @@
   inputs.hydra.url = "github:NixOS/hydra/nix-next";
   inputs.nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-23.11";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-  inputs.pre-commit-hooks.inputs.flake-utils.follows = "flake-utils";
   inputs.pre-commit-hooks.inputs.nixpkgs-stable.follows = "nixpkgs-stable";
   inputs.pre-commit-hooks.inputs.nixpkgs.follows = "nixpkgs";
   inputs.pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";


### PR DESCRIPTION
https://github.com/cachix/git-hooks.nix/commit/de8ccbdc89a9a344a5821b252f66fb3cb1c9ec39