### PR TITLE
refactor: simplify attrs flattening

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,22 +34,12 @@
     lib' = import ./lib.nix {inherit lib;};
 
     inherit
-      (builtins)
-      mapAttrs
-      attrValues
-      ;
-
-    inherit
       (lib)
+      attrValues
       concatMapAttrs
-      recursiveUpdate
       filterAttrs
-      ;
-
-    inherit
-      (lib')
-      flattenAttrsDot
-      flattenAttrsSlash
+      mapAttrs
+      recursiveUpdate
       ;
 
     # Imported from Nixpkgs
@@ -75,15 +65,15 @@
       sources = {inherit inputs;};
     };
 
-    rawExamples = flattenAttrsSlash (
-      mapAttrs (_: project: mapAttrs (_: example: example.path) project.nixos.examples) rawNgiProjects
+    rawExamples = lib'.flattenAttrs "/" (
+      mapAttrs
+      (_: project: mapAttrs (_: example: example.path) project.nixos.examples)
+      rawNgiProjects
     );
 
-    rawNixosModules = flattenAttrsDot (
-      lib.foldl recursiveUpdate {} (attrValues (
-        mapAttrs (_: project: project.nixos.modules) rawNgiProjects
-      ))
-    );
+    rawNixosModules = lib'.flattenAttrs "." (lib.foldl recursiveUpdate {} (attrValues (
+      mapAttrs (_: project: project.nixos.modules) rawNgiProjects
+    )));
 
     nixosModules =
       {
@@ -207,7 +197,7 @@
         ngipkgs
         // {
           overview = import ./overview {
-            inherit lib pkgs self;
+            inherit lib lib' pkgs self;
             projects = ngiProjects;
             options = optionsDoc.optionsNix;
           };

--- a/lib.nix
+++ b/lib.nix
@@ -1,47 +1,12 @@
-# Functions to lay on top of Nixpkgs' lib for convenience.
-{lib}: let
-  inherit
-    (builtins)
-    isAttrs
-    concatStringsSep
-    ;
-
-  inherit
-    (lib)
-    concatMapAttrs
-    ;
-in rec {
-  # Takes an attrset of arbitrary nesting (attrset containing attrset)
-  # and flattens it into an attrset that is *not* nested, i.e., does
-  # *not* contain attrsets.
-  # This is done by concatenating the names of nested values using a
-  # separator.
-  #
-  # Type: flattenAttrs :: string -> [string] -> AttrSet -> AttrSet
-  #
-  # Example:
-  #   flattenAttrs "~" ["1" "2"] { a = { b = "x"; }; c = { d = { e = "y"; }; }; f = "z"; }
-  #   => { "1~2~a~b" = "x"; "1~2~c~d~e" = "y"; "1~2~f" = "z"; }
-  flattenAttrs =
-    # Separator to use to join names of different nesting levels.
-    separator:
-    # Prefix to be prepended to all names in the generated attrset,
-    # as a list that is joined by the separator.
-    prefix: let
-      initPath =
-        if prefix == []
-        then ""
-        else (concatStringsSep separator prefix) + separator;
-      f = path:
-        concatMapAttrs (
-          name: value:
-            if isAttrs value
-            then f (path + name + separator) value
-            else {${path + name} = value;}
-        );
-    in
-      f initPath;
-
-  flattenAttrsSlash = flattenAttrs "/" [];
-  flattenAttrsDot = flattenAttrs "." [];
+{lib}: {
+  # Take an attrset of arbitrary nesting and make it flat
+  # by concatenating the nested names with the given separator.
+  flattenAttrs = separator: let
+    f = path: lib.concatMapAttrs (flatten path);
+    flatten = path: name: value:
+      if lib.isAttrs value
+      then f (path + name + separator) value
+      else {${path + name} = value;};
+  in
+    f "";
 }

--- a/overview/default.nix
+++ b/overview/default.nix
@@ -1,12 +1,11 @@
 {
   lib,
+  lib',
   options,
   pkgs,
   projects,
   self,
 }: let
-  lib' = import ../lib.nix {inherit lib;};
-
   inherit
     (builtins)
     any
@@ -30,11 +29,6 @@
     optionalString
     ;
 
-  inherit
-    (lib')
-    flattenAttrsDot
-    ;
-
   empty = xs: assert isList xs; xs == [];
   heading = i: text: "<h${toString i}>${text}</h${toString i}>";
   dottedLoc = option: concatStringsSep "." option.loc;
@@ -51,7 +45,7 @@
 
   pick = {
     options = project: let
-      spec = attrNames (flattenAttrsDot project.nixos.modules);
+      spec = attrNames (lib'.flattenAttrs "." project.nixos.modules);
     in
       filter
       (option: any ((flip hasPrefix) (dottedLoc option)) spec)
@@ -159,7 +153,8 @@
     <footer>Version: ${version}, Last Modified: ${lastModified}</footer>
   '';
 in
-  pkgs.runCommand "overview" {
+  pkgs.runCommand "overview"
+  {
     nativeBuildInputs = with pkgs; [jq gnused pandoc validator-nu];
   } ''
     mkdir -v $out


### PR DESCRIPTION
this reduces unneeded generality. we probably shouldn't do the premature
attribute flattening at all, it's not clear to me why it's even done to
begin with. the only place where it seems unavoidable is for the
`checks` flake output.