### PR TITLE
Fix project-models.example

### DIFF
--- a/projects/models.nix
+++ b/projects/models.nix
@@ -113,7 +113,7 @@ rec {
           description = ''
             This is how you can run `foobar` in the terminal.
           '';
-          module = { ... }: { };
+          module = ./default.nix;
           links = {
             website = {
               text = "FooBar Documentation";


### PR DESCRIPTION
Type expects an absolute path or a string, not a function

Fixes: https://github.com/ngi-nix/ngipkgs/issues/561