### PR TITLE
don't pass `nixpkgs` to projects import

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -120,7 +120,6 @@
           inherit inputs;
           examples = rawExamples;
           modules = extendedNixosModules;
-          inherit nixpkgs;
         };
       };
 


### PR DESCRIPTION
this is unused and probably a remnant of some refactoring