### PR TITLE
docs: add to readme section on how-to install software

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,16 @@ The Vula service can then be enabled in the `configuration.nix`, as documented i
 
 The list of projects that are available to be deployed in this way, and how the module for each one is labelled, is available in the `nixosModules` section of the outputs listed by the `nix flake show` command when run in the NGIpkgs repo.
 
+### Configuring a binary cache for NGIpkgs
+
+Add the following lines to your `configuration.nix` to enable the binary cache substituter for NGIpkgs, which will minimize the building of packages from source:
+```
+  nix.settings.substituters = ["https://ngi.cachix.org/"];
+  nix.settings.trusted-public-keys = ["ngi.cachix.org-1:n+CAL72ROC3qQuLxIHpV+Tw5t42WhXmMhprAGkRSrOw="];
+```
+
+For further documentation on use of the binary cache see https://github.com/ngi-nix/ngipkgs/blob/main/maintainers/cachix.md.
+
 ## Continuous builds of packages with Hydra
 
 All packages in the [main branch of NGIpkgs](https://github.com/ngi-nix/ngipkgs/tree/main) are automatically built by a [Hydra](https://github.com/NixOS/hydra) server.

--- a/README.md
+++ b/README.md
@@ -91,19 +91,29 @@ nix run github:ngi-nix/ngipkgs#atomic-cli
 
 ### Deploy **services** to machines running NixOS
 
-1. Run the following script to prepare a local repo for deploying from NGIpkgs:
+1. Run the `deploy-ngipkgs` script to create a local repo for deploying from NGIpkgs:
 ```
-git clone --no-checkout --depth=1 https://github.com/ngi-nix/ngipkgs.git deploy-ngipkgs &&
-cd deploy-ngipkgs && 
-git checkout main -- projects && # checkout only the projects directory of ngipkgs
-cp -a projects/. . && # copy contents of the projects directory into the root of deploy-ngipkgs
-rm -rf .git projects default.nix && # cleanup
-git init && git add . # create a new git repo for tracking config changes during deployment
+nix run github:ngi-nix/ngipkgs/howto-docs#deploy-ngipkgs
+# TODO: remove PR branch name here and in package.nix before merging
 ```
 
-2. Edit the flake.nix to enable a service by removing comments from its config lines under 
+2. Edit the flake.nix to enable a service by removing comments from its module and example config. For example, this would enable the Kbin service:
 ```
 modules = [
+  [...]
+  ### VULA
+  # ngipkgs.nixosModules."services.vula"
+  # ./Vula/example-simple.nix
+  ###
+  ### KBIN
+  ngipkgs.nixosModules."services.kbin"
+  ./Kbin/example.nix
+  ###
+  ### PEERTUBE
+  # ngipkgs.nixosModules."services.peertube.plugins"
+  # ./PeerTube/example.nix
+  ###
+  ];
 ```
 
 3. Run the following commands to build deploy a local QEMU VM running the enabled service:

--- a/pkgs/by-name/deploy-ngipkgs/package.nix
+++ b/pkgs/by-name/deploy-ngipkgs/package.nix
@@ -2,15 +2,29 @@
   writeShellApplication,
   git,
 }:
+let
+  repo = fetchGit {
+    url = "https://github.com/ngi-nix/ngipkgs/howto-docs";
+  };
+  storePath = builtins.storePath repo;
+in
 writeShellApplication {
   name = "deploy-ngipkgs";
   runtimeInputs = [ git ];
   text = ''
-    git clone -b howto-docs --no-checkout --depth=1 https://github.com/ngi-nix/ngipkgs.git deploy-ngipkgs && # clone an empty version of ngipkgs to a dir called deploy-ngipkgs
-    cd deploy-ngipkgs &&
-    git checkout howto-docs -- projects && # checkout only the projects directory of ngipkgs
-    cp -a projects/. . && # copy contents of the projects directory into the root of deploy-ngipkgs
-    rm -rf .git projects default.nix && # cleanup
-    git init && git add . # create a new git repo for tracking config changes during deployment
+    # Create a new directory for the deployment repo
+    mkdir ./deploy-ngipkgs
+
+    # Copy projects directory from repo already downloaded to the local store
+    cp -r ${storePath}/projects/* ./deploy-ngipkgs
+
+    # Cleanup project files that are not used for deployment
+    cd ./deploy-ngipkgs
+    find . -type f \( -name 'default.nix' -o -name 'service.nix' -o -name 'container.nix' -o -name 'module.nix' -o -name 'nss*' -o -name 'dbus*' \) -exec rm {} \;
+    find . -name 'test*' -exec rm -r {} \;
+    find . -type d -empty -delete
+
+    # Create a new git repo for tracking config changes during deployment
+    git init && git add .
   '';
 }

--- a/pkgs/by-name/deploy-ngipkgs/package.nix
+++ b/pkgs/by-name/deploy-ngipkgs/package.nix
@@ -1,30 +1,68 @@
 {
-  writeShellApplication,
+  lib,
+  writeText,
+  ngipkgs,
   git,
+
 }:
 let
-  repo = fetchGit {
-    url = "https://github.com/ngi-nix/ngipkgs/howto-docs";
-  };
-  storePath = builtins.storePath repo;
+
+#  repo = fetchGit {
+#    url = "https://github.com/ngi-nix/ngipkgs/howto-docs";
+#  };
+#  storePath = builtins.storePath repo;
+
+  # Function to generate lines for modules with examples
+  generateLines = lib.concatStrings (lib.mapAttrsToList (name: module:
+    if module ? example then ''
+      services.${name} = import ../ngipkgs/nixosModules/${name};
+      example.${name} = import ../ngipkgs/nixosModules/${name}/example.nix;
+    '' else ""
+  ) ngipkgs.nixosModules);
+
+  # Function to update flake content
+  updateFlakeContent = flakeContent:
+    lib.replaceStrings
+      ["# GENERATE-HERE"]
+      [generateLines]
+      flakeContent;
+
 in
-writeShellApplication {
+derivation {
   name = "deploy-ngipkgs";
-  runtimeInputs = [ git ];
-  text = ''
-    # Create a new directory for the deployment repo
-    mkdir ./deploy-ngipkgs
+  system = builtins.currentSystem;
+  builder = "${pkgs.bash}/bin/bash";
+  args = [
+    "-c"
+    ''
+      # Create a new directory for the deployment repo
+      mkdir ./deploy-ngipkgs
 
-    # Copy projects directory from repo already downloaded to the local store
-    cp -r ${storePath}/projects/* ./deploy-ngipkgs
+      # Copy projects directory from repo already downloaded to the local store
+      cp -r ${ngipkgs.outPath}/projects/* ./deploy-ngipkgs
 
-    # Cleanup project files that are not used for deployment
-    cd ./deploy-ngipkgs
-    find . -type f \( -name 'default.nix' -o -name 'service.nix' -o -name 'container.nix' -o -name 'module.nix' -o -name 'nss*' -o -name 'dbus*' \) -exec rm {} \;
-    find . -name 'test*' -exec rm -r {} \;
-    find . -type d -empty -delete
+      # Cleanup project files that are not used for deployment
+      cd ./deploy-ngipkgs
+      find . -type f \( -name 'default.nix' -o -name 'service.nix' -o -name 'container.nix' -o -name 'module.nix' -o -name 'nss*' -o -name 'dbus*' \) -exec rm {} \;
+      find . -name 'test*' -exec rm -r {} \;
+      find . -type d -empty -delete
 
-    # Create a new git repo for tracking config changes during deployment
-    git init && git add .
-  '';
+      # Get the flake.nix from the ngipkgs source in the Nix store
+      flakeFile="${ngipkgs.outPath}/projects/flake.nix"
+
+      # Read the original content, update it, and write to the deploy repo
+      originalContent=$(cat "$flakeFile")
+      updatedContent=$(nix-instantiate --eval --expr '(${updateFlakeContent "''${originalContent}"})' --raw)
+      echo "$updatedContent" > ./projects/flake.nix
+
+      # Replace the default flake.nix with the generated version
+      # cp ${updatedFlakeFile} ./flake.nix
+
+      # Create a new git repo for tracking config changes during deployment
+      git init && git add .
+
+      # Meet the nix requirement that a derivation outputs to the store
+      touch $out
+   ''
+  ];
 }

--- a/pkgs/by-name/deploy-ngipkgs/package.nix
+++ b/pkgs/by-name/deploy-ngipkgs/package.nix
@@ -1,0 +1,16 @@
+{
+  writeShellApplication,
+  git,
+}:
+writeShellApplication {
+  name = "deploy-ngipkgs";
+  runtimeInputs = [ git ];
+  text = ''
+    git clone -b howto-docs --no-checkout --depth=1 https://github.com/ngi-nix/ngipkgs.git deploy-ngipkgs && # clone an empty version of ngipkgs to a dir called deploy-ngipkgs
+    cd deploy-ngipkgs &&
+    git checkout howto-docs -- projects && # checkout only the projects directory of ngipkgs
+    cp -a projects/. . && # copy contents of the projects directory into the root of deploy-ngipkgs
+    rm -rf .git projects default.nix && # cleanup
+    git init && git add . # create a new git repo for tracking config changes during deployment
+  '';
+}

--- a/projects/configuration.nix
+++ b/projects/configuration.nix
@@ -1,0 +1,29 @@
+{ config, pkgs, ... }:
+{
+
+  # For more info: https://github.com/ngi-nix/ngipkgs/blob/main/maintainers/cachix.md
+  nix.settings.substituters = ["https://ngi.cachix.org/"];
+  nix.settings.trusted-public-keys = ["ngi.cachix.org-1:n+CAL72ROC3qQuLxIHpV+Tw5t42WhXmMhprAGkRSrOw="];
+
+  users.users.user = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    initialPassword = "pass";
+  };
+
+  services.openssh = {
+    enable = true;
+    settings.PasswordAuthentication = true;
+  };
+  networking.firewall.allowedTCPPorts = [ 22 ];
+
+  environment.systemPackages = with pkgs; [
+    #libgnunetchat
+  ];
+
+  #services.vula.enable = true;
+  #services.vula.openFirewall = true;
+
+  system.stateVersion = "24.11";
+}
+

--- a/projects/flake.nix
+++ b/projects/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "An example deployment of NGIpkgs software to a local VM";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    ngipkgs.url = "github:ngi-nix/ngipkgs";
+  };
+
+  outputs = { self, nixpkgs, ngipkgs }: {
+
+    nixosConfigurations.myMachine = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        ./configuration.nix
+        ngipkgs.nixosModules.default
+        ###
+        ### VULA
+        # ngipkgs.nixosModules."services.vula"
+        # ./Vula/example-simple.nix
+        ###
+        ### KBIN
+        # ngipkgs.nixosModules."services.kbin"
+        # ./Kbin/example.nix
+        ###
+        ### PEERTUBE
+        # ngipkgs.nixosModules."services.peertube.plugins"
+        # ./PeerTube/example.nix
+        ###
+
+      ];
+    };
+  };
+}

--- a/projects/flake.nix
+++ b/projects/flake.nix
@@ -13,7 +13,13 @@
       modules = [
         ./configuration.nix
         ngipkgs.nixosModules.default
-        ###
+
+        # GENERATE-HERE
+
+
+
+       ########################################
+
         ### VULA
         # ngipkgs.nixosModules."services.vula"
         # ./Vula/example-simple.nix


### PR DESCRIPTION
A few questions and comments arising from this:

- [ ] https://github.com/ngi-nix/ngipkgs/issues/296
  
  I only tested with flakes because that's what I'm more familiar with and currently have setup. How much of a priority is testing and documentation of non-flake use cases?

  Is there a good reason that the nixosModule outputs for project services need to be in quotes, like `ngipkgs.nixosModules."services.vula"`? It seems to break with usual conventions around nix syntax which seems more likely to result in confusion or errors.

- [ ] Export all modules and packages in `ngipkgs.nixosModules.default`

  Perhaps most of the third step could be removed by restructuring things so that all of the nixosModules project outputs are included in the default one? I may dig around and see if I can find a way to implement this. 

  In the way I'm proposing to document this there seems to be some minor semantic confusion with the term "modules", especially in the use of `ngipkgs.nixosModules.default` to import all the packages (which are defined as distinct from modules earlier in the readme). I try to paper over this a bit by referring to the "default _packages_ module for NGIpkgs" (emphasis added) but this is maybe making things worse since it is not referred to this way anywhere else. I don't have concrete ideas yet about if/how this should be improved but thought it was at least worth naming as a potential issue.

- [ ] https://github.com/ngi-nix/ngipkgs/issues/297

    Currently, the packages associated with a project are not included with the nixosModule for that project. The project services will fail with "package is missing" errors if `ngipkgs.nixosModules.default` is not also included. This seems like it might be a bug.