### PR TITLE
Add Agorakit nixpkgs and NixOS refs

### DIFF
--- a/overview/default.nix
+++ b/overview/default.nix
@@ -64,7 +64,7 @@
           <table>
             <tr>
               <td>Description:</td>
-              <td>${value.description}</td>
+              <td>${lib.escapeXML value.description}</td>
             </tr>
             <tr>
               <td>Type:</td>

--- a/projects/Agorakit/default.nix
+++ b/projects/Agorakit/default.nix
@@ -1,0 +1,14 @@
+{
+  pkgs,
+  lib,
+  sources,
+} @ args: {
+  packages = {
+    inherit (pkgs) agorakit;
+  };
+  nixos = {
+    modules.services.agorakit = "${sources.inputs.nixpkgs}/nixos/modules/services/web-apps/agorakit.nix";
+    tests.basic = "${sources.inputs.nixpkgs}/nixos/tests/web-apps/agorakit.nix";
+    examples = null;
+  };
+}


### PR DESCRIPTION
There's [no dedicated test](https://github.com/NixOS/nixpkgs/pull/345014/files#diff-307c155c790abf7b54b5dec19dc230c6d692c6dca0604760d8389c7aed543c10) yet, therefore it was defined as `null`.

The build fails though with the following error.

> jq: parse error: Expected string key before ':' at line 1, column 71

Maybe something along the lines of jq breaking the css file due to too many items? Can't really tell from the get go.