### PR TITLE
Update documentation for some infra related processes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,10 @@ However, there may be reasons speaking against that, including:
 
 In any case, it is encouraged to create a pull request to Nixpkgs, then to this repository, with a comment linking to the Nixpkgs pull request in the description and the Nix expressions.
 
+## Documentation style guide
+
+When contributing documentation, do not split lines at arbitrary character lengths.
+Instead, write one sentence per line, as this makes it easier to review changes.
 
 ## How to create pull requests to NGIpkgs
 

--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ Many of them represent services that map to one or more systemd services that ar
 These modules are ready to be deployed to a NixOS system, such as a container, virtual machine, or physical machine.
 Example configurations found in the corresponding per-project directory are a good starting point for anyone interested in using these modules, and are sure to work because they are also used for testing.
 
-## Continuous builds of packages with Hydra
+## Continuous builds of packages with Buildbot
 
-All packages in the [main branch of NGIpkgs](https://github.com/ngi-nix/ngipkgs/tree/main) are automatically built by a [Hydra](https://github.com/NixOS/hydra) server.
-The results of these builds can be found at <https://hydra.ngi0.nixos.org/jobset/ngipkgs/main#tabs-jobs>
+All packages in the [main branch of NGIpkgs](https://github.com/ngi-nix/ngipkgs/tree/main) are automatically built by a [Buildbot](https://github.com/buildbot/buildbot) server.
+The results of these builds can be found at <https://buildbot.ngi.nixos.org/#/projects/1>
 
 ## Reasoning for creation of the NGIpkgs monorepo
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -25,3 +25,51 @@ To make changes to `makemake`:
       ```
       nixos-rebuild switch --show-trace -L --flake /root/ngipkgs/#makemake
       ```
+
+## Secret management
+We use [sops-nix](https://github.com/Mic92/sops-nix) to manage secrets in NGIpkgs.
+In order to access the secrets they must be encrypted with your public key and you must have the matching private key available in your system.
+[SOPS](https://github.com/getsops/sops) must also be installed and configured.
+
+### Viewing and editing secrets
+By default on Linux, SOPS expects the private keys to be in `$XDG_CONFIG_HOME/sops/age/keys.txt` or `$HOME/.config/sops/age/keys.txt`.
+You can generate an [age](https://github.com/FiloSottile/age) key using `age-keygen` or convert an SSH key with `ssh-to-age` to one compatible with age.
+Once you've setup your key, you can run `sops -d <file-to-decrypt>` to view an encrypted file or `sops <file-to-edit>` to edit a file.
+
+### Encrypting secrets for a new key
+To add a new person or a key, edit `infra/.sops.yaml`, add the name of the person and their age public key under `.humans`.
+Additionally, you need to add their names to any files you want them to have access.
+This is done in `infra/.sops.yaml` under the `creation_rules` section.
+
+This is an example diff of what this might look like:
+```
+diff --git a/infra/.sops.yaml b/infra/.sops.yaml
+index 68dbb5b..849002e 100644
+--- a/infra/.sops.yaml
++++ b/infra/.sops.yaml
+@@ -2,6 +2,7 @@
+   .humans:
++    - &anewuser      age1ve389y20udzc4ndx709u67dcjcclc3durqhadxs9w0ven56mncxsha5668
+     - &erethon       age187upwqdte7t0hkyec22jhac357m9y4fkcdvpg9sj5q9mekjupfnqg9a077
+     - &lorenzleutgeb age1c0g6s6daxy79dlm9uqczwlkh0hvjpghw5h8zzljc3vs275rvvqus30hv9l
+   .machines:
+     - &makemake      age1ewus3xraznqv6xc2ptua2qjqrjyhfd8uugu08wjduushj3uhgqwsqd6vkk
+
+@@ -9,6 +10,7 @@ creation_rules:
+   - path_regex: makemake/secrets
+     key_groups:
+       - age:
++        - *anewuser
+         - *erethon
+         - *lorenzleutgeb
+         - *makemake
+```
+
+Remember to keep entries ordered alphabetically!
+
+Once that's done, you need to re-encrypt the secrets with their key.
+From the `infra` directory run:
+
+```
+sops updatekeys <files-you-want-to-update>
+```

--- a/infra/README.md
+++ b/infra/README.md
@@ -8,6 +8,11 @@
 
 ## Rebuilding `makemake`
 
+### Applying patches automatically
+By default, [a GitHub action deploys `makemake` automatically](https://github.com/ngi-nix/ngipkgs/actions/workflows/makemake.yaml) on every push to the `main` branch.
+No manual actions are required from our side.
+
+### Manually updating makemake to test changes
 A clone of this repository is stored at `/root/ngipkgs`, and is the source of
 truth for what is applied in `makemake`.
 


### PR DESCRIPTION
This PR updates the documentation in `infra` with instructions on how to edit/update sops secrets. Additionally, it adds a small explanation on how `makemake` is re-deployed automatically on merge.