### PR TITLE
expose forgejo

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,7 +80,7 @@
     # Note that modules and examples are system-agnostic, so import them first.
     rawNgiProjects = import ./projects {
       inherit lib;
-      sources = {};
+      sources = {inherit inputs;};
     };
 
     rawExamples = flattenAttrsSlash (mapAttrs (_: v: mapAttrs (_: v: v.path) v) (
@@ -118,6 +118,7 @@
       import ./projects {
         inherit lib pkgs;
         sources = {
+          inherit inputs;
           examples = rawExamples;
           modules = extendedNixosModules;
         };

--- a/projects/Forgejo/default.nix
+++ b/projects/Forgejo/default.nix
@@ -1,0 +1,10 @@
+{
+  pkgs,
+  lib,
+  sources,
+} @ args: {
+  packages = {inherit (pkgs) forgejo;};
+  nixos = {
+    modules.services.forgejo = "${sources.inputs.nixpkgs}/nixos/modules/services/misc/forgejo.nix";
+  };
+}


### PR DESCRIPTION
Closes #268

This is dirty, but modules from nixpkgs can be exported

If this is accepted, #288 can be modified to:


```diff
- modules.services.ntpd-rs = null;
+ modules.services.ntpd-rs = "${lib.modulePath}/services/networking/ntp/ntpd-rs.nix";
```