### PR TITLE
inko doesn't need NixOS examples

### DIFF
--- a/projects/Inko/default.nix
+++ b/projects/Inko/default.nix
@@ -6,7 +6,4 @@
   packages = {
     inherit (pkgs) inko ivm;
   };
-  nixos = {
-    examples = null;
-  };
 }


### PR DESCRIPTION
There's no service where we need to give guidance on how to set it up.

(There's a tree sitter grammar people may want to hook up with their nvim, and having an example there would surely be useful, but that's out of scope for us)