### PR TITLE
overview: Stable project urls

### DIFF
--- a/overview/default.nix
+++ b/overview/default.nix
@@ -30,6 +30,8 @@ let
     mapAttrsToList
     optionalString
     recursiveUpdate
+    mapAttrs'
+    nameValuePair
     ;
 
   empty =
@@ -146,17 +148,23 @@ let
         '';
     };
 
-    projects = rec {
+    projects = {
       one = name: project: ''
-        <section><details><summary>${heading 2 name}</summary>
+        ${heading 1 name}
         <https://nlnet.nl/project/${name}>
 
         ${render.packages.many (pick.packages project)}
         ${render.options.many (pick.options project)}
         ${render.examples.many (pick.examples project)}
-        </details></section>
       '';
-      many = projects: concatLines (mapAttrsToList one projects);
+      # Many projects are renderes as links to their individual project sites
+      many =
+        projects:
+        concatLines (
+          mapAttrsToList (name: _: ''
+            <a href="${name}">${name}</a>
+          '') projects
+        );
     };
   };
 
@@ -168,12 +176,41 @@ let
     )
   );
 
-  content = pkgs.writeText "overview.html" ''
+  # The top-level overview for all projects
+  index = pkgs.writeText "index.html" ''
     ${render.projects.many projects}
 
     <hr>
     <footer>Version: ${version}, Last Modified: ${lastModified}</footer>
   '';
+
+  # Every HTML page that we generate
+  pages =
+    {
+      "index.html" = index;
+    }
+    // mapAttrs' (
+      name: project:
+      nameValuePair "${name}/index.html" (pkgs.writeText "index.html" (render.projects.one name project))
+    ) projects;
+
+  # Ensure that directories exist and that HTML is complete and works as a standalone file
+  writeHtmlCommand = path: content: ''
+    mkdir -p "$out/$(dirname '${path}')"
+
+    pandoc \
+      --from=markdown+raw_html \
+      --to=html \
+      --standalone \
+      --css="/style.css" \
+      --metadata-file=${metadata} \
+      --output="$out/${path}" ${content}
+
+    sed --file=${./fixup.sed} \
+      --in-place \
+      "$out/${path}"
+  '';
+
 in
 pkgs.runCommand "overview"
   {
@@ -184,21 +221,14 @@ pkgs.runCommand "overview"
       validator-nu
     ];
   }
-  ''
-    mkdir -v $out
-    cp -v ${./style.css} $out/style.css
+  (
+    ''
+      mkdir -v $out
+      cp -v ${./style.css} $out/style.css
+    ''
+    + (concatLines (mapAttrsToList writeHtmlCommand pages))
+    + ''
 
-    pandoc \
-      --from=markdown+raw_html \
-      --to=html \
-      --standalone \
-      --css="style.css" \
-      --metadata-file=${metadata} \
-      --output=$out/index.html ${content}
-
-    sed --file=${./fixup.sed} \
-      --in-place \
-      $out/index.html
-
-    vnu -Werror --format json $out/*.html | jq
-  ''
+      vnu -Werror --format json $out/*.html | jq
+    ''
+  )

--- a/overview/default.nix
+++ b/overview/default.nix
@@ -162,7 +162,7 @@ let
         projects:
         concatLines (
           mapAttrsToList (name: _: ''
-            <a href="${name}">${name}</a>
+            <a href="/project/${name}">${name}</a>
           '') projects
         );
     };
@@ -187,7 +187,7 @@ let
     }
     // mapAttrs' (
       name: project:
-      nameValuePair "${name}/index.html" {
+      nameValuePair "project/${name}/index.html" {
         pagetitle = "NGIpkgs | ${name}";
         html = pkgs.writeText "index.html" (render.projects.one name project);
       }

--- a/overview/metadata.nix
+++ b/overview/metadata.nix
@@ -1,7 +1,0 @@
-{ date }:
-{
-  inherit date;
-  title = "NGIpkgs Overview";
-  lang = "en";
-  dir = "ltr";
-}


### PR DESCRIPTION
Closes #505 

Beware that this currently mixes the names of `projects/` and `projects-old/`, even though the names in `projects-old/` are actually grant names, which we don't want to use. As NGIpkgs is experimental and the overview isn't even hosted in it's designated place yet, I didn't care yet to write logic to only use names from `projects/`.

Currently this uses the following URL format for the URL of e.g. the Canaille project: `https://ngi.nixos.org/Canaille`

![tmp C0CpqKLLiM](https://github.com/user-attachments/assets/0c644898-a0b7-4b96-bbd4-163830843aea)

![tmp UPjDaWf5V4](https://github.com/user-attachments/assets/3ac12b99-1768-4aa8-abaf-36cb8e1677e0)


