### PR TITLE
dmt-core: init at 2.1.0

### DIFF
--- a/pkgs/by-name/dmt-core/package.nix
+++ b/pkgs/by-name/dmt-core/package.nix
@@ -26,11 +26,12 @@ let
   };
 
 in buildPythonPackage rec {
-  pname = "DMT_core";
+  pname = "dmt-core";
   version = "2.1.0";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit version;
+    pname = "DMT_core";
     hash = "sha256-489E+uNn4NgyCwxsUMEPH/1ZuM+5uNq4zx8F88rkHMU=";
   };
   doCheck = false;

--- a/pkgs/by-name/dmt-core/package.nix
+++ b/pkgs/by-name/dmt-core/package.nix
@@ -1,14 +1,16 @@
-{ lib, fetchPypi, fetchurl, python3Packages }:
-
-let
+{
+  lib,
+  fetchPypi,
+  fetchurl,
+  python3Packages,
+}: let
   inherit (python3Packages) buildPythonPackage;
 
   reprint = buildPythonPackage rec {
     pname = "reprint";
     version = "0.6.0";
     src = fetchurl {
-      url =
-        "https://files.pythonhosted.org/packages/ab/30/a742e69e37d4148dfa89acb6aa2a82ea298d1dfea02c6e9b2a43d4ed1065/reprint-0.6.0-py2.py3-none-any.whl";
+      url = "https://files.pythonhosted.org/packages/ab/30/a742e69e37d4148dfa89acb6aa2a82ea298d1dfea02c6e9b2a43d4ed1065/reprint-0.6.0-py2.py3-none-any.whl";
       hash = "sha256-DrxNwhrvyBAgXz/MIXg+qRu5YpKoUAZjSC6GSYm/9U0=";
     };
     format = "wheel";
@@ -18,57 +20,54 @@ let
     pname = "verilogae";
     version = "1.0.0";
     src = fetchurl {
-      url =
-        "https://files.pythonhosted.org/packages/aa/a6/9daea00745844faba44c2917c66838adfc315269f38518ecca49e6eb5fb5/verilogae-1.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+      url = "https://files.pythonhosted.org/packages/aa/a6/9daea00745844faba44c2917c66838adfc315269f38518ecca49e6eb5fb5/verilogae-1.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
       hash = "sha256-QsEVq/4c44xCkovOhXOj8Zh6rp4Ipq+NGjbTW25Fd6E=";
     };
     format = "wheel";
   };
+in
+  buildPythonPackage rec {
+    pname = "dmt-core";
+    version = "2.1.0";
 
-in buildPythonPackage rec {
-  pname = "dmt-core";
-  version = "2.1.0";
+    src = fetchPypi {
+      inherit version;
+      pname = "DMT_core";
+      hash = "sha256-489E+uNn4NgyCwxsUMEPH/1ZuM+5uNq4zx8F88rkHMU=";
+    };
+    doCheck = false;
 
-  src = fetchPypi {
-    inherit version;
-    pname = "DMT_core";
-    hash = "sha256-489E+uNn4NgyCwxsUMEPH/1ZuM+5uNq4zx8F88rkHMU=";
-  };
-  doCheck = false;
+    propagatedBuildInputs = [
+      python3Packages.colorama
+      python3Packages.colormath
+      python3Packages.cycler
+      python3Packages.h5py
+      python3Packages.joblib
+      python3Packages.matplotlib
+      python3Packages.more-itertools
+      python3Packages.packaging
+      python3Packages.pandas
+      python3Packages.pint
+      python3Packages.pyarrow
+      python3Packages.pyqtgraph
+      python3Packages.pyyaml
+      python3Packages.requests
+      python3Packages.scikit-rf
+      python3Packages.scipy
+      python3Packages.semver
+      python3Packages.setuptools
+      reprint
+      verilogae
+    ];
 
-  propagatedBuildInputs = [
-    python3Packages.colorama
-    python3Packages.colormath
-    python3Packages.cycler
-    python3Packages.h5py
-    python3Packages.joblib
-    python3Packages.matplotlib
-    python3Packages.more-itertools
-    python3Packages.packaging
-    python3Packages.pandas
-    python3Packages.pint
-    python3Packages.pyarrow
-    python3Packages.pyqtgraph
-    python3Packages.pyyaml
-    python3Packages.requests
-    python3Packages.scikit-rf
-    python3Packages.scipy
-    python3Packages.semver
-    python3Packages.setuptools
-    reprint
-    verilogae
-  ];
+    nativeCheckInputs = [python3Packages.pytest];
 
-  nativeCheckInputs = [ python3Packages.pytest ];
-
-  meta = {
-    changelog =
-      "https://gitlab.com/dmt-development/dmt-core/-/blob/Version_${version}/CHANGELOG?ref_type=tags";
-    description =
-      "Python tool to help modeling engineers extract model parameters, run circuit and TCAD simulations and automate infrastructure";
-    homepage = "https://gitlab.com/dmt-development/dmt-core";
-    license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ jasonodoom ];
-    platforms = lib.platforms.linux;
-  };
-}
+    meta = {
+      changelog = "https://gitlab.com/dmt-development/dmt-core/-/blob/Version_${version}/CHANGELOG?ref_type=tags";
+      description = "Python tool to help modeling engineers extract model parameters, run circuit and TCAD simulations and automate infrastructure";
+      homepage = "https://gitlab.com/dmt-development/dmt-core";
+      license = lib.licenses.gpl3Plus;
+      maintainers = with lib.maintainers; [jasonodoom];
+      platforms = lib.platforms.linux;
+    };
+  }

