### PR TITLE
Add prefix and update label of NGI project issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-triaging.yaml
+++ b/.github/ISSUE_TEMPLATE/project-triaging.yaml
@@ -1,7 +1,7 @@
 name: Project Triaging
 description: A template for information to look for in an NGI project's resources
-title: <PROJECT_NAME>
-labels: ["project"]
+title: "NGI Project: <PROJECT_NAME>"
+labels: ["NGI Project"]
 projects: ["Nix@NGI"]
 body:
   - type: textarea


### PR DESCRIPTION
Make NGI project tasks more visible.

This change will require rename of currently existing `project` label.
