### PR TITLE
get all projects from default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,8 +2,7 @@
   sources ? (import ./flake-compat.nix {root = ./.;}).inputs,
   system ? builtins.currentSystem,
   pkgs ?
-    import sources.nixpkgs
-    {
+    import sources.nixpkgs {
       config = {};
       overlays = [];
       inherit system;
@@ -13,6 +12,12 @@
   dream2nix = import sources.dream2nix;
   sops-nix = import "${sources.sops-nix}/modules/sops";
 in rec {
+  inherit lib pkgs system sources;
+
+  # TODO: we should be exporting our custom functions as `lib`, but refactoring
+  # this to use `pkgs.lib` everywhere is a lot of movement
+  lib' = import ./lib.nix {inherit lib;};
+
   overlays.default = final: prev:
     import ./pkgs/by-name {
       pkgs = prev;

--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,7 @@
     },
   lib ? import "${sources.nixpkgs}/lib",
 }: let
-  dream2nix = import sources.dream2nix;
+  dream2nix = (import sources.dream2nix).overrideInputs {inherit (sources) nixpkgs;};
   sops-nix = import "${sources.sops-nix}/modules/sops";
 in rec {
   inherit lib pkgs system sources;

--- a/deploy/flake.nix
+++ b/deploy/flake.nix
@@ -18,19 +18,19 @@
         ngipkgs.nixosModules.default
 
         ### VULA
-        # ngipkgs.nixosModules."services.vula"
+        # ngipkgs.nixosModules.services.vula
         # ../projects/Vula/example-simple.nix
         ###
         ### KBIN
-        # ngipkgs.nixosModules."services.kbin"
+        # ngipkgs.nixosModules.services.kbin
         # ../projects/Kbin/example.nix
         ###
         ### PEERTUBE
-        # ngipkgs.nixosModules."services.peertube"
+        # ngipkgs.nixosModules.services.peertube
         # ../projects/PeerTube/example.nix
         ###
         ### ATOMICDATA
-        # ngipkgs.nixosModules."services.atomic-server"
+        # ngipkgs.nixosModules.services.atomic-server
         # ../projects/AtomicData/example.nix
         ###
       ];

--- a/projects/Agorakit/default.nix
+++ b/projects/Agorakit/default.nix
@@ -8,7 +8,8 @@
   };
   nixos = {
     modules.services.agorakit = "${sources.inputs.nixpkgs}/nixos/modules/services/web-apps/agorakit.nix";
-    tests.basic = "${sources.inputs.nixpkgs}/nixos/tests/web-apps/agorakit.nix";
+    # TODO: wait for https://github.com/NixOS/nixpkgs/pull/359164 to land in `nixpkgs-unstable`
+    # tests.basic = import "${sources.inputs.nixpkgs}/nixos/tests/web-apps/agorakit.nix" args;
     examples = null;
   };
 }

--- a/projects/AtomicData/test.nix
+++ b/projects/AtomicData/test.nix
@@ -17,9 +17,9 @@ in {
       ...
     }: {
       imports = [
-        sources.modules.default
-        sources.modules."services.atomic-server"
-        sources.examples."AtomicData/base"
+        sources.modules.ngipkgs
+        sources.modules.services.atomic-server
+        sources.examples.AtomicData.base
       ];
     };
   };

