### PR TITLE
Add Rosenpass NixOS services and missing example

### DIFF
--- a/projects/Rosenpass/default.nix
+++ b/projects/Rosenpass/default.nix
@@ -3,8 +3,12 @@
   lib,
   sources,
 } @ args: {
-  packages = {inherit (pkgs) rosenpass rosenpass-tools;};
+  packages = {
+    inherit (pkgs) rosenpass rosenpass-tools;
+  };
   nixos = {
+    modules.services.rosenpass = "${sources.inputs.nixpkgs}/nixos/modules/services/networking/rosenpass.nix";
     tests.rosenpass = import ./tests args;
+    examples = null;
   };
 }


### PR DESCRIPTION
Kept local tests, as they are more current than the upstream version. Should they get upstreamed or replaced by the [one](https://github.com/NixOS/nixpkgs/blob/8d3b1a87c98d22d470d3cd7d31160524445251cf/nixos/tests/rosenpass.nix#L27) upstream?