### PR TITLE
infra: Automatically deploy makemake

### DIFF
--- a/.github/workflows/makemake.yaml
+++ b/.github/workflows/makemake.yaml
@@ -1,0 +1,44 @@
+name: makemake
+
+on: { push: { branches: [ 'main' ] } }
+
+jobs:
+  deploy:
+    environment: makemake
+    runs-on: ubuntu-latest
+    env:
+      SSH_KEY: ${{ secrets.SSH_KEY }}
+      FLAKE_REF_SHORT: github:${{ github.repository }}/${{ github.sha }}#makemake
+      FLAKE_REF_TOPLEVEL: github:${{ github.repository }}/${{ github.sha }}#nixosConfigurations.makemake.config.system.build.toplevel
+      SSH_HOST: root@makemake.ngi.nixos.org
+    steps:
+      - uses: 'DeterminateSystems/nix-installer-action@main'
+        name: 'Install Nix'
+        with: { extra-conf: 'experimental-features = no-url-literals' }
+
+      - name: Prepare SSH
+        run: |
+          mkdir -p ~/.ssh
+          printenv SSH_KEY > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          echo "makemake.ngi.nixos.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAID4ejRuAQPx6AbuS1u+Q7UUi1TIwkY2S//kjgpBxYNfU" \
+            > ~/.ssh/known_hosts
+
+      - name: Build
+        run: |
+          nix run nixpkgs#nixos-rebuild -- build \
+            --flake "$FLAKE_REF_SHORT" \
+            --build-host "$SSH_HOST" \
+            --target-host "$SSH_HOST"
+
+      - name: Difference
+        run: |
+          ssh "$SSH_HOST" -- \
+            "nix build \"$FLAKE_REF_TOPLEVEL\" && nix run nixpkgs#nvd -- diff /run/current-system result"
+
+      - name: Deploy
+        run: |
+          nix run nixpkgs#nixos-rebuild -- switch \
+            --flake "$FLAKE_REF_SHORT" \
+            --build-host "$SSH_HOST" \
+            --target-host "$SSH_HOST"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
-/infra/ @Erethon @Ericson2314 @fricklerhandwerk @Janik-Haag @lorenzleutgeb
+/infra/ @ngi-nix/infra
+/.github/workflows/makemake.yaml @ngi-nix/infra

--- a/infra/ssh-keys.nix
+++ b/infra/ssh-keys.nix
@@ -20,6 +20,8 @@ let
 
   erethon = "sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIPb9z1U7Sti2lls0mlcmyPwmwD91amKwVlLZHYclSoULAAAABHNzaDo=";
 
+  deploy = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIF0avMIgFAj/8xzr2+3aXn7a0odDKIpwj90n5inhoQ4S";
+
   infra = [
     delroth
     hexa-gaia
@@ -37,4 +39,4 @@ let
     erethon
   ];
 in
-  infra ++ ngi
+  infra ++ ngi ++ [deploy]


### PR DESCRIPTION
As requested by @fricklerhandwerk.

Looks like this: https://github.com/ngi-nix/ngipkgs/deployments/makemake

I wanted to implement a fancier deployment via webhooks, but that turned out to be a rabbit hole. Can implement that when we have time. This works for now.