### PR TITLE
flake.nix: split lib.nix from nixpkgs lib

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,8 @@
     ...
   }: let
     # Take Nixpkgs' lib and update it with the definitions in ./lib.nix
-    lib = nixpkgs.lib.recursiveUpdate nixpkgs.lib (import ./lib.nix {inherit (nixpkgs) lib;});
+    lib = import (nixpkgs + "/lib");
+    lib' = import ./lib.nix {inherit lib;};
 
     inherit
       (builtins)
@@ -47,14 +48,25 @@
       foldr
       recursiveUpdate
       nameValuePair
-      nixosSystem
       filterAttrs
       attrByPath
-      mapAttrByPath
-      flattenAttrsDot
-      flattenAttrsSlash
       optionalAttrs
       ;
+
+    inherit
+      (lib')
+      flattenAttrsDot
+      flattenAttrsSlash
+      mapAttrByPath
+      ;
+
+    # Imported from Nixpkgs
+    nixosSystem = args:
+      import (nixpkgs + "/nixos/lib/eval-config.nix") ({
+          inherit lib;
+          system = null;
+        }
+        // args);
 
     # NGI packages are imported from ./pkgs/by-name/default.nix.
     importNgiPackages = pkgs: let

--- a/overview/default.nix
+++ b/overview/default.nix
@@ -5,6 +5,8 @@
   projects,
   self,
 }: let
+  lib' = import ../lib.nix {inherit lib;};
+
   inherit
     (builtins)
     any
@@ -14,7 +16,6 @@
     filter
     isList
     readFile
-    stringLength
     substring
     toJSON
     toString
@@ -23,11 +24,15 @@
   inherit
     (lib)
     concatLines
-    flattenAttrsDot
     flip
     hasPrefix
     mapAttrsToList
     optionalString
+    ;
+
+  inherit
+    (lib')
+    flattenAttrsDot
     ;
 
   empty = xs: assert isList xs; xs == [];


### PR DESCRIPTION
Previously, `lib.nix` is merged into nixpkgs' [flake-dependent](https://github.com/NixOS/nixpkgs/blob/52a6b383fc60d6e75ee31457fd48b5a9495e5ba7/flake.nix#L18-L44) lib, which is then inherited in packages. Although this is not the case for now, it could make packages less upstreamable if non-nixpkgs / flake-dependent functions are accidentally used.