### PR TITLE
makemake: Switch to latest buildbot and use GH app

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -11,13 +11,13 @@
       "locked": {
         "lastModified": 1725761443,
         "narHash": "sha256-RX3qnLYaFxlvOAYL6WsM5nGjNnMZQIgKIpIxigPmiAU=",
-        "owner": "Mic92",
+        "owner": "nix-community",
         "repo": "buildbot-nix",
         "rev": "ade5f42d7e56c8298d729aa0e804c8062e7a77ac",
         "type": "github"
       },
       "original": {
-        "owner": "Mic92",
+        "owner": "nix-community",
         "repo": "buildbot-nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
   inputs.sops-nix.inputs.nixpkgs.follows = "nixpkgs";
   inputs.sops-nix.url = "github:Mic92/sops-nix";
   inputs.buildbot-nix.inputs.nixpkgs.follows = "nixpkgs";
-  inputs.buildbot-nix.url = "github:Mic92/buildbot-nix";
+  inputs.buildbot-nix.url = "github:nix-community/buildbot-nix";
 
   # See <https://github.com/ngi-nix/ngipkgs/issues/24> for plans to support Darwin.
   inputs.systems.url = "github:nix-systems/default-linux";

--- a/infra/makemake/buildbot.nix
+++ b/infra/makemake/buildbot.nix
@@ -16,8 +16,11 @@ in {
       github = {
         oauthId = "Ov23linNGNKJg5zddrwX";
         oauthSecretFile = secret "github/oauth";
-        authType.legacy.tokenFile = secret "github/pat";
         webhookSecretFile = secret "github/webhook";
+        authType.app = {
+          id = 994441;
+          secretKeyFile = secret "buildbot.pem";
+        };
       };
       useHTTPS = true;
       cachix = {
@@ -56,6 +59,10 @@ in {
     // {
       ${sopsPrefix "workers"} = {
         sopsFile = ./secrets/buildbot-workers.json;
+        format = "binary";
+      };
+      ${sopsPrefix "buildbot.pem"} = {
+        sopsFile = ./secrets/buildbot.pem;
         format = "binary";
       };
     };

--- a/infra/makemake/secrets/buildbot.pem
+++ b/infra/makemake/secrets/buildbot.pem
@@ -1,0 +1,32 @@
+{
+        "data": "ENC[AES256_GCM,data:qPjsauN0xDZAqwKAPzsfvyejf7cHFzUFfr0hU5Zu8qimvUKE6xyqv8nJurcHVD3lW1xZeQWYN7qxYtOd/FcY07VP/uMzF9QN0KnqUljZK4OLB66j3evcAcr/JdexYfHYnuHtUQS5Ef9t0WTB//b0I53mPQw2b2J0LVPDMbvlXgItGC4IsB+TD3H68VMSO+8F8ieZBmyzkozEwptO/kdZrDgHfEzApi1rDq4DNOR0Hm+NzB3ARkOVVZDWKgV82x8GTC+Yuswi4NlIhj45NAE3KITzeiZeJtOzKyKH6skMjImsdKuVyRCUwvrN7hDkRzPzZeeKs9tXGtL6AYnb+iihv2K0pXqB1Co/sD3Uk7i4h7VuLq6OYCPxzUKD3vcWRBS4s3+2UtIJABPcar8CRnyLyokEUPauF9l55RISkCB4TSLjCzHwHxYM81L9P1u8zjKTSTnwlCtP0UwWIfojJPqbG1LiSnQ7HbkSwl5+lO49NIddKmrDaM+I/BHQxCI79OwT/x6uniqpU0ofPq69h8ZdqOaNoQLo+EVfa/IelLAdl0tH27X6F+B3SNsJ1Q5dsRO43qaLL9cCTqu0YbKiEnhjdClVUWSHaUdtOqBPNNdE659IrepdCslrfZjj7aDzsbNf823ESOW4yu811xI8wmiCNmSMWPHosiosQkw9LjToDknNj6UCS5XYg0fqjLO9v3KO3me9ilbr+1t0vIhaA6bl3a3/dbZeQgj1Y5dLJSJGRY1PRHl4bIcsGuDOfi0G1WuTkwPT1soBF8oJmGZKKaJqYGSrhCmrS+5thxTLLxf5V3z60N5qnWJ59iqEfXe05UwcR5hDUqNgNbFFYozQTqd2mu0eUrY4sNAVYtHcraVLFfcYNgVXiZhNeyIbHj5IwWcsI+QLe6C8tdUX1t01GeUgpbsXNAWuCKcRjPTG5PXvpwgaB7YvpVHadDYP7kewXDlB2yimjr8ebsm9QsFiVbA9rNIIzIcv0skoXdKeJHTS37KrQhCA5XUSubacTzL6/xbunW0fOyIEqreTHsNgY1gebWQi5ySbEsJ3Njxm5ELv1Zfc3ER30T64PwhRVCrz3gjhhSjRkgm/4Ptb0ccByXZs4K1qlmt9qRVwF3d0KyNELFSIFJzJrQ2ZxvFYS/3NkaYS69dvvPSOy7Vu+q/Ptixfmt7ayQLJNOWAeHAMBIzhn+LtS38Tsy7AYn+RMQnwP2Qr//19Tjf2Nz8RTbjQd4l5+0sslXOmSVbry56eA29bc8hy7rLcqvoRSXVL3IY0F3rSw4lJ2i1DeAdR8wc9rwDLXVG0uhbGYvWHURdnNq7hjDYKs6ZgdUuvg0auU6mzHK2n8XZpYmExkx4CS2HUvjAK7k6zLYLeNJm2Hd+3ZdegYTO/2QKn+5DL6A8XVpXn01qKGMZaw/g98x2Ezei89sr7UdUY2LjVeG8c6RhgdPqp5i1qImNlpxR7DujFjemxAOYkUpsprNPiJER3TfjDyVXpTYm+Z1bsElYLKwMcEyZkmSHcv109STu87S7niLR7EZ8kZcQdKwtf3WG2hsFiiDZLBrTKAqdkM0BH0MR9RlrQZp8fZcMsmVFFXL92xTEJONytyPxKZbV1PfyW8MbO7tnSQDFCgwd0ucC54chhubFECDj6c1ejvfpQdTT0O4va81GHXuYnM2VrzGZm6GF7jXadohTenOX4T4jd1L8AFlw5LVb9ZDGHHiVD2s70JY2L76UK0fyrgZDdvbK7HAJ76gk3A+jY5ywvf83JTkrJdPFHwOdMyfa7V8mKgqXA3IGMRZfjJLGP6z3Sc1ymQRJ9m0MqjVOavHA/jGCJxGi2kewMkE2ur8TKE8YQr/KcO1X0RAyQNhYBRe0GMFLuSMG+0n5JnXQOWsT/7aALQyQTw40q3FzIg/LF5pwMxEavnCzY0HtdSeu9BLEDQRRMkxhzups+MLSxPVVsbRKQgkrrcMopjvFO2I4HKhrkr3YLSOr+Rp9BLg4yl/K/5C033Djj1LcoFiG+22xfuTrGoN+wZ6qZfReDq1PUpvALwZ6gAly1lYOy2ldYIkgNM6lWJGOxoTdvoASrHn/IP7ALszfzOAdnJSE4es/f17Lta3wrPtc8A+l1jHjoB3IPgN3z/Cn41lmGwJqwVZGa6s+ZKNIvT+zilK5CUaPqS2hTb/c8mbC1WViOdupzt262O26x4SqrhPNnzjCcoLggBUM1fi9BLLqAi9AMKF8re5VdTFRissgO6zU=,iv:N77984WrbMqm3mkQL0RZ3jqU48G11C2HECiGSLvCRqY=,tag:bIOdVgME76plVA7NmcIvxg==,type:str]",
+        "sops": {
+                "kms": null,
+                "gcp_kms": null,
+                "azure_kv": null,
+                "hc_vault": null,
+                "age": [
+                        {
+                                "recipient": "age187upwqdte7t0hkyec22jhac357m9y4fkcdvpg9sj5q9mekjupfnqg9a077",
+                                "enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUaHk4TXFFVjhaU0ZUZCtn\nUjJNWlBEN243Q3ROd3g4emNpTTdUNGl1dEd3CmNLdTZYT0xkWXFwcVlhZ00wR1NC\nZ0xXOTB2UEVlNlBrUDgvLy94NW5yamsKLS0tIGwrdjFtTEdzbVBFKzhjSXo0WDd1\ncVRnRHdHZHkxV2RMK2tvVmVzbG9IeGsKbbN6SeRGmtUakj2XoNrmz+RuIFoHyH9f\nFxiIxkeED/YrfdmlG29OroiEylo8PP59TDda8Ghh0mPg8gcG9Xswfw==\n-----END AGE ENCRYPTED FILE-----\n"
+                        },
+                        {
+                                "recipient": "age10ldm537vh6np7hvgc084c30njmwgam2p22wysapyj8ya86rycyhsf8gmcn",
+                                "enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZbnBBampJeTF3QjFGOVNB\nK3k1d3VZVENrTVZlUFNMRkUybWd6dEQ3ZEFFCmV0bEVtaWNQaWNyOCtmcStYdTNs\nb1dvV1NZY3FueDVJR2loT2o4ZU02ZEEKLS0tIHpYZTcxMjA0Um4zbHpJK2hkR3Jn\nZFdmcEF4SUxWVE4xYTAxVmI5WFh6aEkKfcHGYZdCPYxNtDqPyBdL4Bo8AwPD8i9r\n9AGh8JtzWHF/Q1YiG37ZOuCssDtWiUM5I2ePDX3l+L9xcMBXODZrQA==\n-----END AGE ENCRYPTED FILE-----\n"
+                        },
+                        {
+                                "recipient": "age1c0g6s6daxy79dlm9uqczwlkh0hvjpghw5h8zzljc3vs275rvvqus30hv9l",
+                                "enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxaEE4SGY4blNNM2lvMnlz\naFZlOTc1ZmVTbmtBMUJaN3hJWWt0bC9sSEh3CjBQSlNmNzdxRzFNeWMyMGRvcWJN\nRVZQanIzbWc2L1h1aFFUd1FwMnJLbWMKLS0tIFpPZnF2ZUo1UmM4SkV6MTYxZFpz\ndms2bmc3M3BoaURRT0hJRkdlL05yRXcKhs0Q96hE5HG50BHDy2d5dTvYolf+3FlM\nPa9Lp5yU6TDYMB0NgW3UiP7UmWjF4VKN6jolrIyDy/7A2e3WwFwHdA==\n-----END AGE ENCRYPTED FILE-----\n"
+                        },
+                        {
+                                "recipient": "age1ewus3xraznqv6xc2ptua2qjqrjyhfd8uugu08wjduushj3uhgqwsqd6vkk",
+                                "enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyYm9wRmtWS1djdHZCSDdo\naGNkSC9Qc2dhRFhGWjc2VERycG5MNXBkV0dVCkpmR1NVTGVmTWU1cmVYZlFXbk9q\nNUVhRi9pblBKZkVvaTFoMnJ4OHMxR3MKLS0tIFJSTFk0dFNrRlpaMmkyK2R5OTg2\nZ1c4aGsvUkR6dW1lMlEyb0ljMnUwRVkK1QHzoi8IKLHSHrqgkjLmD2N8v0Yb0eIX\nDMuU8yVS4N6bclgnKRksxS7N3YV78Qv6pgQV0kR1CmjJXK5r7HyujA==\n-----END AGE ENCRYPTED FILE-----\n"
+                        }
+                ],
+                "lastmodified": "2024-09-11T13:30:28Z",
+                "mac": "ENC[AES256_GCM,data:bDNvYmFOaCMraZrDxHBpZAJaBdpFqDClFbU9yrpxTbN7Foihvo4QRibCeyoPnI+23/F5ONA2OBVceT9z3yrdTTRiKoApRg3XV5bAR1c1X4Y0Mkayn/V7RHECM0st6j77pFcdX/Hp0UHqVdSY34N+EjY/UdNHt4i+n/I8+P3xAi4=,iv:umYoW6gzgDqMO8iwkhu8SukU4rozAkaEnSHn0WKE1wM=,tag:rx/WxUWYf+BDcGTYde/UYg==,type:str]",
+                "pgp": null,
+                "unencrypted_suffix": "_unencrypted",
+                "version": "3.8.1"
+        }
+}


### PR DESCRIPTION
This came up while working on #347. It switches the flake to follow `nix-community/buildbot-nix` instead of `Mic92/buildbot-nix` (it's a redirect either way) as well as switches to the new GitHub app authentication for Buildbot instead of legacy tokens.