### PR TITLE
pkgs/by-name: make callPackage intrinsic

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,17 +69,11 @@
         // args);
 
     # NGI packages are imported from ./pkgs/by-name/default.nix.
-    importNgiPackages = pkgs: let
-      callPackage = pkgs.newScope (
-        ngiPackages // {inherit callPackage;}
-      );
-
-      ngiPackages = import ./pkgs/by-name {
+    importNgiPackages = pkgs:
+      import ./pkgs/by-name {
         inherit (pkgs) lib;
-        inherit callPackage dream2nix pkgs;
+        inherit dream2nix pkgs;
       };
-    in
-      ngiPackages;
 
     # NGI projects are imported from ./projects/default.nix.
     # Each project includes packages, and optionally, modules, configurations and tests.

--- a/pkgs/by-name/default.nix
+++ b/pkgs/by-name/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  callPackage,
   dream2nix,
   pkgs,
 }: let
@@ -28,7 +27,7 @@
   callModule = module: let
     evaluated = lib.evalModules {
       specialArgs = {
-        inherit dream2nix;
+        dream2nix = import dream2nix;
         packageSets.nixpkgs = pkgs;
       };
       modules = [
@@ -43,6 +42,10 @@
     };
   in
     evaluated.config.public;
+
+  callPackage = pkgs.newScope (
+    self // {inherit callPackage;}
+  );
 
   self =
     mapAttrs (


### PR DESCRIPTION
Ideally, I would only need to pass the input sources (and the nixpkgs lib?) to `pkgs/by-name/default.nix` for it to work.

Tested with the following saved as `default.nix`, along with the `nix/flake-compat` folder from #209.

```nix
{
  system ? builtins.currentSystem,
  inputs ? import ./nix/flake-compat/inputs.nix,
  nixpkgs ? inputs.nixpkgs,
  dream2nix ? inputs.dream2nix,
}:
let
  pkgs = import nixpkgs { inherit system; };

  ngiPackages = import ./pkgs/by-name {
    inherit (pkgs) lib;
    inherit dream2nix pkgs;
  };
in
ngiPackages
```