--- a/pkgs/by-name/dmt-core/package.nix
+++ b/pkgs/by-name/dmt-core/package.nix
@@ -1,71 +1,73 @@
-{ lib, buildPythonApplication, fetchurl, fetchPypi, pythonPackages }:
+{ lib, fetchPypi, fetchurl, python3Packages }:
 
 let
-  reprint = buildPythonApplication rec {
+  inherit (python3Packages) buildPythonPackage;
+
+  reprint = buildPythonPackage rec {
     pname = "reprint";
     version = "0.6.0";
     src = fetchurl {
       url =
         "https://files.pythonhosted.org/packages/ab/30/a742e69e37d4148dfa89acb6aa2a82ea298d1dfea02c6e9b2a43d4ed1065/reprint-0.6.0-py2.py3-none-any.whl";
-      sha256 = "DrxNwhrvyBAgXz/MIXg+qRu5YpKoUAZjSC6GSYm/9U0=";
+      hash = "sha256-DrxNwhrvyBAgXz/MIXg+qRu5YpKoUAZjSC6GSYm/9U0=";
     };
     format = "wheel";
   };
 
-  verilogae = buildPythonApplication rec {
+  verilogae = buildPythonPackage rec {
     pname = "verilogae";
     version = "1.0.0";
     src = fetchurl {
       url =
         "https://files.pythonhosted.org/packages/aa/a6/9daea00745844faba44c2917c66838adfc315269f38518ecca49e6eb5fb5/verilogae-1.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
-      sha256 = "QsEVq/4c44xCkovOhXOj8Zh6rp4Ipq+NGjbTW25Fd6E=";
+      hash = "sha256-QsEVq/4c44xCkovOhXOj8Zh6rp4Ipq+NGjbTW25Fd6E=";
     };
     format = "wheel";
   };
 
-in buildPythonApplication rec {
+in buildPythonPackage rec {
   pname = "DMT_core";
   version = "2.1.0";
-  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "489E+uNn4NgyCwxsUMEPH/1ZuM+5uNq4zx8F88rkHMU=";
+    hash = "sha256-489E+uNn4NgyCwxsUMEPH/1ZuM+5uNq4zx8F88rkHMU=";
   };
+  doCheck = false;
 
   propagatedBuildInputs = [
-    pythonPackages.joblib
-    pythonPackages.pint
-    pythonPackages.pyyaml
-    pythonPackages.more-itertools
-    pythonPackages.semver
-    pythonPackages.h5py
-    pythonPackages.cycler
-    pythonPackages.colormath
-    pythonPackages.colorama
-    pythonPackages.scipy
-    pythonPackages.scikit-rf
-    pythonPackages.packaging
-    pythonPackages.pandas
-    pythonPackages.pyqtgraph
-    pythonPackages.matplotlib
-    pythonPackages.pyarrow
-    pythonPackages.requests
+    python3Packages.colorama
+    python3Packages.colormath
+    python3Packages.cycler
+    python3Packages.h5py
+    python3Packages.joblib
+    python3Packages.matplotlib
+    python3Packages.more-itertools
+    python3Packages.packaging
+    python3Packages.pandas
+    python3Packages.pint
+    python3Packages.pyarrow
+    python3Packages.pyqtgraph
+    python3Packages.pyyaml
+    python3Packages.requests
+    python3Packages.scikit-rf
+    python3Packages.scipy
+    python3Packages.semver
+    python3Packages.setuptools
     reprint
     verilogae
-    pythonPackages.setuptools
   ];
 
-  nativeCheckInputs = [ pythonPackages.pytest ];
+  nativeCheckInputs = [ python3Packages.pytest ];
 
-  meta = with lib; {
+  meta = {
     changelog =
       "https://gitlab.com/dmt-development/dmt-core/-/blob/Version_${version}/CHANGELOG?ref_type=tags";
     description =
-      "DeviceModelingToolkit (DMT) is a Python tool targeted at helping modeling engineers extract model parameters, run circuit and TCAD simulations and automate their infrastructure.";
+      "Python tool to help modeling engineers extract model parameters, run circuit and TCAD simulations and automate infrastructure";
     homepage = "https://gitlab.com/dmt-development/dmt-core";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ jasonodoom ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ jasonodoom ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/dmt-core/package.nix
+++ b/pkgs/by-name/dmt-core/package.nix
@@ -1,0 +1,71 @@
+{ lib, buildPythonApplication, fetchurl, fetchPypi, pythonPackages }:
+
+let
+  reprint = buildPythonApplication rec {
+    pname = "reprint";
+    version = "0.6.0";
+    src = fetchurl {
+      url =
+        "https://files.pythonhosted.org/packages/ab/30/a742e69e37d4148dfa89acb6aa2a82ea298d1dfea02c6e9b2a43d4ed1065/reprint-0.6.0-py2.py3-none-any.whl";
+      sha256 = "DrxNwhrvyBAgXz/MIXg+qRu5YpKoUAZjSC6GSYm/9U0=";
+    };
+    format = "wheel";
+  };
+
+  verilogae = buildPythonApplication rec {
+    pname = "verilogae";
+    version = "1.0.0";
+    src = fetchurl {
+      url =
+        "https://files.pythonhosted.org/packages/aa/a6/9daea00745844faba44c2917c66838adfc315269f38518ecca49e6eb5fb5/verilogae-1.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+      sha256 = "QsEVq/4c44xCkovOhXOj8Zh6rp4Ipq+NGjbTW25Fd6E=";
+    };
+    format = "wheel";
+  };
+
+in buildPythonApplication rec {
+  pname = "DMT_core";
+  version = "2.1.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "489E+uNn4NgyCwxsUMEPH/1ZuM+5uNq4zx8F88rkHMU=";
+  };
+
+  propagatedBuildInputs = [
+    pythonPackages.joblib
+    pythonPackages.pint
+    pythonPackages.pyyaml
+    pythonPackages.more-itertools
+    pythonPackages.semver
+    pythonPackages.h5py
+    pythonPackages.cycler
+    pythonPackages.colormath
+    pythonPackages.colorama
+    pythonPackages.scipy
+    pythonPackages.scikit-rf
+    pythonPackages.packaging
+    pythonPackages.pandas
+    pythonPackages.pyqtgraph
+    pythonPackages.matplotlib
+    pythonPackages.pyarrow
+    pythonPackages.requests
+    reprint
+    verilogae
+    pythonPackages.setuptools
+  ];
+
+  nativeCheckInputs = [ pythonPackages.pytest ];
+
+  meta = with lib; {
+    changelog =
+      "https://gitlab.com/dmt-development/dmt-core/-/blob/Version_${version}/CHANGELOG?ref_type=tags";
+    description =
+      "DeviceModelingToolkit (DMT) is a Python tool targeted at helping modeling engineers extract model parameters, run circuit and TCAD simulations and automate their infrastructure.";
+    homepage = "https://gitlab.com/dmt-development/dmt-core";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ jasonodoom ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
This PR packages [DMT-core](https://gitlab.com/dmt-development/dmt-core) lib as funded by NGI through NLnet. DeviceModelingToolkit (DMT) is a Python tool targeted at helping modeling engineers extract model parameters, run circuit and TCAD simulations and automate their infrastructure.