### PR TITLE
Add Canaille Nixpkgs and NixOS refs

### DIFF
--- a/projects/Canaille/default.nix
+++ b/projects/Canaille/default.nix
@@ -1,0 +1,14 @@
+{
+  pkgs,
+  lib,
+  sources,
+} @ args: {
+  packages = {
+    inherit (pkgs) canaille;
+  };
+  nixos = {
+    modules.services.canaille = "${sources.inputs.nixpkgs}/nixos/modules/services/security/canaille.nix";
+    tests.canaille = "${sources.inputs.nixpkgs}/nixos/tests/canaille.nix";
+    examples = null;
+  };
+}


### PR DESCRIPTION
Closes: #14.

Draft until the nixpkgs unstable branch is updated with latest changes.