### PR TITLE
overview: don't parse vnu stderr as JSON

### DIFF
--- a/overview/default.nix
+++ b/overview/default.nix
@@ -172,5 +172,5 @@ in
       --in-place \
       $out/index.html
 
-    vnu -Werror --format json $out/*.html 2>&1 | jq
+    vnu -Werror --format json $out/*.html | jq
   ''


### PR DESCRIPTION
this will in fact swallow the actual error and make the build failure
inscrutable by merely reporting a `jq` parse error