### PR TITLE
Cleanup nixos modules; pass sops-nix directly

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -52,6 +52,8 @@ rec {
     with lib;
     [
       nixos-modules.ngipkgs
+      # TODO: needed for examples that use sops (like Pretalx)
+      sops-nix
     ]
     ++ attrValues nixos-modules.programs
     ++ attrValues nixos-modules.services;
@@ -65,10 +67,7 @@ rec {
         pkgs = pkgs // ngipkgs;
         sources = {
           inputs = sources;
-          # TODO: sops-nix is needed only for Pretalx and Rosenpass, and they can get it from `sources`
-          modules = nixos-modules // {
-            inherit sops-nix;
-          };
+          modules = nixos-modules;
           inherit examples;
         };
       };

--- a/default.nix
+++ b/default.nix
@@ -48,6 +48,14 @@ rec {
     }
     // foldl recursiveUpdate { } (map (project: project.nixos.modules) (attrValues projects));
 
+  extendedNixosModules =
+    with lib;
+    [
+      nixos-modules.ngipkgs
+    ]
+    ++ attrValues nixos-modules.programs
+    ++ attrValues nixos-modules.services;
+
   ngipkgs = import ./pkgs/by-name { inherit pkgs lib dream2nix; };
 
   raw-projects =

--- a/flake.nix
+++ b/flake.nix
@@ -74,18 +74,6 @@
         default.nixpkgs.overlays = [ overlay ];
       } // rawNixosModules;
 
-      extendedNixosModules =
-        # TODO: clean this up
-        classic'.nixos-modules.programs
-        // classic'.nixos-modules.services
-        // {
-          inherit (classic'.nixos-modules) ngipkgs;
-        }
-        // {
-          # TODO: only one module uses this, get it from `sources` there
-          sops-nix = sops-nix.nixosModules.default;
-        };
-
       mkNixosSystem =
         config:
         nixosSystem {
@@ -107,7 +95,7 @@
             ]
             # TODO: this needs to take a different shape,
             # otherwise the transformation to obtain it is confusing
-            ++ attrValues extendedNixosModules;
+            ++ classic'.extendedNixosModules;
         };
 
       toplevel = machine: machine.config.system.build.toplevel;

--- a/projects-old/Pretalx/test/default.nix
+++ b/projects-old/Pretalx/test/default.nix
@@ -24,7 +24,7 @@ in
           sources.examples.Pretalx.postgresql
           sources.modules.ngipkgs
           sources.modules.services.ngi-pretalx
-          sources.modules.sops-nix
+          "${sources.inputs.sops-nix}/modules/sops"
         ];
 
         sops = mkForce {

--- a/projects-old/Rosenpass/tests/default.nix
+++ b/projects-old/Rosenpass/tests/default.nix
@@ -59,7 +59,7 @@ in
         {
           imports = [
             sources.modules.ngipkgs
-            sources.modules.sops-nix
+            "${sources.inputs.sops-nix}/modules/sops"
           ];
 
           services.rosenpass = {


### PR DESCRIPTION
Since we're only interested in the attribute sets' values, we can directly use lists, instead of updating the attrs, then calling `attrsValues`.

With this, we avoid shadowing `programs` and `services` that share the same name.