### PR TITLE
filter out `null` artifacts from project overview

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -167,32 +167,6 @@
           .options;
       };
     in rec {
-      # This is omitted in `nix flake show`.
-      legacyPackages = {
-        # Run interactive tests with:
-        #
-        #     nix run .#legacyPackages.x86_64-linux.nixosTests.<project>.<test>.driverInteractive
-        #
-        nixosTests = let
-          nixosTest = test: let
-            # Amenities for interactive tests
-            tools = {pkgs, ...}: {
-              environment.systemPackages = with pkgs; [vim tmux jq];
-              # Use kmscon <https://www.freedesktop.org/wiki/Software/kmscon/>
-              # to provide a slightly nicer console.
-              # kmscon allows zooming with [Ctrl] + [+] and [Ctrl] + [-]
-              services.kmscon = {
-                enable = true;
-                autologinUser = "root";
-              };
-            };
-            debugging.interactive.nodes = mapAttrs (_: _: tools) test.nodes;
-          in
-            pkgs.nixosTest (debugging // test);
-        in
-          mapAttrs (_: project: mapAttrs (_: nixosTest) project.nixos.tests) ngiProjects;
-      };
-
       packages =
         ngipkgs
         // {
@@ -224,7 +198,7 @@
           checksForProject = projectName: project: let
             checksForNixosTests =
               concatMapAttrs
-              (testName: test: {"projects/${projectName}/nixos/tests/${testName}" = pkgs.nixosTest test;})
+              (testName: test: {"projects/${projectName}/nixos/tests/${testName}" = test;})
               project.nixos.tests;
 
             checksForNixosExamples =

--- a/projects/default.nix
+++ b/projects/default.nix
@@ -28,6 +28,22 @@
   in
     concatMapAttrs names (readDir baseDirectory);
 
+  nixosTest = test: let
+    # Amenities for interactive tests
+    tools = {pkgs, ...}: {
+      environment.systemPackages = with pkgs; [vim tmux jq];
+      # Use kmscon <https://www.freedesktop.org/wiki/Software/kmscon/>
+      # to provide a slightly nicer console.
+      # kmscon allows zooming with [Ctrl] + [+] and [Ctrl] + [-]
+      services.kmscon = {
+        enable = true;
+        autologinUser = "root";
+      };
+    };
+    debugging.interactive.nodes = mapAttrs (_: _: tools) test.nodes;
+  in
+    pkgs.nixosTest (debugging // test);
+
   hydrate = let
     empty-if-null = x:
       if x != null
@@ -41,7 +57,19 @@
       packages = empty-if-null (project.packages or {});
       nixos.modules = empty-if-null (project.nixos.modules or {});
       nixos.examples = empty-if-null (project.nixos.examples or {});
-      nixos.tests = empty-if-null (project.nixos.tests or {});
+      nixos.tests =
+        mapAttrs
+        (
+          _: test:
+            if lib.isString test
+            then
+              (import test {
+                inherit pkgs;
+                inherit (pkgs) system;
+              })
+            else nixosTest test
+        )
+        (empty-if-null (project.nixos.tests or {}));
     };
 in
   mapAttrs

--- a/projects/default.nix
+++ b/projects/default.nix
@@ -28,12 +28,21 @@
   in
     concatMapAttrs names (readDir baseDirectory);
 
-  hydrate = project: {
-    packages = project.packages or {};
-    nixos.modules = project.nixos.modules or {};
-    nixos.examples = project.nixos.examples or {};
-    nixos.tests = project.nixos.tests or {};
-  };
+  hydrate = let
+    empty-if-null = x:
+      if x != null
+      then x
+      else {};
+  in
+    # we use fields to track state of completion.
+    # - `null` means "expected but missing"
+    # - not set means "not applicable"
+    project: {
+      packages = empty-if-null (project.packages or {});
+      nixos.modules = empty-if-null (project.nixos.modules or {});
+      nixos.examples = empty-if-null (project.nixos.examples or {});
+      nixos.tests = empty-if-null (project.nixos.tests or {});
+    };
 in
   mapAttrs
   (


### PR DESCRIPTION
we use that information to track state of completion of packaging for each project

- test modules only once

  before that we may have been running tests twice, the second time being in
  `legacyPackages`. But there's no need to expose tests another time, once
  can just access them via `checks` if needed.