### PR TITLE
flake: Change passthru tests so they're unique

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -205,7 +205,7 @@
                         "packages/${packageName}" = package;
                       };
                       checksForPackagePassthruTests = concatMapAttrs (passthruName: test: {
-                        "packages/${packageName}/passthru/${passthruName}" = test;
+                        "packages/${packageName}-${passthruName}" = test;
                       }) (package.passthru.tests or { });
                     in
                     checksForPackageDerivation // checksForPackagePassthruTests;


### PR DESCRIPTION
This is in order to avoid a path conflict with the package derivation. Closes #490

Opening as draft until I see what the CI does to make sure this actually works.