--- a/projects/Kbin/test.nix
+++ b/projects/Kbin/test.nix
@@ -17,9 +17,9 @@ in {
       ...
     }: {
       imports = [
-        sources.modules.default
-        sources.modules."services.kbin"
-        sources.examples."Kbin/base"
+        sources.modules.ngipkgs
+        sources.modules.services.kbin
+        sources.examples.Kbin.base
       ];
 
       services.phpfpm.pools.kbin = {

--- a/projects/LiberaForms-E2EE/test.nix
+++ b/projects/LiberaForms-E2EE/test.nix
@@ -8,8 +8,8 @@
       ...
     }: {
       imports = [
-        sources.modules.default
-        sources.modules."services.liberaforms"
+        sources.modules.ngipkgs
+        sources.modules.services.liberaforms
       ];
 
       services.liberaforms = {

--- a/projects/Libervia/test.nix
+++ b/projects/Libervia/test.nix
@@ -86,9 +86,9 @@ in {
         '';
     in {
       imports = [
-        sources.modules.default
-        sources.modules."programs.libervia"
-        sources.examples."Libervia/base"
+        sources.modules.ngipkgs
+        sources.modules.programs.libervia
+        sources.examples.Libervia.base
         # can't test Libervia/unfree, enabling unfree derivations breaks nixosTests eval
       ];
 

--- a/projects/Openfire-IPv6/test.nix
+++ b/projects/Openfire-IPv6/test.nix
@@ -16,8 +16,8 @@
   nodes = {
     server = {config, ...}: {
       imports = [
-        sources.modules.default
-        sources.modules."services.openfire-server"
+        sources.modules.ngipkgs
+        sources.modules.services.openfire-server
       ];
 
       services.openfire-server = {

--- a/projects/PeerTube/test.nix
+++ b/projects/PeerTube/test.nix
@@ -9,9 +9,9 @@
   nodes = {
     server = {config, ...}: {
       imports = [
-        sources.modules.default
-        sources.modules."services.peertube"
-        sources.examples."PeerTube/base"
+        sources.modules.ngipkgs
+        sources.modules.services.peertube
+        sources.examples.PeerTube.base
       ];
 
       boot.kernelPackages = pkgs.linuxPackages_latest;

--- a/projects/Pretalx/test/default.nix
+++ b/projects/Pretalx/test/default.nix
@@ -17,10 +17,10 @@ in {
       ...
     }: {
       imports = [
-        sources.examples."Pretalx/base"
-        sources.examples."Pretalx/postgresql"
-        sources.modules.default
-        sources.modules."services.ngi-pretalx"
+        sources.examples.Pretalx.base
+        sources.examples.Pretalx.postgresql
+        sources.modules.ngipkgs
+        sources.modules.services.ngi-pretalx
         sources.modules.sops-nix
       ];
 

--- a/projects/Rosenpass/tests/default.nix
+++ b/projects/Rosenpass/tests/default.nix
@@ -52,7 +52,7 @@ in {
       ...
     }: {
       imports = [
-        sources.modules.default
+        sources.modules.ngipkgs
         sources.modules.sops-nix
       ];
 

--- a/projects/Vula/test.nix
+++ b/projects/Vula/test.nix
@@ -9,8 +9,8 @@ in {
 
   nodes.a = {
     imports = [
-      sources.modules.default
-      sources.modules."services.vula"
+      sources.modules.ngipkgs
+      sources.modules.services.vula
     ];
 
     services.vula.enable = true;
@@ -31,8 +31,8 @@ in {
   };
 
   nodes.b.imports = [
-    sources.modules.default
-    sources.modules."services.vula"
+    sources.modules.ngipkgs
+    sources.modules.services.vula
     ./example-simple.nix
   ];
 

--- a/projects/mCaptcha/tests/bring-your-own-services.nix
+++ b/projects/mCaptcha/tests/bring-your-own-services.nix
@@ -20,8 +20,8 @@ in {
     ...
   }: {
     imports = [
-      sources.modules.default
-      sources.modules."services.mcaptcha"
+      sources.modules.ngipkgs
+      sources.modules.services.mcaptcha
     ];
 
     services.mcaptcha.enable = true;
@@ -42,7 +42,7 @@ in {
 
   nodes.my_own_services = {pkgs, ...}: {
     imports = [
-      sources.modules.default
+      sources.modules.ngipkgs
     ];
     networking.firewall.enable = false;
     services.postgresql.enable = true;

--- a/projects/mCaptcha/tests/create-locally.nix
+++ b/projects/mCaptcha/tests/create-locally.nix
@@ -6,8 +6,8 @@ in {
 
   nodes.mcaptcha = {pkgs, ...}: {
     imports = [
-      sources.modules.default
-      sources.modules."services.mcaptcha"
+      sources.modules.ngipkgs
+      sources.modules.services.mcaptcha
     ];
 
     services.mcaptcha.enable = true;


### PR DESCRIPTION
this reduces the number of moving parts and finally removes a code path that was unnecessarily hard to reason about

towards https://github.com/ngi-nix/ngipkgs/pull/209