### PR TITLE
Define deliverables for projects and init issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-triaging.yaml
+++ b/.github/ISSUE_TEMPLATE/project-triaging.yaml
@@ -1,0 +1,32 @@
+name: Project Triaging
+description: >-
+  A template for information to look for in an NGI project's resources
+title: "<PROJECT_NAME>"
+labels:
+  - project
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Short Summary
+      description: A short description of the project (optional)
+  - type: input
+    id: website
+    attributes:
+      label: Website
+      placeholder: https://foobar.com
+  - type: textarea
+    id: source
+    attributes:
+      label: Source repository
+      placeholder: "- https://github.com/foo/foobar"
+  - type: textarea
+    id: nlnet
+    attributes:
+      label: NLnet page(s)
+      description: >-
+        Navigate to the [NLnet project list](https://nlnet.nl/project/) and add
+        the links to related projects
+      placeholder: "- https://nlnet.nl/project/<PROJECT_NAME>"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/project-triaging.yaml
+++ b/.github/ISSUE_TEMPLATE/project-triaging.yaml
@@ -58,7 +58,7 @@ body:
       value: |-
         - Language/Framework:
         - Dependency management:
-        - Development envirnment: [default.nix, shell.nix, flake.nix, devenv.nix, ...](<FILE_LINK>)
+        - Development environment: [default.nix, shell.nix, flake.nix, devenv.nix, ...](<FILE_LINK>)
   - type: textarea
     id: nixos
     attributes:

--- a/.github/ISSUE_TEMPLATE/project-triaging.yaml
+++ b/.github/ISSUE_TEMPLATE/project-triaging.yaml
@@ -49,13 +49,14 @@ body:
         - Other:
           -
   - type: textarea
-    id: components
+    id: artefacts
     attributes:
-      label: Components
+      label: Artefacts
       description: >-
-        Name of project component according to its type. Any specific **links or
-        documentation** to this component should also be linked here.
-      placeholder: |
+        Provide all project components and link any relevant documentation or
+        information you can find about them. Make sure to **remove the ones
+        that don't exist** from the following list:
+      value: |
         - CLI:
           - foobar:
             - documentation:
@@ -65,7 +66,7 @@ body:
         - Services/daemons:
         - Libraries:
         - Extensions:
-        - Mobile:
+        - Mobile Apps:
   - type: textarea
     id: nixos
     attributes:

--- a/.github/ISSUE_TEMPLATE/project-triaging.yaml
+++ b/.github/ISSUE_TEMPLATE/project-triaging.yaml
@@ -9,6 +9,16 @@ body:
     attributes:
       label: Short Summary
       description: A short description of the project (optional)
+  - type: textarea
+    id: nlnet
+    attributes:
+      label: NLnet page(s)
+      description: >-
+        Navigate to the [NLnet project list](https://nlnet.nl/project/) and add
+        the links to related projects
+      placeholder: "- https://nlnet.nl/project/foobar"
+    validations:
+      required: true
   - type: input
     id: website
     attributes:
@@ -27,16 +37,6 @@ body:
         - Language/Framework:
         - Dependency management:
         - Development environment: [default.nix, shell.nix, flake.nix, devenv.nix, ...](<FILE_LINK>)
-  - type: textarea
-    id: nlnet
-    attributes:
-      label: NLnet page(s)
-      description: >-
-        Navigate to the [NLnet project list](https://nlnet.nl/project/) and add
-        the links to related projects
-      placeholder: "- https://nlnet.nl/project/foobar"
-    validations:
-      required: true
   - type: textarea
     id: documentation
     attributes:
@@ -70,7 +70,7 @@ body:
   - type: textarea
     id: nixos
     attributes:
-      label: NixOS
+      label: Nixpkgs/NixOS
       description: >-
         Go to the nixpkgs search pages for
         [packages](https://search.nixos.org/packages) and

--- a/.github/ISSUE_TEMPLATE/project-triaging.yaml
+++ b/.github/ISSUE_TEMPLATE/project-triaging.yaml
@@ -1,7 +1,6 @@
 name: Project Triaging
-description: >-
-  A template for information to look for in an NGI project's resources
-title: "<PROJECT_NAME>"
+description: A template for information to look for in an NGI project's resources
+title: <PROJECT_NAME>
 labels:
   - project
 body:
@@ -30,3 +29,41 @@ body:
       placeholder: "- https://nlnet.nl/project/<PROJECT_NAME>"
     validations:
       required: true
+  - type: textarea
+    id: documentation
+    attributes:
+      label: Documentation
+      value: |-
+        - Quick start/Usage Examples:
+        - Building/Development:
+        - Other:
+  - type: textarea
+    id: components
+    attributes:
+      label: Components
+      description: >-
+        Name of project component according to its type. Any specific **links or
+        documentation** to this component should also be linked here.
+      placeholder: |
+        - CLI:
+        - GUI:
+        - Service/daemon:
+        - Library:
+        - Extensions:
+        - Mobile:
+  - type: textarea
+    id: metadata
+    attributes:
+      label: Metadata
+      placeholder: |-
+        - Framework:
+        - Dependency management:
+        - Development envirnment:
+          - [default.nix, flake.nix, devenv.nix, ...](<SOURCE_REPO_LINK>)
+  - type: textarea
+    id: extra
+    attributes:
+      label: Extra Information
+      description: >-
+        Anything interesting or helpful for packaging the project like notes,
+        issues or pull requests

--- a/.github/ISSUE_TEMPLATE/project-triaging.yaml
+++ b/.github/ISSUE_TEMPLATE/project-triaging.yaml
@@ -26,7 +26,7 @@ body:
       description: >-
         Navigate to the [NLnet project list](https://nlnet.nl/project/) and add
         the links to related projects
-      placeholder: "- https://nlnet.nl/project/<PROJECT_NAME>"
+      placeholder: "- https://nlnet.nl/project/foobar"
     validations:
       required: true
   - type: textarea
@@ -58,8 +58,7 @@ body:
       value: |-
         - Language/Framework:
         - Dependency management:
-        - Development envirnment:
-          - [default.nix, flake.nix, devenv.nix, ...](<SOURCE_REPO_LINK>)
+        - Development envirnment: [default.nix, shell.nix, flake.nix, devenv.nix, ...](<FILE_LINK>)
   - type: textarea
     id: nixos
     attributes:

--- a/.github/ISSUE_TEMPLATE/project-triaging.yaml
+++ b/.github/ISSUE_TEMPLATE/project-triaging.yaml
@@ -20,6 +20,14 @@ body:
       label: Source repository
       placeholder: "- https://github.com/foo/foobar"
   - type: textarea
+    id: metadata
+    attributes:
+      label: Metadata
+      value: |-
+        - Language/Framework:
+        - Dependency management:
+        - Development environment: [default.nix, shell.nix, flake.nix, devenv.nix, ...](<FILE_LINK>)
+  - type: textarea
     id: nlnet
     attributes:
       label: NLnet page(s)
@@ -35,8 +43,11 @@ body:
       label: Documentation
       value: |-
         - Usage Examples:
+          -
         - Build from source/Development:
+          -
         - Other:
+          -
   - type: textarea
     id: components
     attributes:
@@ -46,19 +57,15 @@ body:
         documentation** to this component should also be linked here.
       placeholder: |
         - CLI:
+          - foobar:
+            - documentation:
+            - examples:
+            - tests:
         - GUI:
-        - Service/daemon:
-        - Library:
+        - Services/daemons:
+        - Libraries:
         - Extensions:
         - Mobile:
-  - type: textarea
-    id: metadata
-    attributes:
-      label: Metadata
-      value: |-
-        - Language/Framework:
-        - Dependency management:
-        - Development environment: [default.nix, shell.nix, flake.nix, devenv.nix, ...](<FILE_LINK>)
   - type: textarea
     id: nixos
     attributes:

--- a/.github/ISSUE_TEMPLATE/project-triaging.yaml
+++ b/.github/ISSUE_TEMPLATE/project-triaging.yaml
@@ -34,8 +34,8 @@ body:
     attributes:
       label: Documentation
       value: |-
-        - Quick start/Usage Examples:
-        - Building/Development:
+        - Usage Examples:
+        - Build from source/Development:
         - Other:
   - type: textarea
     id: components
@@ -55,11 +55,25 @@ body:
     id: metadata
     attributes:
       label: Metadata
-      placeholder: |-
-        - Framework:
+      value: |-
+        - Language/Framework:
         - Dependency management:
         - Development envirnment:
           - [default.nix, flake.nix, devenv.nix, ...](<SOURCE_REPO_LINK>)
+  - type: textarea
+    id: nixos
+    attributes:
+      label: NixOS
+      description: >-
+        Go to the nixpkgs search pages for
+        [packages](https://search.nixos.org/packages) and
+        [services](https://search.nixos.org/options?) and check if anything
+        related to the project is already packaged.
+      value: |2
+           - Packages:
+             - [<NAME>](<SOURCE_LINK>)
+           - Services:
+             - [<NAME>](<SOURCE_LINK>)
   - type: textarea
     id: extra
     attributes:

--- a/.github/ISSUE_TEMPLATE/project-triaging.yaml
+++ b/.github/ISSUE_TEMPLATE/project-triaging.yaml
@@ -1,8 +1,8 @@
 name: Project Triaging
 description: A template for information to look for in an NGI project's resources
 title: <PROJECT_NAME>
-labels:
-  - project
+labels: ["project"]
+projects: ["Nix@NGI"]
 body:
   - type: textarea
     id: summary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ Instead, write one sentence per line, as this makes it easier to review changes.
 
 ## Triaging an NGI project
 
-These are the step to take when adding a new NGI project to ngipkgs
+When [opening an issue for a new NGI project](https://github.com/ngi-nix/ngipkgs/issues/new?template=project-triaging.yaml), it's recommended to follow the workflow below, which details which information we'd like to know about a project.
 
 1. Navigate to <https://nlnet.nl/project/>.
    In the search bar, type the project name and look for any related projects.
@@ -139,7 +139,7 @@ These are the step to take when adding a new NGI project to ngipkgs
    In the project pages, look for any `website` or `source code` links and open them.
 
 1. In the project's website, look for any tabs or buttons that lead to the documentation. You may also use your favorite search engine and look for `<PROJECT_NAME> documentation`.
-   The most relavant information we want is documentation about building the project from source or examples for using it.
+   The most relavant information we want is documentation about building the project from source and examples for using it.
    If the project has many components, it would be ideal to have this information for each one of them.
 
    ```
@@ -152,13 +152,12 @@ These are the step to take when adding a new NGI project to ngipkgs
        - https://foo.bar/docs/dev/mobile
    ```
 
-1. In the project's source repository, we'd like to know some information about what `framework` and `dependency management` tools the project uses so we can estimate the effort to package it. If possible, we'd also like to have links to Nix development environments, if they exist in the repo.
+1. In the project's source repository, we'd like to know some information about what `framework` and `dependency management` tools the project uses so we can estimate the time and effort needed to package it. If possible, we'd also like to have links to Nix development environments, if they exist in the repo.
 
    ```
-   - Framework: Django
+   - Language/Framework: Python/Django
    - Dependency management: pip
-   - Development envirnment:
-     - [default.nix, flake.nix, devenv.nix, ...](<SOURCE_REPO_LINK>)
+   - Development envirnment: [default.nix, shell.nix, flake.nix, devenv.nix, ...](<FILE_LINK>)
    ```
 
 1. Go to the nixpkgs search pages for [packages](https://search.nixos.org/packages) and [services](https://search.nixos.org/options?) and check if anything related to the project is already packaged.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,52 @@ Instead, write one sentence per line, as this makes it easier to review changes.
    Respond to review comments, potential CI failures, and potential merge conflicts by updating the pull request.
    Always keep the pull request in a mergeable state.
 
+## Triaging an NGI project
+
+These are the step to take when adding a new NGI project to ngipkgs
+
+1. Navigate to <https://nlnet.nl/project/>.
+   In the search bar, type the project name and look for any related projects.
+
+   ```
+   - https://nlnet.nl/project/foobar
+   - https://nlnet.nl/project/foobar-core
+   ```
+
+   In the project pages, look for any `website` or `source code` links and open them.
+
+1. In the project's website, look for any tabs or buttons that lead to the documentation. You may also use your favorite search engine and look for `<PROJECT_NAME> documentation`.
+   The most relavant information we want is documentation about building the project from source or examples for using it.
+   If the project has many components, it would be ideal to have this information for each one of them.
+
+   ```
+   - Usage Examples:
+     - https://foo.bar/docs/quickstart
+   - Building:
+     - foobar-cli:
+       - https://foo.bar/docs/dev/cli
+     - foobar-mobile:
+       - https://foo.bar/docs/dev/mobile
+   ```
+
+1. In the project's source repository, we'd like to know some information about what `framework` and `dependency management` tools the project uses so we can estimate the effort to package it. If possible, we'd also like to have links to Nix development environments, if they exist in the repo.
+
+   ```
+   - Framework: Django
+   - Dependency management: pip
+   - Development envirnment:
+     - [default.nix, flake.nix, devenv.nix, ...](<SOURCE_REPO_LINK>)
+   ```
+
+1. Go to the nixpkgs search pages for [packages](https://search.nixos.org/packages) and [services](https://search.nixos.org/options?) and check if anything related to the project is already packaged.
+
+   ```
+   - Packages:
+     - [<NAME>](<SOURCE_LINK>)
+   - Services:
+     - [<NAME>](<SOURCE_LINK>)
+   ```
+
 <!-- TODO: Add details about how to do more production-like deployments that require non-default config options. -->
 
 <!-- TODO: How to import all of NGIpkgs as an input to an existing NixOS configuration, in order to deploy a service alongside other services on the same virtual or physical machine. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,14 @@ When [opening an issue for a new NGI project](https://github.com/ngi-nix/ngipkgs
 
    In the project pages, look for any `website` or `source code` links and open them.
 
+1. In the project's source repository, we'd like to know some information about what `framework` and `dependency management` tools the project uses so we can estimate the time and effort needed to package it. If possible, we'd also like to have links to Nix development environments, if they exist in the repo.
+
+   ```
+   - Language/Framework: Python/Django
+   - Dependency management: pip
+   - Development envirnment: [default.nix, shell.nix, flake.nix, devenv.nix, ...](<FILE_LINK>)
+   ```
+
 1. In the project's website, look for any tabs or buttons that lead to the documentation. You may also use your favorite search engine and look for `<PROJECT_NAME> documentation`.
    The most relavant information we want is documentation about building the project from source and examples for using it.
    If the project has many components, it would be ideal to have this information for each one of them.
@@ -145,19 +153,9 @@ When [opening an issue for a new NGI project](https://github.com/ngi-nix/ngipkgs
    ```
    - Usage Examples:
      - https://foo.bar/docs/quickstart
-   - Building:
-     - foobar-cli:
-       - https://foo.bar/docs/dev/cli
-     - foobar-mobile:
-       - https://foo.bar/docs/dev/mobile
-   ```
-
-1. In the project's source repository, we'd like to know some information about what `framework` and `dependency management` tools the project uses so we can estimate the time and effort needed to package it. If possible, we'd also like to have links to Nix development environments, if they exist in the repo.
-
-   ```
-   - Language/Framework: Python/Django
-   - Dependency management: pip
-   - Development envirnment: [default.nix, shell.nix, flake.nix, devenv.nix, ...](<FILE_LINK>)
+   - Build from source/Development:
+     - foobar-cli: https://foo.bar/docs/dev/cli
+     - foobar-mobile: https://foo.bar/docs/dev/mobile
    ```
 
 1. Go to the nixpkgs search pages for [packages](https://search.nixos.org/packages) and [services](https://search.nixos.org/options?) and check if anything related to the project is already packaged.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ Instead, write one sentence per line, as this makes it easier to review changes.
 
 ## Triaging an NGI project
 
-When [opening an issue for a new NGI project](https://github.com/ngi-nix/ngipkgs/issues/new?template=project-triaging.yaml), it's recommended to follow the workflow below, which details which information we'd like to know about a project.
+The following information is needed to [open an issue for a new NGI project](https://github.com/ngi-nix/ngipkgs/issues/new?template=project-triaging.yaml):
 
 1. Navigate to <https://nlnet.nl/project/>.
    In the search bar, type the project name and look for any related projects.
@@ -144,6 +144,7 @@ When [opening an issue for a new NGI project](https://github.com/ngi-nix/ngipkgs
    - Language/Framework: Python/Django
    - Dependency management: pip
    - Development environment: [default.nix, shell.nix, flake.nix, devenv.nix, ...](<FILE_LINK>)
+   ```
 
 1. In the project's website, look for any tabs or buttons that lead to the documentation. You may also use your favorite search engine and look for `<PROJECT_NAME> documentation`.
    The most important information we need are the instructions for building the project from source and examples for using it.
@@ -155,6 +156,7 @@ When [opening an issue for a new NGI project](https://github.com/ngi-nix/ngipkgs
    - Build from source/Development:
      - foobar-cli: https://foo.bar/docs/dev/cli
      - foobar-mobile: https://foo.bar/docs/dev/mobile
+   ```
 
 1. Go to the [nixpkgs search](https://search.nixos.org/packages) and [services search](https://search.nixos.org/options?) and check if anything related to the project is already packaged.
 
@@ -163,6 +165,7 @@ When [opening an issue for a new NGI project](https://github.com/ngi-nix/ngipkgs
      - [<NAME>](<SOURCE_LINK>)
    - Services:
      - [<NAME>](<SOURCE_LINK>)
+   ```
 
 <!-- TODO: Add details about how to do more production-like deployments that require non-default config options. -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ When [opening an issue for a new NGI project](https://github.com/ngi-nix/ngipkgs
 1. Navigate to <https://nlnet.nl/project/>.
    In the search bar, type the project name and look for any related projects.
 
-   ```
+   ```md
    - https://nlnet.nl/project/foobar
    - https://nlnet.nl/project/foobar-core
    ```
@@ -140,7 +140,7 @@ When [opening an issue for a new NGI project](https://github.com/ngi-nix/ngipkgs
 
 1. In the project's source repository, we'd like to know some information about what `framework` and `dependency management` tools the project uses so we can estimate the time and effort needed to package it. If possible, we'd also like to have links to Nix development environments, if they exist in the repo.
 
-   ```
+   ```md
    - Language/Framework: Python/Django
    - Dependency management: pip
    - Development envirnment: [default.nix, shell.nix, flake.nix, devenv.nix, ...](<FILE_LINK>)
@@ -150,7 +150,7 @@ When [opening an issue for a new NGI project](https://github.com/ngi-nix/ngipkgs
    The most relavant information we want is documentation about building the project from source and examples for using it.
    If the project has many components, it would be ideal to have this information for each one of them.
 
-   ```
+   ```md
    - Usage Examples:
      - https://foo.bar/docs/quickstart
    - Build from source/Development:
@@ -160,7 +160,7 @@ When [opening an issue for a new NGI project](https://github.com/ngi-nix/ngipkgs
 
 1. Go to the nixpkgs search pages for [packages](https://search.nixos.org/packages) and [services](https://search.nixos.org/options?) and check if anything related to the project is already packaged.
 
-   ```
+   ```md
    - Packages:
      - [<NAME>](<SOURCE_LINK>)
    - Services:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,17 +138,16 @@ When [opening an issue for a new NGI project](https://github.com/ngi-nix/ngipkgs
 
    In the project pages, look for any `website` or `source code` links and open them.
 
-1. In the project's source repository, we'd like to know some information about what `framework` and `dependency management` tools the project uses so we can estimate the time and effort needed to package it. If possible, we'd also like to have links to Nix development environments, if they exist in the repo.
+1. We'd like to know some information about the `framework` and `dependency management` tools the project is using which helps us to estimate the time and effort needed to package it. If possible, we'd also like to know about Nix development environments, if they exist in the repo.
 
    ```md
    - Language/Framework: Python/Django
    - Dependency management: pip
-   - Development envirnment: [default.nix, shell.nix, flake.nix, devenv.nix, ...](<FILE_LINK>)
-   ```
+   - Development environment: [default.nix, shell.nix, flake.nix, devenv.nix, ...](<FILE_LINK>)
 
 1. In the project's website, look for any tabs or buttons that lead to the documentation. You may also use your favorite search engine and look for `<PROJECT_NAME> documentation`.
-   The most relavant information we want is documentation about building the project from source and examples for using it.
-   If the project has many components, it would be ideal to have this information for each one of them.
+   The most important information we need are the instructions for building the project from source and examples for using it.
+   If the project has multiple components, it would be ideal to have this information for each one of them.
 
    ```md
    - Usage Examples:
@@ -156,16 +155,14 @@ When [opening an issue for a new NGI project](https://github.com/ngi-nix/ngipkgs
    - Build from source/Development:
      - foobar-cli: https://foo.bar/docs/dev/cli
      - foobar-mobile: https://foo.bar/docs/dev/mobile
-   ```
 
-1. Go to the nixpkgs search pages for [packages](https://search.nixos.org/packages) and [services](https://search.nixos.org/options?) and check if anything related to the project is already packaged.
+1. Go to the [nixpkgs search](https://search.nixos.org/packages) and [services search](https://search.nixos.org/options?) and check if anything related to the project is already packaged.
 
    ```md
    - Packages:
      - [<NAME>](<SOURCE_LINK>)
    - Services:
      - [<NAME>](<SOURCE_LINK>)
-   ```
 
 <!-- TODO: Add details about how to do more production-like deployments that require non-default config options. -->
 


### PR DESCRIPTION
## Changes

- Add section to `CONTRIBUTING.md` that details what deliverables we need for projects and the workflow to get that information
- Add GitHub issue template for projects
  - Preview: https://github.com/eljamm/ngipkgs/issues/new?template=project-triaging.yaml
  - Example: https://github.com/eljamm/ngipkgs/issues/611

Related: https://github.com/ngi-nix/summer-of-nix/issues/175 https://github.com/ngi-nix/summer-of-nix/issues/163