### PR TITLE
atomic-server: refactor to rebuild from github source

### DIFF
--- a/pkgs/by-name/atomic-server/package.nix
+++ b/pkgs/by-name/atomic-server/package.nix
@@ -1,7 +1,8 @@
 {
   lib,
-  fetchCrate,
+  fetchFromGitHub,
   rustPlatform,
+  atomic-browser,
 }: let
   inherit
     (lib)
@@ -12,12 +13,22 @@ in
     pname = "atomic-server";
     version = "0.37.0";
 
-    src = fetchCrate {
-      inherit pname version;
-      hash = "sha256-/OKYac0HA9EWDQ5qNyMPITN5iUdLM9SAVmOm6PVIFOk=";
+    src = fetchFromGitHub {
+      owner = "atomicdata-dev";
+      repo = pname;
+      rev = "v${version}";
+      hash = "sha256-+Lk2MvkTj+B+G6cNbWAbPrN5ECiyMJ4HSiiLzBLd74g=";
     };
 
-    cargoHash = "sha256-LwSyK/7EEoTf1x7KGtebPxYTqH3SCjXGONNMxcmdEv0=";
+    cargoHash = "sha256-cSv1XnuzL5PxVOTAUiyiQsMHSRUMaFDkW2/4Bt75G9o=";
+
+    # server/assets_tmp is the directory atomic-server's build will check for
+    # compiled frontend assets to decide whether to rebuild or not
+    # https://github.com/atomicdata-dev/atomic-server/blob/ba3c5959867a563d4da00bb23fd13e45e69dc5d7/server/build.rs#L22-L37
+    postUnpack = ''
+      mkdir -p source/server/assets_tmp
+      cp -r ${atomic-browser}/* source/server/assets_tmp
+    '';
 
     doCheck = false; # TODO(jl): broken upstream
 


### PR DESCRIPTION
This refactor builds atomic-server using the separately packaged
atomic-browser and then the github source. Not only is this more
reflective of the real build process used, but it is helpful when trying
to debug atomic-server by building a fork with additional logging, which
we did while working on https://github.com/ngi-nix/ngipkgs/pull/220

Previously we were building atomic-server from the published crate,
which is usually "from source". But in this case that meant only the
rust source, and separately built web assets were packaged into the
crate. This can be verified by running
`curl -L 'https://crates.io/api/v1/crates/atomic-server/0.37.0/download' | tar -tv`
and checking for the `assets_tmp` directory.

Part of https://github.com/ngi-nix/ngipkgs/issues/15
