### PR TITLE
Add Servo nixpkgs ref

### DIFF
--- a/projects/Servo/default.nix
+++ b/projects/Servo/default.nix
@@ -1,0 +1,3 @@
+{pkgs, ...} @ args: {
+  packages = {inherit (pkgs) servo;};
+}


### PR DESCRIPTION
related: [Verso](https://github.com/ngi-nix/ngipkgs/issues/318) (web browser)

the project is still young, probably focusing on modules/tests/… is not a good idea yet

if work is to continue, then embed engine in Verso’s presentation layer and del servo entry