### PR TITLE
infra: Add fricklerhandwerk to sops config

### DIFF
--- a/infra/.sops.yaml
+++ b/infra/.sops.yaml
@@ -1,21 +1,24 @@
 .keys:
   .humans:
-    - &erethon       age187upwqdte7t0hkyec22jhac357m9y4fkcdvpg9sj5q9mekjupfnqg9a077
-    - &lorenzleutgeb age1c0g6s6daxy79dlm9uqczwlkh0hvjpghw5h8zzljc3vs275rvvqus30hv9l
+    - &erethon          age187upwqdte7t0hkyec22jhac357m9y4fkcdvpg9sj5q9mekjupfnqg9a077
+    - &fricklerhandwerk age1028rq5gm5eakhycepydglqh0h2npxj3y4s4ls97ge02sw0aersysh3kqax
+    - &lorenzleutgeb    age1c0g6s6daxy79dlm9uqczwlkh0hvjpghw5h8zzljc3vs275rvvqus30hv9l
   .machines:
-    - &makemake      age1ewus3xraznqv6xc2ptua2qjqrjyhfd8uugu08wjduushj3uhgqwsqd6vkk
+    - &makemake         age1ewus3xraznqv6xc2ptua2qjqrjyhfd8uugu08wjduushj3uhgqwsqd6vkk
 
 creation_rules:
   - path_regex: makemake/secrets
     key_groups:
       - age:
         - *erethon
+        - *fricklerhandwerk
         - *lorenzleutgeb
         - *makemake
   - path_regex: secrets.json
     key_groups:
       - age:
         - *erethon
+        - *fricklerhandwerk
         - *lorenzleutgeb
         - *makemake
 

--- a/infra/.sops.yaml
+++ b/infra/.sops.yaml
@@ -1,7 +1,7 @@
 .keys:
   .humans:
     - &erethon          age187upwqdte7t0hkyec22jhac357m9y4fkcdvpg9sj5q9mekjupfnqg9a077
-    - &fricklerhandwerk age1028rq5gm5eakhycepydglqh0h2npxj3y4s4ls97ge02sw0aersysh3kqax
+    - &fricklerhandwerk age10ldm537vh6np7hvgc084c30njmwgam2p22wysapyj8ya86rycyhsf8gmcn
     - &lorenzleutgeb    age1c0g6s6daxy79dlm9uqczwlkh0hvjpghw5h8zzljc3vs275rvvqus30hv9l
   .machines:
     - &makemake         age1ewus3xraznqv6xc2ptua2qjqrjyhfd8uugu08wjduushj3uhgqwsqd6vkk


### PR DESCRIPTION
This is based on

```sh
% curl -s https://github.com/fricklerhandwerk.keys | ssh-to-age 2> /dev/null
age1028rq5gm5eakhycepydglqh0h2npxj3y4s4ls97ge02sw0aersysh3kqax
```

Please verify that this is indeed the key you would like to use (for example, compare with `ssh-to-age -i ~/.ssh/id_ed25519.pub`). If it is not, please update this PR accordingly (for example via GitHub's suggestion feature) to provide the desired key. Thanks!