### PR TITLE
PeerTube plugins: init official & livechat plugins, add module & test

### DIFF
--- a/pkgs/by-name/peertube-plugin-akismet/package.nix
+++ b/pkgs/by-name/peertube-plugin-akismet/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitLab,
+}:
+buildNpmPackage rec {
+  pname = "peertube-plugin-akismet";
+  version = "0.1.1";
+
+  src = fetchFromGitLab {
+    domain = "framagit.org";
+    owner = "framasoft";
+    repo = "peertube/official-plugins";
+    rev = "6d07c51ac627d76de63b093ef0cd9e20da1019cf";
+    hash = "sha256-vKA9rdfatdJqXlLqMsLL0xrNIj7A+dechwDl3QMquwE=";
+  };
+
+  sourceRoot = "${src.name}/peertube-plugin-akismet";
+
+  npmDepsHash = "sha256-U+AQeOJI31QPeZrej6STDRtnwYJgSp86ycf4vsqSats=";
+
+  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+
+  meta = {
+    description = "Reject local comments, remote comments and registrations based on Akismet service";
+    homepage = "https://framagit.org/framasoft/peertube/official-plugins/tree/master/peertube-plugin-akismet";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/by-name/peertube-plugin-auth-ldap/package.nix
+++ b/pkgs/by-name/peertube-plugin-auth-ldap/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitLab,
+}:
+buildNpmPackage rec {
+  pname = "peertube-plugin-auth-ldap";
+  version = "0.0.12";
+
+  src = fetchFromGitLab {
+    domain = "framagit.org";
+    owner = "framasoft";
+    repo = "peertube/official-plugins";
+    rev = "fb3226e552a475f70b5ee033803274ed27a86619";
+    hash = "sha256-VzypXOf05nigevG9E8AIISEbR7XI+TExyJMv1MDMfOY=";
+  };
+
+  sourceRoot = "${src.name}/peertube-plugin-auth-ldap";
+
+  npmDepsHash = "sha256-1esTdjtbBIf3xY90xPbTZ9YmydhHO8tF430O8sIevjo=";
+
+  dontNpmBuild = true;
+
+  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+
+  meta = {
+    description = "Add LDAP support to login form in PeerTube";
+    homepage = "https://framagit.org/framasoft/peertube/official-plugins/tree/master/peertube-plugin-auth-ldap";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/by-name/peertube-plugin-auth-openid-connect/package.nix
+++ b/pkgs/by-name/peertube-plugin-auth-openid-connect/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitLab,
+}:
+buildNpmPackage rec {
+  pname = "peertube-plugin-auth-openid-connect";
+  version = "0.1.1";
+
+  src = fetchFromGitLab {
+    domain = "framagit.org";
+    owner = "framasoft";
+    repo = "peertube/official-plugins";
+    rev = "9ed56041e9a9dcb98cc610e938c7853db38cd349";
+    hash = "sha256-L9yD+amw49s+zhP4anTkXGdemitOoqJgqwzwd9PHWyw=";
+  };
+
+  sourceRoot = "${src.name}/peertube-plugin-auth-openid-connect";
+
+  npmDepsHash = "sha256-3FD9i4utzkHOjBXVPz574vttOL6VDuqM1kxtgqp8eOA=";
+
+  dontNpmBuild = true;
+
+  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+
+  meta = {
+    description = "Add OpenID Connect support to login form in PeerTube";
+    homepage = "https://framagit.org/framasoft/peertube/official-plugins/tree/master/peertube-plugin-auth-openid-connect";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/by-name/peertube-plugin-auth-saml2/package.nix
+++ b/pkgs/by-name/peertube-plugin-auth-saml2/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitLab,
+}:
+buildNpmPackage rec {
+  pname = "peertube-plugin-auth-saml2";
+  version = "0.0.8";
+
+  src = fetchFromGitLab {
+    domain = "framagit.org";
+    owner = "framasoft";
+    repo = "peertube/official-plugins";
+    rev = "6737d29dce5272d2abeac8a8c501ba874413e422";
+    hash = "sha256-xmyVwfXPMl/8TNtDXzJ6ngrC3Y1G5gdFK+zmIEbL5Uw=";
+  };
+
+  sourceRoot = "${src.name}/peertube-plugin-auth-saml2";
+
+  npmDepsHash = "sha256-Mkku+nu9WewKXzUcyaaekB3MgZ7mLeAOwGXLU5evdp8=";
+
+  dontNpmBuild = true;
+
+  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+
+  meta = {
+    description = "Add SAML2 support to login form in PeerTube";
+    homepage = "https://framagit.org/framasoft/peertube/official-plugins/tree/master/peertube-plugin-auth-saml2";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/by-name/peertube-plugin-auto-block-videos/package.nix
+++ b/pkgs/by-name/peertube-plugin-auto-block-videos/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitLab,
+}:
+buildNpmPackage rec {
+  pname = "peertube-plugin-auto-block-videos";
+  version = "0.0.2";
+
+  src = fetchFromGitLab {
+    domain = "framagit.org";
+    owner = "framasoft";
+    repo = "peertube/official-plugins";
+    rev = "bf3602a782fb4605cc674aa21e1fe7dcb2693cf3";
+    hash = "sha256-R+jbfubeph68aVP1Kg7QozRwrgwhXvK5QuGSZHU5iJk=";
+  };
+
+  sourceRoot = "${src.name}/peertube-plugin-auto-block-videos";
+
+  npmDepsHash = "sha256-inmRylbPXSJjglozVM1Xxja9eZaM+h5bv6CffiX61cA=";
+
+  dontNpmBuild = true;
+
+  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+
+  meta = {
+    description = "Auto block videos based on public blocklists";
+    homepage = "https://framagit.org/framasoft/peertube/official-plugins/tree/master/peertube-plugin-auto-block-videos";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/by-name/peertube-plugin-auto-mute/package.nix
+++ b/pkgs/by-name/peertube-plugin-auto-mute/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitLab,
+}:
+buildNpmPackage rec {
+  pname = "peertube-plugin-auto-mute";
+  version = "0.0.6";
+
+  src = fetchFromGitLab {
+    domain = "framagit.org";
+    owner = "framasoft";
+    repo = "peertube/official-plugins";
+    rev = "932c51d45ce3160ab9ba097bbede51a44d890a61";
+    hash = "sha256-UGqoevqoyvWfAmumuOsdDdMIDPfaOhnjwoFXynWCgHQ=";
+  };
+
+  sourceRoot = "${src.name}/peertube-plugin-auto-mute";
+
+  npmDepsHash = "sha256-YbFEefvSLk9jf6g6FMmCahxqA+X+FD4MCc+c6luRZq4=";
+
+  dontNpmBuild = true;
+
+  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+
+  meta = {
+    description = "Auto mute accounts or instances based on public blocklists";
+    homepage = "https://framagit.org/framasoft/peertube/official-plugins/tree/master/peertube-plugin-auto-mute";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/by-name/peertube-plugin-hello-world/package.nix
+++ b/pkgs/by-name/peertube-plugin-hello-world/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitLab,
+}:
+buildNpmPackage rec {
+  pname = "peertube-plugin-hello-world";
+  version = "0.0.22";
+
+  src = fetchFromGitLab {
+    domain = "framagit.org";
+    owner = "framasoft";
+    repo = "peertube/official-plugins";
+    rev = "fa9005ab1bab93e41e10bb1be3dc4837bd6bbc47";
+    hash = "sha256-d1DGrmRCavc1a6r3UvT7AzcLkFMJktwDKpEjgx7RJAI=";
+  };
+
+  sourceRoot = "${src.name}/peertube-plugin-hello-world";
+
+  npmDepsHash = "sha256-Y6bq2w5ykqLMY9eDTNKL3DMkoOx+imV7OCw2Hy961Tk=";
+
+  dontNpmBuild = true;
+
+  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+
+  meta = {
+    description = "Hello world PeerTube plugin example";
+    homepage = "https://framagit.org/framasoft/peertube/official-plugins/tree/master/peertube-plugin-hello-world";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/by-name/peertube-plugin-livechat/9000-Default-to-using-system-installed-prosody.patch
+++ b/pkgs/by-name/peertube-plugin-livechat/9000-Default-to-using-system-installed-prosody.patch
@@ -1,0 +1,34 @@
+From 30f241d1246fe4c0ed7c30631348af99f0a20d36 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Tue, 11 Jun 2024 18:18:06 +0200
+Subject: [PATCH] Default to using system-installed prosody
+
+---
+ server/lib/settings.ts | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/server/lib/settings.ts b/server/lib/settings.ts
+index eda78e1df..098ae3b14 100644
+--- a/server/lib/settings.ts
++++ b/server/lib/settings.ts
+@@ -120,7 +120,7 @@ function initImportantNotesSettings ({ registerSetting }: RegisterServerOptions)
+       // Note: the following text as a variable in it.
+       //   Not translating it: it should be very rare.
+       descriptionHTML: `<span class="peertube-plugin-livechat-warning">
+-It seems that your are using a ${process.arch} CPU, 
++It seems that your are using a ${process.arch} CPU,
+ which is not compatible with the plugin.
+ Please read
+ <a
+@@ -535,7 +535,7 @@ function initChatServerAdvancedSettings ({ registerSetting }: RegisterServerOpti
+     label: loc('system_prosody_label'),
+     descriptionHTML: loc('system_prosody_description'),
+     private: true,
+-    default: false
++    default: true
+   })
+ 
+   registerSetting({
+-- 
+2.44.1
+

--- a/pkgs/by-name/peertube-plugin-livechat/package.nix
+++ b/pkgs/by-name/peertube-plugin-livechat/package.nix
@@ -1,0 +1,264 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchNpmDeps,
+  fetchFromGitHub,
+  fetchpatch,
+  runCommand,
+  stdenvNoCC,
+  symlinkJoin,
+  prosody,
+}: let
+  details = {
+    livechat = rec {
+      pname = "peertube-plugin-livechat";
+      version = "10.0.2";
+      src = fetchFromGitHub {
+        owner = "JohnXLivingston";
+        repo = "peertube-plugin-livechat";
+        rev = "refs/tags/v${version}";
+        hash = "sha256-NnhH69yWyB1gZWKtp3+GmK1gwWp3eadQaO+Z/ISQmhI=";
+      };
+      npmDeps = fetchNpmDeps {
+        name = "${pname}-${version}-deps";
+        inherit src;
+        hash = "sha256-atXmU6wAh0zLG6jsUwi1GBXexYbJvGvDiGHHdFdAm5k=";
+      };
+    };
+
+    # Check <livechat-src>/conversejs/build-conversejs.sh for which conversejs to use
+    conversejs = rec {
+      pname = "conversejs-livechat";
+      version = "10.0.0";
+      src = fetchFromGitHub {
+        owner = "JohnXLivingston";
+        repo = "converse.js";
+        rev = "refs/tags/livechat-${version}";
+        hash = "sha256-YyaCmq/BXcxPe512w8mPBk5OP1zKmywyGqgdQIiGz5c=";
+      };
+      npmDeps = fetchNpmDeps {
+        name = "${pname}-${version}-deps";
+        inherit src;
+        hash = "sha256-1ObgAiaIsXK6ACxdNjRWxmRYClDfHZ3BdBb+47EsD4Q=";
+      };
+    };
+  };
+
+  commonMeta = {
+    description = "Provides chat system for Peertube videos";
+    homepage = "https://github.com/JohnXLivingston/peertube-plugin-livechat";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [];
+    platforms = lib.platforms.unix;
+  };
+
+  # converse.js building needs generated translations from livechat
+  translations = buildNpmPackage {
+    pname = "${details.livechat.pname}-translations";
+    inherit (details.livechat) version src npmDeps;
+
+    dontConfigure = true;
+
+    npmBuildScript = "build:languages";
+
+    installPhase = ''
+      runHook preInstall
+
+      mv dist/languages $out
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "${commonMeta.description} - generated translations";
+      inherit
+        (commonMeta)
+        homepage
+        license
+        maintainers
+        platforms
+        ;
+    };
+  };
+
+  # converse.js src is expected to be downloaded here by various scripts
+  merged-src =
+    runCommand "${details.livechat.pname}-src-full"
+    {
+      meta = {
+        description = "${commonMeta.description} - source with converse.js merged in";
+        platforms = lib.platforms.all;
+        inherit (commonMeta) homepage license maintainers;
+      };
+    }
+    ''
+      cp -r --no-preserve=mode,ownership ${details.livechat.src} $out
+      mkdir -p $out/vendor
+      cp -r --no-preserve=mode,ownership ${details.conversejs.src} $out/vendor/${details.conversejs.pname}-${details.conversejs.version}
+    '';
+
+  # <livechat-src>/conversejs/build-conversejs.sh applies various patches to the converse.js source before attempting to build it
+  # Patch the script to only applies its patches, then return the new source for separate converse.js building
+  merged-patched-src = buildNpmPackage {
+    pname = "${details.conversejs.pname}-src-patched";
+    inherit (details.conversejs) version;
+    inherit (details.livechat) npmDeps;
+
+    src = merged-src;
+
+    postPatch = ''
+      substituteInPlace conversejs/build-conversejs.sh \
+        --replace-fail '/bin/env node' 'node' \
+        --replace-fail 'if [[ ! -d "$converse_build_dir/node_modules" ]]; then' 'echo "Done patching ConverseJS" && exit 0; if [[ ! -d "$converse_build_dir/node_modules" ]]; then'
+    '';
+
+    dontConfigure = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+      bash conversejs/build-conversejs.sh
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      rm -r node_modules
+      rm -r vendor/${details.conversejs.pname}-${details.conversejs.version}
+      mv build/conversejs vendor/${details.conversejs.pname}-${details.conversejs.version}
+      rmdir build
+
+      cp -r . $out
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "${commonMeta.description} - source with merged converse.js patched";
+      inherit
+        (commonMeta)
+        homepage
+        license
+        maintainers
+        platforms
+        ;
+    };
+  };
+
+  # livechat needs converse.js
+  conversejs = buildNpmPackage rec {
+    inherit (details.conversejs) pname version npmDeps;
+
+    src = merged-patched-src;
+
+    postPatch = ''
+      substituteInPlace conversejs/build-conversejs.sh \
+        --replace-fail 'converse_build_dir="$rootdir/build/conversejs"' 'converse_build_dir="$converse_src_dir"' \
+        --replace-fail 'if cmp -s "$converse_src_dir/package.json" "$converse_build_dir/package.json"' 'echo "Skipping re-modifying of source..."; if false; then if cmp -s "$converse_src_dir/package.json" "$converse_build_dir/package.json"' \
+        --replace-fail 'if [[ ! -d "$converse_build_dir/node_modules" ]]; then' 'fi; if [[ ! -d "$converse_build_dir/node_modules" ]]; then'
+    '';
+
+    npmRoot = "vendor/${details.conversejs.pname}-${details.conversejs.version}";
+
+    makeCacheWritable = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+      # Translations are needed for webpack building, else it silently fails
+      mkdir dist
+      cp -r --no-preserve=mode,ownership ${translations} dist/languages
+
+      bash conversejs/build-conversejs.sh
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      cp -r dist/client/conversejs $out
+
+      runHook postInstall
+    '';
+
+    doInstallCheck = true;
+
+    installCheckPhase = ''
+      runHook preInstallCheck
+
+      if [ ! -f $out/converse.min.js -o ! -f $out/converse.min.css ]; then
+        echo "converse.min.js or converse.min.css failed to be generated, please check the build log!"
+        exit 1
+      fi
+
+      runHook postInstallCheck
+    '';
+
+    meta = {
+      description = "Web-based XMPP/Jabber chat client written in JavaScript";
+      homepage = "https://conversejs.org";
+      license = lib.licenses.mpl20;
+      inherit (commonMeta) maintainers platforms;
+    };
+  };
+in
+  buildNpmPackage rec {
+    inherit (details.livechat) pname version npmDeps;
+
+    src = merged-src;
+
+    patches = [
+      # Fix EPIPE when talking to prosodyctl process
+      # Remove when fix for https://github.com/JohnXLivingston/peertube-plugin-livechat/issues/416 merged & in Nixpkgs / release
+      (fetchpatch {
+        name = "0001-peertube-plugin-livechat-Fix-EPIPE.patch";
+        url = "https://github.com/JohnXLivingston/peertube-plugin-livechat/commit/ad27a76fab884ae1d939aee094ec7414ee174ab7.patch";
+        excludes = ["CHANGELOG.md"];
+        hash = "sha256-sfLPeYStXlkX9QVEIlyNovojNyUl8GUPzEY4w1EiBxI=";
+      })
+
+      # Change default, we don't want to bother with downloading & including a bundled prosody AppImage
+      ./9000-Default-to-using-system-installed-prosody.patch
+    ];
+
+    postPatch = ''
+      mkdir -p dist/client
+      cp -r --no-preserve=mode,ownership ${translations} dist/languages
+      cp -r --no-preserve=mode,ownership ${conversejs} dist/client/conversejs
+
+      # Don't try to delete & rebuild everything when installing (either in this derivation or as a plugin in peertube)
+      # clean:light would get rid of the built conversejs
+      # build:languages & conversejs already built separately, build:prosody would try to download an AppImage
+      substituteInPlace package.json \
+        --replace-fail '"prepare": "npm run clean && npm run build",' "" \
+        --replace-fail '"build:avatars": "./build-avatars.js"' '"build:avatars": "node ./build-avatars.js"' \
+        --replace-fail '"build": "npm-run-all -s clean:light build:languages' '"build": "npm-run-all -s' \
+        --replace-fail 'build:prosodymodules build:converse build:prosody' 'build:prosodymodules'
+
+      substituteInPlace conversejs/build-conversejs.sh \
+        --replace-fail '/bin/env node' 'node'
+
+      # We don't want to rely on a bundled AppImage version of prosody
+      substituteInPlace server/lib/settings.ts \
+        --replace-fail 'default: false' 'default: true'
+
+      # Wants to run its own prosody instance
+      substituteInPlace server/lib/prosody/config.ts \
+        --replace-fail "exec = 'prosody'" "exec = '${lib.getExe' prosody "prosody"}'" \
+        --replace-fail "execCtl = 'prosodyctl'" "execCtl = '${lib.getExe' prosody "prosodyctl"}'" \
+    '';
+
+    meta = {
+      inherit
+        (commonMeta)
+        description
+        homepage
+        license
+        maintainers
+        platforms
+        ;
+    };
+  }

--- a/pkgs/by-name/peertube-plugin-livechat/package.nix
+++ b/pkgs/by-name/peertube-plugin-livechat/package.nix
@@ -3,7 +3,6 @@
   buildNpmPackage,
   fetchNpmDeps,
   fetchFromGitHub,
-  fetchpatch,
   runCommand,
   stdenvNoCC,
   symlinkJoin,
@@ -12,29 +11,29 @@
   details = {
     livechat = rec {
       pname = "peertube-plugin-livechat";
-      version = "10.0.2";
+      version = "10.1.2";
       src = fetchFromGitHub {
         owner = "JohnXLivingston";
         repo = "peertube-plugin-livechat";
         rev = "refs/tags/v${version}";
-        hash = "sha256-NnhH69yWyB1gZWKtp3+GmK1gwWp3eadQaO+Z/ISQmhI=";
+        hash = "sha256-YXx171816oZhZyNA4OSAlFIzyqq9nVLEZSHhM+F7AHg=";
       };
       npmDeps = fetchNpmDeps {
         name = "${pname}-${version}-deps";
         inherit src;
-        hash = "sha256-atXmU6wAh0zLG6jsUwi1GBXexYbJvGvDiGHHdFdAm5k=";
+        hash = "sha256-VnV1EyHDhvrjVUSOdjFef8aV6lGRVv8DZllf6ODVwx4=";
       };
     };
 
     # Check <livechat-src>/conversejs/build-conversejs.sh for which conversejs to use
     conversejs = rec {
       pname = "conversejs-livechat";
-      version = "10.0.0";
+      version = "10.1.0";
       src = fetchFromGitHub {
         owner = "JohnXLivingston";
         repo = "converse.js";
         rev = "refs/tags/livechat-${version}";
-        hash = "sha256-YyaCmq/BXcxPe512w8mPBk5OP1zKmywyGqgdQIiGz5c=";
+        hash = "sha256-udSpkYSyBkR2d5jxRBz3qLwiRH4PXdHCsv8j4Z6i8xY=";
       };
       npmDeps = fetchNpmDeps {
         name = "${pname}-${version}-deps";
@@ -211,15 +210,6 @@ in
     src = merged-src;
 
     patches = [
-      # Fix EPIPE when talking to prosodyctl process
-      # Remove when fix for https://github.com/JohnXLivingston/peertube-plugin-livechat/issues/416 merged & in Nixpkgs / release
-      (fetchpatch {
-        name = "0001-peertube-plugin-livechat-Fix-EPIPE.patch";
-        url = "https://github.com/JohnXLivingston/peertube-plugin-livechat/commit/ad27a76fab884ae1d939aee094ec7414ee174ab7.patch";
-        excludes = ["CHANGELOG.md"];
-        hash = "sha256-sfLPeYStXlkX9QVEIlyNovojNyUl8GUPzEY4w1EiBxI=";
-      })
-
       # Change default, we don't want to bother with downloading & including a bundled prosody AppImage
       ./9000-Default-to-using-system-installed-prosody.patch
     ];

--- a/pkgs/by-name/peertube-plugin-logo-framasoft/package.nix
+++ b/pkgs/by-name/peertube-plugin-logo-framasoft/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitLab,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "peertube-plugin-logo-framasoft";
+  version = "0.0.1";
+
+  src = fetchFromGitLab {
+    domain = "framagit.org";
+    owner = "framasoft";
+    repo = "peertube/official-plugins";
+    rev = "b4ff861a3458bd502a6b95c9005c90d786f2a74e";
+    hash = "sha256-BPV1DrqCvKsV5SA4o2+oUsE/kNY9sL6svJmshjDTG+Y=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/peertube-plugin-logo-framasoft";
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/node_modules
+    cp -r $PWD $out/lib/node_modules/${finalAttrs.pname}
+
+    runHook postInstall
+  '';
+
+  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+
+  meta = {
+    description = "Framasoft logo on PeerTube";
+    homepage = "https://framagit.org/framasoft/peertube/official-plugins/tree/master/peertube-plugin-logo-framasoft";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/peertube-plugin-matomo/package.nix
+++ b/pkgs/by-name/peertube-plugin-matomo/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitLab,
+}:
+buildNpmPackage rec {
+  pname = "peertube-plugin-matomo";
+  version = "1.0.2";
+
+  src = fetchFromGitLab {
+    domain = "framagit.org";
+    owner = "framasoft";
+    repo = "peertube/official-plugins";
+    rev = "9bd2db9033c11c650cdf1035f7eed6f4ba61cf54";
+    hash = "sha256-EUocSJLi2s9VXddRIffG1Aj8/1AlegwP+76IbowhoOo=";
+  };
+
+  sourceRoot = "${src.name}/peertube-plugin-matomo";
+
+  npmDepsHash = "sha256-s2vrUKMRF+VhBPAbv/RQ66UBNOBYEvi/axxJB132R9s=";
+
+  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+
+  meta = {
+    description = "Matomo plugin that tracks page views on a PeerTube instance";
+    homepage = "https://framagit.org/framasoft/peertube/official-plugins/tree/master/peertube-plugin-matomo";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/by-name/peertube-plugin-privacy-remover/package.nix
+++ b/pkgs/by-name/peertube-plugin-privacy-remover/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitLab,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "peertube-plugin-privacy-remover";
+  version = "0.0.1";
+
+  src = fetchFromGitLab {
+    domain = "framagit.org";
+    owner = "framasoft";
+    repo = "peertube/official-plugins";
+    rev = "2df3a5909536f17f143b2c391bb483e339f36c3e";
+    hash = "sha256-2kcugu4uEPd/WgOe3vV6xaA1d2OcSBJy2ZkZ8gNv760=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/peertube-plugin-privacy-remover";
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/node_modules
+    cp -r $PWD $out/lib/node_modules/${finalAttrs.pname}
+
+    runHook postInstall
+  '';
+
+  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+
+  meta = {
+    description = "Remove video privacy settings of your choice";
+    homepage = "https://framagit.org/framasoft/peertube/official-plugins/tree/master/peertube-plugin-privacy-remover";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/peertube-plugin-transcoding-custom-quality/package.nix
+++ b/pkgs/by-name/peertube-plugin-transcoding-custom-quality/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitLab,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "peertube-plugin-transcoding-custom-quality";
+  version = "0.1.0";
+
+  src = fetchFromGitLab {
+    domain = "framagit.org";
+    owner = "framasoft";
+    repo = "peertube/official-plugins";
+    rev = "9731357f9fb68c48df9cdc3f51fe3dafbecf3bf6";
+    hash = "sha256-diklMd0S6wUsQKunQYLGzrIJqIfAfDzBTZy6aUiu584=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/peertube-plugin-transcoding-custom-quality";
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/node_modules
+    cp -r $PWD $out/lib/node_modules/${finalAttrs.pname}
+
+    runHook postInstall
+  '';
+
+  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+
+  meta = {
+    description = "Set a custom quality for transcoding";
+    homepage = "https://framagit.org/framasoft/peertube/official-plugins/tree/master/peertube-plugin-transcoding-custom-quality";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/peertube-plugin-transcoding-profile-debug/package.nix
+++ b/pkgs/by-name/peertube-plugin-transcoding-profile-debug/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitLab,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "peertube-plugin-transcoding-profile-debug";
+  version = "0.0.5";
+
+  src = fetchFromGitLab {
+    domain = "framagit.org";
+    owner = "framasoft";
+    repo = "peertube/official-plugins";
+    rev = "077c983e32743462372c503b636814543f65845e";
+    hash = "sha256-fL+JhHHtSIb1X87z6VqX8I0C31yewjj2C9tx1aVzJPA=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/peertube-plugin-transcoding-profile-debug";
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/node_modules
+    cp -r $PWD $out/lib/node_modules/${finalAttrs.pname}
+
+    runHook postInstall
+  '';
+
+  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+
+  meta = {
+    description = "Allow admins to create custom transcoding profiles using the plugin settings";
+    homepage = "https://framagit.org/framasoft/peertube/official-plugins/tree/master/peertube-plugin-transcoding-profile-debug";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/peertube-plugin-video-annotation/package.nix
+++ b/pkgs/by-name/peertube-plugin-video-annotation/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitLab,
+}:
+buildNpmPackage rec {
+  pname = "peertube-plugin-video-annotation";
+  version = "0.0.8";
+
+  src = fetchFromGitLab {
+    domain = "framagit.org";
+    owner = "framasoft";
+    repo = "peertube/official-plugins";
+    rev = "fee5b7eb1d8d1a51c56ea9a6b4b7d109f91b20c3";
+    hash = "sha256-MWcHMAXPLAxlp+EEFs60nIAR99PBNw15bWj1/NA3ZWs=";
+  };
+
+  # prepare script breaks installation at peertube plugin time
+  postPatch = ''
+    substituteInPlace package.json \
+      --replace-fail '"prepare": "npm run build",' ""
+  '';
+
+  sourceRoot = "${src.name}/peertube-plugin-video-annotation";
+
+  npmDepsHash = "sha256-gqEa1DwNlNR5JED0Lhhi9XFKCoJ+NhNHKioNR1A8puU=";
+
+  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+
+  meta = {
+    description = "Add a field in the video form so users can set annotation to their video";
+    homepage = "https://framagit.org/framasoft/peertube/official-plugins/tree/master/peertube-plugin-video-annotation";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/by-name/peertube-theme-background-red/package.nix
+++ b/pkgs/by-name/peertube-theme-background-red/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitLab,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "peertube-theme-background-red";
+  version = "0.0.4";
+
+  src = fetchFromGitLab {
+    domain = "framagit.org";
+    owner = "framasoft";
+    repo = "peertube/official-plugins";
+    rev = "e763baddf3ad0efb215bcc8c0d3eb286d0471f21";
+    hash = "sha256-50H4JU4BW/2+6xQzXkoK6Ug30FzFDRpt42mTXh1SH9o=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/peertube-theme-background-red";
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/node_modules
+    cp -r $PWD $out/lib/node_modules/${finalAttrs.pname}
+
+    runHook postInstall
+  '';
+
+  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+
+  meta = {
+    description = "Ugly and painful example theme";
+    homepage = "https://framagit.org/framasoft/peertube/official-plugins/tree/master/peertube-theme-background-red";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/peertube-theme-dark/package.nix
+++ b/pkgs/by-name/peertube-theme-dark/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitLab,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "peertube-theme-dark";
+  version = "2.5.0";
+
+  src = fetchFromGitLab {
+    domain = "framagit.org";
+    owner = "framasoft";
+    repo = "peertube/official-plugins";
+    rev = "631f784774dc5f9686bf06033d6ceb0d596ef987";
+    hash = "sha256-VvtqF9et2uLxj8kGIjdaHQjxQbeNIAwz+NTPME/6Wpk=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/peertube-theme-dark";
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/node_modules
+    cp -r $PWD $out/lib/node_modules/${finalAttrs.pname}
+
+    runHook postInstall
+  '';
+
+  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+
+  meta = {
+    description = "PeerTube dark theme";
+    homepage = "https://framagit.org/framasoft/peertube/official-plugins/tree/master/peertube-theme-dark";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/peertube-theme-framasoft/package.nix
+++ b/pkgs/by-name/peertube-theme-framasoft/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitLab,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "peertube-theme-framasoft";
+  version = "0.0.1";
+
+  src = fetchFromGitLab {
+    domain = "framagit.org";
+    owner = "framasoft";
+    repo = "peertube/official-plugins";
+    rev = "e85121a9d68c9337a60198ed67e68ef520d6b50b";
+    hash = "sha256-uLw4XK1I1YM/hI5gbYKJ3flyZ1GOVLarvUNa57W5bBs=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/peertube-theme-framasoft";
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/node_modules
+    cp -r $PWD $out/lib/node_modules/${finalAttrs.pname}
+
+    runHook postInstall
+  '';
+
+  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+
+  meta = {
+    description = "PeerTube Framasoft theme";
+    homepage = "https://framagit.org/framasoft/peertube/official-plugins/tree/master/peertube-theme-framasoft";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/projects/PeerTube/default.nix
+++ b/projects/PeerTube/default.nix
@@ -1,0 +1,19 @@
+{
+  pkgs,
+  lib,
+  sources,
+} @ args: {
+  packages = {
+    inherit (pkgs) peertube-plugin-akismet peertube-plugin-auth-ldap peertube-plugin-auth-openid-connect peertube-plugin-auth-saml2 peertube-plugin-auto-block-videos peertube-plugin-auto-mute peertube-plugin-hello-world peertube-plugin-logo-framasoft peertube-plugin-matomo peertube-plugin-privacy-remover peertube-plugin-transcoding-custom-quality peertube-plugin-transcoding-profile-debug peertube-plugin-video-annotation peertube-theme-background-red peertube-theme-dark peertube-theme-framasoft peertube-plugin-livechat;
+  };
+  nixos = {
+    modules.services.peertube.plugins = ./module.nix;
+    tests.peertube-plugins = import ./test.nix args;
+    examples = {
+      base = {
+        description = "Basic configuration, mainly used for testing purposes.";
+        path = ./example.nix;
+      };
+    };
+  };
+}

--- a/projects/PeerTube/example.nix
+++ b/projects/PeerTube/example.nix
@@ -1,0 +1,96 @@
+{
+  config,
+  pkgs,
+  ...
+}: let
+  storageBase = "/var/lib/peertube";
+  storageDir = subdir: "${storageBase}/${subdir}/";
+in {
+  environment = {
+    # Sets the initial password of the root user to a fixed value. Make sure to change the password afterwards!
+    etc."peertube-envvars".text = ''
+      PT_INITIAL_ROOT_PASSWORD=changeme
+    '';
+  };
+
+  services.peertube = {
+    enable = true;
+
+    # The system user & their group under which peertube will run
+    user = "peertube";
+    group = "peertube";
+
+    # Do *NOT* use this in production, follow the docs and properly generate a secret here! i.e. using the output of:
+    # openssl rand -hex 32
+    # https://docs.joinpeertube.org/install/any-os#peertube-configuration
+    secrets.secretsFile = pkgs.writeText "secrets.txt" "secrets";
+
+    # Configure locally-running instances of redis server & database.
+    database.createLocally = true;
+    redis.createLocally = true;
+
+    # Where we're running
+    localDomain = "localhost";
+    listenWeb = 9000;
+
+    # Example settings, adjust as desired
+    settings = {
+      listen = {
+        hostname = "0.0.0.0";
+      };
+      log = {
+        level = "debug";
+      };
+      storage = {
+        tmp = storageDir "tmp";
+        logs = storageDir "logs";
+        cache = storageDir "cache";
+        plugins = storageDir "plugins";
+      };
+    };
+
+    plugins = {
+      enable = true;
+
+      # The plugins you wish to use.
+      plugins = with pkgs; [
+        peertube-plugin-akismet
+        peertube-plugin-auth-ldap
+        peertube-plugin-auth-openid-connect
+        peertube-plugin-auth-saml2
+        peertube-plugin-auto-block-videos
+        peertube-plugin-auto-mute
+        peertube-plugin-hello-world
+        peertube-plugin-logo-framasoft
+        peertube-plugin-matomo
+        peertube-plugin-privacy-remover
+        peertube-plugin-transcoding-custom-quality
+        peertube-plugin-transcoding-profile-debug
+        peertube-plugin-video-annotation
+        peertube-theme-background-red
+        peertube-theme-dark
+        peertube-theme-framasoft
+
+        peertube-plugin-livechat
+      ];
+    };
+
+    # For initial password
+    serviceEnvironmentFile = "/etc/peertube-envvars";
+  };
+
+  systemd.tmpfiles.settings = let
+    dirArgs = {
+      mode = "0700";
+      inherit (config.services.peertube) user group;
+    };
+  in {
+    "99-peertube-plugins-test-setup" = {
+      "${storageBase}".d = dirArgs;
+      "${storageDir "tmp"}".d = dirArgs;
+      "${storageDir "logs"}".d = dirArgs;
+      "${storageDir "cache"}".d = dirArgs;
+      "${storageDir "plugins"}".d = dirArgs;
+    };
+  };
+}

--- a/projects/PeerTube/module.nix
+++ b/projects/PeerTube/module.nix
@@ -1,0 +1,232 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  peerCfg = config.services.peertube;
+  cfg = peerCfg.plugins;
+in {
+  options.services.peertube.plugins = {
+    enable = lib.mkEnableOption ''
+      declarative plugin management for PeerTube
+    '';
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.peertube;
+      defaultText = lib.literalExpression "pkgs.peertube";
+      description = "Base PeerTube package to use when using declarative plugin management. This overrides `services.peertube.package`.";
+    };
+
+    plugins = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [];
+      example = lib.literalExpression ''
+        with pkgs; [
+          peertube-plugin-hello-world
+        ]
+      '';
+      description = ''
+        List of packages with peertube plugins that should be added.
+      '';
+    };
+  };
+
+  config = let
+    # Based on let block of Nixpkgs' peertube module
+    env = {
+      NODE_CONFIG_DIR = "/var/lib/peertube/config";
+      NODE_ENV = "production";
+      NODE_EXTRA_CA_CERTS = "/etc/ssl/certs/ca-certificates.crt";
+      NPM_CONFIG_CACHE = "/var/cache/peertube/.npm";
+      NPM_CONFIG_PREFIX = peerCfg.package;
+      HOME = peerCfg.package;
+    };
+
+    systemCallsList = [
+      "@cpu-emulation"
+      "@debug"
+      "@keyring"
+      "@ipc"
+      "@memlock"
+      "@mount"
+      "@obsolete"
+      "@privileged"
+      "@setuid"
+    ];
+
+    cfgService = {
+      # Proc filesystem
+      ProcSubset = "pid";
+      ProtectProc = "invisible";
+      # Access write directories
+      UMask = "0027";
+      # Capabilities
+      CapabilityBoundingSet = "";
+      # Security
+      NoNewPrivileges = true;
+      # Sandboxing
+      ProtectSystem = "strict";
+      ProtectHome = true;
+      PrivateTmp = true;
+      PrivateDevices = true;
+      PrivateUsers = true;
+      ProtectClock = true;
+      ProtectHostname = true;
+      ProtectKernelLogs = true;
+      ProtectKernelModules = true;
+      ProtectKernelTunables = true;
+      ProtectControlGroups = true;
+      RestrictNamespaces = true;
+      LockPersonality = true;
+      RestrictRealtime = true;
+      RestrictSUIDSGID = true;
+      RemoveIPC = true;
+      PrivateMounts = true;
+      # System Call Filtering
+      SystemCallArchitectures = "native";
+    };
+    # End Nixpkgs' let block
+
+    mkPluginService = configured:
+      {
+        description = "Management of declaratively specified PeerTube plugins${
+          lib.optionalString (!configured) " (initial)"
+        }";
+
+        wantedBy = ["multi-user.target"];
+
+        environment = env;
+
+        script = let
+          nixosPluginsJson = pkgs.writeText "nixos-plugins.json" (
+            builtins.toJSON (map (plugin: plugin.pname) cfg.plugins)
+          );
+        in
+          lib.getExe (
+            pkgs.writeShellApplication {
+              name = "peertube-plugins${lib.optionalString (!configured) "-initial"}-script";
+
+              runtimeInputs = with pkgs;
+                [
+                  jq
+                  nodejs
+                ]
+                ++ lib.optionals (!configured) [
+                  iproute2
+                ];
+
+              text = ''
+                set -euo pipefail
+
+                ${lib.optionalString (!configured) ''
+                  # Ensure peertube is done configuring & running (HACK)
+                  while ! ss -H -t -l -n sport = :${toString peerCfg.listenWeb} | grep -q "^LISTEN.*:${toString peerCfg.listenWeb}"; do
+                    sleep 1
+                  done
+                ''}
+
+                if [ -e "${peerCfg.settings.storage.plugins}/package.json" ]; then
+                  packages_hash_pre="$(sha256sum ${peerCfg.settings.storage.plugins}/package.json)"
+                else
+                  packages_hash_pre=""
+                fi
+
+                # To install packages offline from their caches, configure NPM to behave
+                npmfun="$(mktemp -d)"
+                export NPM_CONFIG_USERCONFIG="$npmfun"/.npmrc
+                npm config set offline true
+                npm config set progress false
+
+                ${lib.concatMapStrings (plugin: ''
+                    npm config set cache ${plugin.npmDeps or "/no-npm-deps"}
+                    echo "Running installer for ${plugin}/lib/node_modules/${plugin.pname}"
+                    node ~/dist/scripts/plugin/install.js -p ${plugin}/lib/node_modules/${plugin.pname}
+                  '')
+                  cfg.plugins}
+
+                rm -r "$npmfun"
+
+                if [ -e "${peerCfg.settings.storage.plugins}/nixos-plugins.json" ]; then
+                  for plugin in $(jq --slurp --raw-output '.[0] - .[1] | .[]' ${peerCfg.settings.storage.plugins}/nixos-plugins.json ${nixosPluginsJson}); do
+                    # ignore trailing newline
+                    [ -z "$plugin" ] && continue
+                    echo "Removing plugin $plugin (even on success, a (wrong) error message is returned)"
+                    node ~/dist/scripts/plugin/uninstall.js -n "$plugin"
+                  done
+                fi
+
+                ln -sf ${nixosPluginsJson} ${peerCfg.settings.storage.plugins}/nixos-plugins.json
+
+                packages_hash_post="$(sha256sum ${peerCfg.settings.storage.plugins}/package.json)"
+                [ "$packages_hash_pre" = "$packages_hash_post" ] || touch ${peerCfg.settings.storage.plugins}/.restart
+              '';
+            }
+          );
+
+        serviceConfig =
+          {
+            ExecCondition =
+              if configured
+              then "${pkgs.coreutils}/bin/test -f ${peerCfg.settings.storage.plugins}/nixos-plugins.json"
+              else "${pkgs.coreutils}/bin/test ! -f ${peerCfg.settings.storage.plugins}/nixos-plugins.json";
+
+            ExecStartPost = "+${pkgs.writeShellScript "peertube-plugins-post" ''
+              set -euo pipefail
+              if [ -e "${peerCfg.settings.storage.plugins}/.restart" ]; then
+                systemctl restart --no-block peertube
+                rm ${peerCfg.settings.storage.plugins}/.restart
+              fi
+            ''}";
+
+            Type = "oneshot";
+            WorkingDirectory = peerCfg.package;
+            ReadWritePaths =
+              [
+                "/var/lib/peertube" # NPM stuff
+              ]
+              ++ peerCfg.dataDirs;
+
+            # User and group
+            User = peerCfg.user;
+            Group = peerCfg.group;
+
+            # Sandboxing
+            RestrictAddressFamilies = [];
+
+            # System Call Filtering
+            SystemCallFilter = [
+              ("~" + lib.concatStringsSep " " systemCallsList)
+              "pipe"
+              "pipe2"
+            ];
+          }
+          // cfgService;
+      }
+      // (
+        if configured
+        then {before = ["peertube.service"];}
+        else {after = ["peertube.service"];}
+      );
+  in
+    lib.mkIf (peerCfg.enable && cfg.enable) {
+      services.peertube.package = cfg.package.overrideAttrs (oa: {
+        # yarn can't handle npm caches, and we can't build npm packages with our yarn tooling
+        # Working on getting declarative plugin management into upstream to avoid this: https://github.com/Chocobozzz/PeerTube/issues/6428
+        postPatch =
+          (oa.postPatch or "")
+          + ''
+            substituteInPlace server/core/lib/plugins/yarn.ts \
+              --replace-fail 'yarn ''${command}' 'npm --offline ''${command}'
+          '';
+      });
+
+      systemd.services = {
+        peertube-plugins-initial = mkPluginService false;
+        peertube-plugins = mkPluginService true;
+      };
+    };
+
+  meta.maintainers = [];
+}

--- a/projects/PeerTube/test.nix
+++ b/projects/PeerTube/test.nix
@@ -1,0 +1,60 @@
+{
+  sources,
+  pkgs,
+  lib,
+  ...
+}: {
+  name = "peertube-plugins";
+
+  nodes = {
+    server = {config, ...}: {
+      imports = [
+        sources.modules.default
+        sources.modules."services.peertube.plugins"
+        sources.examples."PeerTube/base"
+      ];
+    };
+  };
+
+  testScript = {nodes, ...}: let
+    url = "http://${nodes.server.services.peertube.localDomain}:${toString nodes.server.services.peertube.listenWeb}";
+  in
+    ''
+      start_all()
+
+      with subtest("peertube works"):
+          server.wait_for_unit("peertube.service")
+          server.wait_for_console_text("Web server: ${url}")
+
+      # Eventually peertube-plugins-initial kicks in, sets up the initial state
+    ''
+    + (lib.strings.concatMapStringsSep "\n" (plugin: ''
+        with subtest("peertube plugin ${plugin.pname} installs"):
+            server.wait_for_console_text("Successful installation of plugin ${plugin}")
+      '')
+      nodes.server.services.peertube.plugins.plugins)
+    + ''
+
+      # peertube-plugins-initial triggers a restart and causes regular peertube-plugins to fire instead
+      # Plugins should all still come up
+    ''
+    + (lib.strings.concatMapStringsSep "\n" (plugin: ''
+        with subtest("peertube plugin ${plugin.pname} registers"):
+            server.wait_for_console_text("Registering plugin or theme ${plugin.pname}")
+      '')
+      nodes.server.services.peertube.plugins.plugins)
+    + ''
+
+      # Now wait until we can get through to the instance and trigger some initial loading
+      server.wait_until_succeeds("curl -Ls ${url}")
+
+      # And the plugins should now be loaded
+      # The order of the checks here is based on when different plugins emit their log messages
+
+      with subtest("peertube plugin ${pkgs.peertube-plugin-livechat.pname} works"):
+          server.wait_for_console_text("loading peertube admins and moderators")
+
+      with subtest("peertube plugin ${pkgs.peertube-plugin-hello-world.pname} works"):
+          server.wait_for_console_text("hello world PeerTube admin")
+    '';
+}


### PR DESCRIPTION
For #8:

- Everything in [framasoft/peertube/official-plugins](https://framagit.org/framasoft/peertube/official-plugins) packaged
- [livechat plugin](https://github.com/JohnXLivingston/peertube-plugin-livechat) packaged
- `services.peertube.plugins` module added, plugins can be installed into peertube offline fully from the cache
- `nixosTests.PeerTube.peertube-plugins` test added

What's still missing from #8 is the [vosk-based transcription plugin](https://gitlab.com/apps_education/peertube/plugin-transcription). We've had some issues with packaging that, so we're submitting the whole suite of official plugins instead for now.

The Livechat package is an unholy mess, due to some issues with how the software expects to build itself. I've tried to add comments to explain why the different derivations are needed.

For getting the plugin installation to work, we're patching the peertube package to use `npm --offline` instead of `yarn`. This is because Yarn cannot handle the NPM cache format the packages are using, and (from my understanding) we can't build the packages via Yarn due to builder limitations (they all use `package.lock`, our Yarn builder expects `yarn.lock`). @Infinidoge is working on a separate patch to upstream for getting declarative plugin management starting, upon which we can hopefully build a better solution for this.