### PR TITLE
Add typed models for projects

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -63,6 +63,8 @@ rec {
     };
   };
 
+  project-models = import ./projects/models.nix { inherit lib pkgs sources; };
+
   # TODO: find a better place for this
   metrics = with lib; {
     projects = attrNames raw-projects;

--- a/flake.lock
+++ b/flake.lock
@@ -267,7 +267,8 @@
         "nixpkgs-stable": "nixpkgs-stable",
         "pre-commit-hooks": "pre-commit-hooks",
         "sops-nix": "sops-nix",
-        "systems": "systems"
+        "systems": "systems",
+        "yants": "yants"
       }
     },
     "slimlock": {
@@ -346,6 +347,22 @@
         "owner": "numtide",
         "repo": "treefmt-nix",
         "type": "github"
+      }
+    },
+    "yants": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645270620,
+        "narHash": "sha256-wwkl3K200UbW9Z7BRlVH8HOEXCaVYP2MqZpsF9EhgZg=",
+        "ref": "refs/heads/canon",
+        "rev": "efeb6dc11eb1a1e88d41dc2093fc5aa31f7abd35",
+        "revCount": 15,
+        "type": "git",
+        "url": "https://code.tvl.fyi/depot.git:/nix/yants.git"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://code.tvl.fyi/depot.git:/nix/yants.git"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,8 @@
   inputs.sops-nix.url = "github:Mic92/sops-nix";
   inputs.buildbot-nix.inputs.nixpkgs.follows = "nixpkgs";
   inputs.buildbot-nix.url = "github:nix-community/buildbot-nix";
+  inputs.yants.url = "git+https://code.tvl.fyi/depot.git:/nix/yants.git";
+  inputs.yants.flake = false;
 
   # See <https://github.com/ngi-nix/ngipkgs/issues/24> for plans to support Darwin.
   inputs.systems.url = "github:nix-systems/default-linux";

--- a/projects/models.nix
+++ b/projects/models.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  pkgs,
+  sources,
+}:
+let
+  yants = import sources.yants { };
+
+  inherit (yants)
+    string
+    list
+    option
+    attrs
+    ;
+in
+rec {
+  project =
+    p: with p; {
+      name = string name;
+      metadata = with metadata; {
+        summary = string summary;
+        fund = string fund;
+        status = string status;
+
+        websites = with websites; {
+          repo = string repo;
+          docs = option string (websites.docs or null);
+          other = list string other;
+
+          contact = option (attrs (option string)) {
+            email = contact.email or null;
+            forum = contact.forum or null;
+            matrix = contact.matrix or null;
+            blog = contact.blog or null;
+          };
+        };
+      };
+    };
+
+  example = project {
+    name = "";
+    metadata = {
+      summary = "";
+      websites = {
+        repo = "";
+        contact = null;
+        other = [ ];
+      };
+      fund = "";
+      status = "";
+    };
+  };
+}


### PR DESCRIPTION
Can be tested with:

```sh
nix-instantiate --eval --strict --expr "let self = import ./default.nix {}; in self.project-models.example"
```

You can also use [watchexec](https://search.nixos.org/packages?channel=unstable&show=watchexec&from=0&size=50&sort=relevance&type=packages&query=watchexec) to continuously monitor the output as the file changes:

```sh
watchexec '<COMMAND>'
```

If this is the correct way to go, project deliverables will be added next.