### PR TITLE
ci: Add overview to checks

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -276,6 +276,7 @@
             };
           };
           "infra/makemake" = toplevel self.nixosConfigurations.makemake;
+          "infra/overview" = self.packages.${system}.overview;
         };
 
       devShells.default = pkgs.mkShell {


### PR DESCRIPTION
I had mistakenly removed it in #247, sorry. Once this is merged, I will make the `infra/*` checks mandatory, so we do not accidentally remove them again...

Resolves #279.