### PR TITLE
Remove not active maintainers from maintainers list

### DIFF
--- a/maintainers.nix
+++ b/maintainers.nix
@@ -1,14 +1,10 @@
 {
-  augustebaum = {
-    email = "auguste.apple@gmail.com";
-    github = "augustebaum";
-    githubId = 52001167;
-    name = "Auguste Baum";
-  };
-  kubaneko = {
-    email = "kubanek0ondrej@gmail.com";
-    github = "kubaneko";
-    githubId = 71923533;
-    name = "Ondřej Kubánek";
-  };
+  # This file is using the same format as
+  # https://github.com/NixOS/nixpkgs/blob/master/maintainers/maintainer-list.nix
+  # <username>= {
+  #   email = "<email>";
+  #   github = "<github-handle>";
+  #   githubId = <github-id>;
+  #   name = "<real-user-name>";
+  # };
 }


### PR DESCRIPTION
`maintainers.nix` file was created during SoN 2023 for people not present in 
[nixpkgs maintainers-list.nix file](https://github.com/NixOS/nixpkgs/blob/master/maintainers/maintainer-list.nix). 

I believe `augustebaum` and `kubaneko` are not active ngipkgs maintainers anymore. Let's remove them.

Another alternative is to remove this file completely.
