### PR TITLE
workflows/update: bump action versions

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v11
-      - uses: DeterminateSystems/update-flake-lock@v21
+      - uses: DeterminateSystems/nix-installer-action@v12
+      - uses: DeterminateSystems/update-flake-lock@v23
         with:
           token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
           pr-title: "flake: Update flake.lock"


### PR DESCRIPTION
https://github.com/ngi-nix/ngipkgs/actions/runs/9832406996 is failing.