### PR TITLE
refactor: move test helpers into flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -79,9 +79,11 @@
       mapAttrs (_: project: mapAttrs (_: example: example.path) project.nixos.examples) rawNgiProjects
     );
 
-    rawNixosModules = flattenAttrsDot (lib.foldl recursiveUpdate {} (attrValues (
-      mapAttrs (_: project: project.nixos.modules) rawNgiProjects
-    )));
+    rawNixosModules = flattenAttrsDot (
+      lib.foldl recursiveUpdate {} (attrValues (
+        mapAttrs (_: project: project.nixos.modules) rawNgiProjects
+      ))
+    );
 
     nixosModules =
       {

--- a/flake.nix
+++ b/flake.nix
@@ -175,8 +175,30 @@
           .options;
       };
     in rec {
+      # This is omitted in `nix flake show`.
       legacyPackages = {
-        nixosTests = mapAttrs (_: project: project.nixos.tests) ngiProjects;
+        # Run interactive tests with:
+        #
+        #     nix run .#legacyPackages.x86_64-linux.nixosTests.<project>.<test>.driverInteractive
+        #
+        nixosTests = let
+          nixosTest = test: let
+            # Amenities for interactive tests
+            tools = {pkgs, ...}: {
+              environment.systemPackages = with pkgs; [vim tmux jq];
+              # Use kmscon <https://www.freedesktop.org/wiki/Software/kmscon/>
+              # to provide a slightly nicer console.
+              # kmscon allows zooming with [Ctrl] + [+] and [Ctrl] + [-]
+              services.kmscon = {
+                enable = true;
+                autologinUser = "root";
+              };
+            };
+            debugging.interactive.nodes = mapAttrs (_: _: tools) test.nodes;
+          in
+            pkgs.nixosTest (debugging // test);
+        in
+          mapAttrs (_: project: mapAttrs (_: nixosTest) project.nixos.tests) ngiProjects;
       };
 
       packages =
@@ -205,7 +227,7 @@
       checks = let
         checksForNixosTests = projectName: tests:
           concatMapAttrs
-          (testName: test: {"projects/${projectName}/nixos/tests/${testName}" = test;})
+          (testName: test: {"projects/${projectName}/nixos/tests/${testName}" = pkgs.nixosTest test;})
           tests;
 
         checksForNixosExamples = projectName: examples:

--- a/projects/default.nix
+++ b/projects/default.nix
@@ -28,27 +28,11 @@
   in
     concatMapAttrs names (readDir baseDirectory);
 
-  nixosTest = test: let
-    # Amenities for interactive tests
-    tools = {pkgs, ...}: {
-      environment.systemPackages = with pkgs; [vim tmux jq];
-      # Use kmscon <https://www.freedesktop.org/wiki/Software/kmscon/>
-      # to provide a slightly nicer console.
-      # kmscon allows zooming with [Ctrl] + [+] and [Ctrl] + [-]
-      services.kmscon = {
-        enable = true;
-        autologinUser = "root";
-      };
-    };
-    debugging.interactive.nodes = mapAttrs (_: _: tools) test.nodes;
-  in
-    pkgs.nixosTest (debugging // test);
-
   hydrate = project: {
     packages = project.packages or {};
     nixos.modules = project.nixos.modules or {};
     nixos.examples = project.nixos.examples or {};
-    nixos.tests = mapAttrs (_: nixosTest) project.nixos.tests or {};
+    nixos.tests = project.nixos.tests or {};
   };
 in
   mapAttrs


### PR DESCRIPTION
collecting projects should not deal with debugging workflows.

this change makes the derivation for running CI checks slightly smaller, at
the cost of having a slightly different environment for interactive tests.
it should be okay as long as those differences stay tightly scoped.

an alternative would be moving the definition and application test helpers to the call site of importing projects, but that would require mapping over a nested attribute set, which is a bit more cumbersome and IMO obscures the meaning with irrelevant machinery. 