### PR TITLE
projects: sanitize

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,10 +42,7 @@
     inherit
       (lib)
       concatMapAttrs
-      mapAttrs'
-      foldr
       recursiveUpdate
-      nameValuePair
       filterAttrs
       ;
 
@@ -53,7 +50,6 @@
       (lib')
       flattenAttrsDot
       flattenAttrsSlash
-      mapAttrByPath
       ;
 
     # Imported from Nixpkgs
@@ -79,12 +75,12 @@
       sources = {inherit inputs;};
     };
 
-    rawExamples = flattenAttrsSlash (mapAttrs (_: v: mapAttrs (_: v: v.path) v) (
-      mapAttrByPath ["nixos" "examples"] {} rawNgiProjects
-    ));
+    rawExamples = flattenAttrsSlash (
+      mapAttrs (_: project: mapAttrs (_: example: example.path) project.nixos.examples) rawNgiProjects
+    );
 
     rawNixosModules = flattenAttrsDot (lib.foldl recursiveUpdate {} (attrValues (
-      mapAttrByPath ["nixos" "modules"] {} rawNgiProjects
+      mapAttrs (_: project: project.nixos.modules) rawNgiProjects
     )));
 
     nixosModules =
@@ -180,7 +176,7 @@
       };
     in rec {
       legacyPackages = {
-        nixosTests = mapAttrByPath ["nixos" "tests"] {} ngiProjects;
+        nixosTests = mapAttrs (_: project: project.nixos.tests) ngiProjects;
       };
 
       packages =
@@ -218,8 +214,8 @@
           examples;
 
         checksForProject = projectName: project:
-          (checksForNixosTests projectName (project.nixos.tests or {}))
-          // (checksForNixosExamples projectName (project.nixos.examples or {}));
+          (checksForNixosTests projectName project.nixos.tests)
+          // (checksForNixosExamples projectName project.nixos.examples);
 
         checksForPackageDerivation = packageName: package: {"packages/${packageName}" = package;};
 

--- a/flake.nix
+++ b/flake.nix
@@ -89,7 +89,7 @@
         # This is so that `ngipkgs` can be used alongside `nixpkgs` in a configuration.
         default.nixpkgs.overlays = [overlay];
       }
-      // (filterAttrs (_: v: v != null) rawNixosModules);
+      // rawNixosModules;
 
     # Next, extend the modules with modules that are additionally required in the tests and examples.
     extendedNixosModules =

--- a/lib.nix
+++ b/lib.nix
@@ -2,14 +2,12 @@
 {lib}: let
   inherit
     (builtins)
-    mapAttrs
     isAttrs
     concatStringsSep
     ;
 
   inherit
     (lib)
-    attrByPath
     concatMapAttrs
     ;
 in rec {
@@ -46,6 +44,4 @@ in rec {
 
   flattenAttrsSlash = flattenAttrs "/" [];
   flattenAttrsDot = flattenAttrs "." [];
-
-  mapAttrByPath = attrPath: default: mapAttrs (_: attrByPath attrPath default);
 }

--- a/overview/default.nix
+++ b/overview/default.nix
@@ -28,7 +28,6 @@
     hasPrefix
     mapAttrsToList
     optionalString
-    splitString
     ;
 
   inherit
@@ -52,13 +51,13 @@
 
   pick = {
     options = project: let
-      spec = attrNames (flattenAttrsDot (project.nixos.modules or {}));
+      spec = attrNames (flattenAttrsDot project.nixos.modules);
     in
       filter
       (option: any ((flip hasPrefix) (dottedLoc option)) spec)
       (attrValues options);
-    examples = project: attrValues (project.nixos.examples or {});
-    packages = project: attrValues (project.packages or {});
+    examples = project: attrValues project.nixos.examples;
+    packages = project: attrValues project.packages;
   };
 
   render = {

--- a/projects/Flarum/default.nix
+++ b/projects/Flarum/default.nix
@@ -1,4 +1,3 @@
 {pkgs, ...}: {
   packages = {inherit (pkgs) flarum;};
-  nixos.modules.services.flarum = null;
 }

--- a/projects/PeerTube/default.nix
+++ b/projects/PeerTube/default.nix
@@ -7,7 +7,7 @@
     inherit (pkgs) peertube-plugin-akismet peertube-plugin-auth-ldap peertube-plugin-auth-openid-connect peertube-plugin-auth-saml2 peertube-plugin-auto-block-videos peertube-plugin-auto-mute peertube-plugin-hello-world peertube-plugin-logo-framasoft peertube-plugin-matomo peertube-plugin-privacy-remover peertube-plugin-transcoding-custom-quality peertube-plugin-transcoding-profile-debug peertube-plugin-video-annotation peertube-theme-background-red peertube-theme-dark peertube-theme-framasoft peertube-plugin-livechat;
   };
   nixos = {
-    modules.services.peertube.plugins = ./module.nix;
+    modules.services.peertube = ./module.nix;
     tests.peertube-plugins = import ./test.nix args;
     examples = {
       base = {

--- a/projects/PeerTube/test.nix
+++ b/projects/PeerTube/test.nix
@@ -10,7 +10,7 @@
     server = {config, ...}: {
       imports = [
         sources.modules.default
-        sources.modules."services.peertube.plugins"
+        sources.modules."services.peertube"
         sources.examples."PeerTube/base"
       ];
     };

--- a/projects/Rosenpass/default.nix
+++ b/projects/Rosenpass/default.nix
@@ -5,7 +5,6 @@
 } @ args: {
   packages = {inherit (pkgs) rosenpass rosenpass-tools;};
   nixos = {
-    modules.services.rosenpass = null;
     tests.rosenpass = import ./tests args;
   };
 }

--- a/projects/default.nix
+++ b/projects/default.nix
@@ -13,9 +13,7 @@
   inherit
     (lib.attrsets)
     concatMapAttrs
-    filterAttrs
     mapAttrs
-    recursiveUpdate
     ;
 
   baseDirectory = ./.;
@@ -46,10 +44,12 @@
   in
     pkgs.nixosTest (debugging // test);
 
-  hydrate = project:
-    recursiveUpdate
-    project
-    {nixos.tests = mapAttrs (_: nixosTest) project.nixos.tests or {};};
+  hydrate = project: {
+    packages = project.packages or {};
+    nixos.modules = project.nixos.modules or {};
+    nixos.examples = project.nixos.examples or {};
+    nixos.tests = mapAttrs (_: nixosTest) project.nixos.tests or {};
+  };
 in
   mapAttrs
   (


### PR DESCRIPTION
This PR sanitizes the output of `import ./projects { ... }`, so that one doesn't need `or {}` or even auxiliary functions to extract modules/examples/tests from the output.