### PR TITLE
kbin: fix build

### DIFF
--- a/pkgs/by-name/kbin-backend/antispam-bundle.patch
+++ b/pkgs/by-name/kbin-backend/antispam-bundle.patch
@@ -1,0 +1,19 @@
+diff --git a/composer.lock b/composer.lock
+index 747c4247..1ed82552 100644
+--- a/composer.lock
++++ b/composer.lock
+@@ -5651,12 +5651,12 @@
+             "version": "2.3.2",
+             "source": {
+                 "type": "git",
+-                "url": "https://github.com/nucleos/NucleosAntiSpamBundle.git",
++                "url": "https://github.com/matgrula/NucleosAntiSpamBundle.git",
+                 "reference": "99e3410b14b0bc5b6c1bbd1907b2f3cc09f6bd53"
+             },
+             "dist": {
+                 "type": "zip",
+-                "url": "https://api.github.com/repos/nucleos/NucleosAntiSpamBundle/zipball/99e3410b14b0bc5b6c1bbd1907b2f3cc09f6bd53",
++                "url": "https://api.github.com/repos/matgrula/NucleosAntiSpamBundle/zipball/99e3410b14b0bc5b6c1bbd1907b2f3cc09f6bd53",
+                 "reference": "99e3410b14b0bc5b6c1bbd1907b2f3cc09f6bd53",
+                 "shasum": ""
+             },

--- a/pkgs/by-name/kbin-backend/package.nix
+++ b/pkgs/by-name/kbin-backend/package.nix
@@ -26,7 +26,7 @@ in
     src = fetchgit {
       url = "https://codeberg.org/Kbin/kbin-core/";
       rev = "cc727b9133b60fe7411b8c4dbd90c0319d225916";
-      hash = "sha256-3y9Q+s2ImCFrsET76VXB9uzQ24F3SKfOk+fDINRZjWc=";
+      hash = "sha256-P1LUt5x1RTkSYG/ONWdX7/9MDYz03e//a9CjhqNdrss=";
 
       postFetch = ''
         # Work around <https://github.com/NixOS/nixpkgs/pull/257337>.
@@ -34,6 +34,8 @@ in
           --replace '@symfony/stimulus-bundle' '_symfony/stimulus-bundle' \
           --replace '@symfony/ux-autocomplete' '_symfony/ux-autocomplete' \
           --replace '@symfony/ux-chartjs'      '_symfony/ux-chartjs'
+
+        patch -p1 -d $out < ${./antispam-bundle.patch}
       '';
     };
 
@@ -60,7 +62,7 @@ in
           | sponge config/packages/oneup_flysystem.yaml
       '');
 
-    vendorHash = "sha256-lv13ze8PlJyOMDIrXrPzvQr4AgDpYx8Ns9+lUEFUEJ4=";
+    vendorHash = "sha256-f+ZjdcM+/cBQm/5Nlt42+4t9LI6WNmum0DFfTWQkS0o=";
 
     composerNoPlugins = false;
     composerStrictValidation = false;


### PR DESCRIPTION
There's a fork at https://github.com/matgrula/NucleosAntiSpamBundle, which is archived on [Software Heritage](https://archive.softwareheritage.org/browse/origin/directory/?origin_url=https://github.com/matgrula/NucleosAntiSpamBundle).

Closes #291.
Closes #292.