### PR TITLE
Fix derivation expected for tests

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -223,6 +223,8 @@ rec {
                 inherit pkgs;
                 inherit (pkgs) system;
               })
+            else if lib.isDerivation test then
+              test
             else
               nixosTest test
           ) (empty-if-null (project.nixos.tests or { }));

--- a/projects-old/Forgejo/default.nix
+++ b/projects-old/Forgejo/default.nix
@@ -13,7 +13,7 @@
   };
   nixos = {
     modules.services.forgejo = "${sources.inputs.nixpkgs}/nixos/modules/services/misc/forgejo.nix";
-    tests.setup = "${sources.inputs.nixpkgs}/nixos/tests/forgejo.nix";
+    tests = pkgs.nixosTests.forgejo;
     examples = null;
   };
 }


### PR DESCRIPTION
The root issue is that we [always try to run `nixosTest`](https://github.com/ngi-nix/ngipkgs/blob/e9e9712c2706c5046f85a3543b1669c250c70b4a/default.nix#L182-L183) on non-string tests. This is problematic when tests are already derivations, as is the case [with Forgejo](https://github.com/NixOS/nixpkgs/blob/a89f50cf709baf55015d0d10ccf095e66d7d9f0a/nixos/tests/forgejo.nix#L291):

```
nix-repl> pkgs.nixosTests.forgejo
{
  mysql = «derivation /nix/store/cfz61sgamhz94v4y6rk22xy5ly1gzzg9-vm-test-run-forgejo-mysql.drv»;
  postgres = «derivation /nix/store/kc05xfz95923q6mlv24470i6db1244qi-vm-test-run-forgejo-postgres.drv»;
  sqlite3 = «derivation /nix/store/ik9p0b9mknq5mhrny8gw3bv6yam6q8kq-vm-test-run-forgejo-sqlite3.drv»;
}
```

In those cases, it's better to just pass the derivation.

```
$ nix build .#checks.x86_64-linux.projects/Forgejo/nixos/tests/mysql
$ ls ./result/
dump.tar.zst
```

Another change this PR does is it takes the tests directly from `pkgs.nixosTests` as opposed to importing them from `sources.inputs.nixpkgs`:

```diff
-    tests = import "${sources.inputs.nixpkgs}/nixos/tests/forgejo.nix" { inherit pkgs; };
+    tests = pkgs.nixosTests.forgejo;
```

This should be better since [pkgs is already imported from the same nixpkgs](https://github.com/ngi-nix/ngipkgs/blob/e9e9712c2706c5046f85a3543b1669c250c70b4a/default.nix#L4-L8), so it would be redundant to import that again. Note that this pattern repeats in [other tests](https://github.com/search?q=repo%3Angi-nix%2Fngipkgs+%22import+%5C%22%24%7Bsources.inputs.nixpkgs%7D%2Fnixos%2Ftests%22&type=code) as well.

Fixes: https://github.com/ngi-nix/ngipkgs/issues/502