### PR TITLE
anastasis: fix install check with gnunet 0.21.2

### DIFF
--- a/pkgs/by-name/anastasis/package.nix
+++ b/pkgs/by-name/anastasis/package.nix
@@ -77,9 +77,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   doInstallCheck = true;
 
-  postInstallCheck = ''
-    # Check that anastasis-config can find gnunet at runtime
-    $out/bin/anastasis-config --help > /dev/null
+  # Check that anastasis-config can find gnunet at runtime
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    output=$($out/bin/anastasis-config --help || true)
+    echo "$output" | grep "Report bugs to contact@anastasis.lu."
+
+    runHook postInstallCheck
   '';
 
   passthru.tests.vmTest = callPackage ./test.nix {};


### PR DESCRIPTION
`gnunet-config` now checks the existence of configuration file on every subcommand. Apparently this didn't affect NixOS modules upstream and won't affect NixOS tests here, but there's an installation check in `anastasis` that will fail for the next flake bump. So I changed the test to something a bit more meaningful.

See also https://github.com/Homebrew/homebrew-core/pull/174035#issuecomment-2156339536 for alternative options.