### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,7 @@ Instead, write one sentence per line, as this makes it easier to review changes.
      ```
 
      The module will then be accessible from `nixosModules.services.some-project`.
+     Note that for new projects, it's ideal that you follow the [triaging template](#triaging-an-ngi-project) workflow and create a new issue, detailing some information about this project.
 
    - Add the module tests in `test.nix`, or under a test directory, and reference that file in `default.nix`.
      For example:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,13 +66,16 @@ Instead, write one sentence per line, as this makes it easier to review changes.
 
    An existing example is [libgnunetchat](https://github.com/ngi-nix/ngipkgs/blob/main/pkgs/by-name/libgnunetchat/package.nix).
 
-1. Check if the project already exists in `projects/some-project`.
-   If it does not exist, you can copy the project template and edit it with relevant details:
+1. When contributing to a project, start by checking if it has an entry in `projects/some-project`.
+   If the entry does not exist, you should copy the project template and edit it with relevant details:
 
    ```shellSession
    cp -r templates/project projects/some-project
    $EDITOR projects/some-project/default.nix
    ```
+
+   Note that for new projects, it's ideal that you follow the [triaging template](#triaging-an-ngi-project) workflow and create a new issue, detailing some information about this project.
+   This will allow you to get more familiar with the project and fill out the template more easily.
 
 1. To add a NixOS service module, start by editing the `default.nix` file in the directory `projects/some-project`.
 
@@ -92,7 +95,6 @@ Instead, write one sentence per line, as this makes it easier to review changes.
      ```
 
      The module will then be accessible from `nixosModules.services.some-project`.
-     Note that for new projects, it's ideal that you follow the [triaging template](#triaging-an-ngi-project) workflow and create a new issue, detailing some information about this project.
 
    - Add the module tests in `test.nix`, or under a test directory, and reference that file in `default.nix`.
      For example:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ Instead, write one sentence per line, as this makes it easier to review changes.
    An existing example is [libgnunetchat](https://github.com/ngi-nix/ngipkgs/blob/main/pkgs/by-name/libgnunetchat/package.nix).
 
 1. When contributing to a project, start by checking if it has an entry in `projects/some-project`.
-   If the entry does not exist, you should copy the project template and edit it with relevant details:
+   If the entry does not exist, copy the project template and edit it with relevant details:
 
    ```shellSession
    cp -r templates/project projects/some-project

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ Instead, write one sentence per line, as this makes it easier to review changes.
 
    An existing example is [libgnunetchat](https://github.com/ngi-nix/ngipkgs/blob/main/pkgs/by-name/libgnunetchat/package.nix).
 
-1. To add a NixOS service module, start by creating a `default.nix` file in the directory `projects/some-project` where `some-project` is the project name corresponding to the last URL component in the [NLnet project listing](https://nlnet.nl/project/).
+1. To add a NixOS service module, start by creating a `default.nix` file in the directory `projects/some-project`.
 
    ```shellSession
    mkdir -p projects/some-project
@@ -80,7 +80,7 @@ Instead, write one sentence per line, as this makes it easier to review changes.
 
      ```nix
      nixos.modules = {
-       services.some-project = ./service.nix;
+       services.some-project.module = ./service.nix;
      };
      ```
 
@@ -93,13 +93,13 @@ Instead, write one sentence per line, as this makes it easier to review changes.
      nixos.tests.some-test = import ./test.nix args;
      ```
 
-     The module tests will then be accessible from `nixosTests.some-project`.
+     The module tests will then be accessible from `checks.<system>.some-project`.
 
    - Test the module on `x86_64-linux`.
 
      ```shellSession
      git add pkgs/by-name/some-package projects/some-project
-     nix build .#some-package.passthru.tests.some-test.driverInteractive
+     nix build .#checks.x86_64-linux.projects/some-project/nixos/tests/some-test.driverInteractive
      ./result/bin/nixos-test-driver # Start a shell
      # Once in the spawned shell, start a VM that will execute the tests
      start_all() # Run the VM
@@ -111,7 +111,7 @@ Instead, write one sentence per line, as this makes it easier to review changes.
      nix fmt projects/some-project
      ```
 
-   An existing example is [Kbin](https://github.com/ngi-nix/ngipkgs/tree/main/projects/Kbin).
+   An existing example is [AtomicData](https://github.com/ngi-nix/ngipkgs/tree/main/projects/AtomicData).
 
 1. Commit the changes and push the commits.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,10 +66,17 @@ Instead, write one sentence per line, as this makes it easier to review changes.
 
    An existing example is [libgnunetchat](https://github.com/ngi-nix/ngipkgs/blob/main/pkgs/by-name/libgnunetchat/package.nix).
 
-1. To add a NixOS service module, start by creating a `default.nix` file in the directory `projects/some-project`.
+1. Check if the project already exists in `projects/some-project`.
+   If it does not exist, you can copy the project template and edit it with relevant details:
 
    ```shellSession
-   mkdir -p projects/some-project
+   cp -r templates/project projects/some-project
+   $EDITOR projects/some-project/default.nix
+   ```
+
+1. To add a NixOS service module, start by editing the `default.nix` file in the directory `projects/some-project`.
+
+   ```shellSession
    $EDITOR projects/some-project/default.nix
    ```
 


### PR DESCRIPTION
We should probably add new project/package templates somewhere, instead of linking examples. With this, the documentation links won't point to outdated formats and users can just copy that and start working.