### PR TITLE
Vula: fix option name in example description

### DIFF
--- a/projects/Vula/default.nix
+++ b/projects/Vula/default.nix
@@ -20,7 +20,7 @@
       description = ''
         Simple configuration for Vula. Vula nodes will automatically discover each other on networks that support [multicast DNS](https://en.wikipedia.org/wiki/Multicast_DNS) (mDNS).
 
-        Add users to the group defined in `config.services.vula.adminGroup` to grant them permissions to manage Vula through the `vula` command.
+        Add users to the group defined in `config.services.vula.operatorsGroup` to grant them permissions to manage Vula through the `vula` command.
       '';
       tests.test = import ./test.nix args;
     };


### PR DESCRIPTION
Hey folks, just some simple formatting.

No option was listed for adminGroup, changed to operatorGroup as listed in the options.