### PR TITLE
Add project template

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -109,6 +109,10 @@ rec {
 
   project-models = import ./projects/models.nix { inherit lib pkgs sources; };
 
+  templates.project = project-models.project (
+    import ./templates/project { inherit lib pkgs sources; }
+  );
+
   # TODO: find a better place for this
   metrics = with lib; {
     projects = attrNames raw-projects;

--- a/flake.nix
+++ b/flake.nix
@@ -224,6 +224,8 @@
                 };
                 "infra/makemake" = toplevel self.nixosConfigurations.makemake;
                 "infra/overview" = self.packages.${system}.overview;
+                # fake derivation for flake check
+                "infra/templates" = pkgs.writeText "dummy" (lib.strings.toJSON classic'.templates.project);
               };
             in
             checksForInfrastructure // checksForAllProjects // checksForAllPackages;

--- a/templates/project/default.nix
+++ b/templates/project/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  pkgs,
+  sources,
+}@args:
+{
+  # NOTE:
+  # - Check `projects/models.nix` for a more detailed project structure
+  # - Each program/service must have at least one example
+  # - Set attributes to `null` to indicate that they're needed, but not available
+  metadata = {
+    summary = "";
+    subgrants = [
+      "FooBar"
+      "FooBar-cli"
+    ];
+  };
+
+  nixos.modules.programs = {
+    foobar = {
+      name = "foobar";
+      module = ./module.nix;
+      examples.foobar = {
+        module = ./example.nix;
+        description = "";
+        tests.basic = ./test.nix;
+      };
+      links = {
+        build = {
+          text = "FooBar Documentation";
+          url = "https://foo.bar/build";
+        };
+        test = {
+          text = "FooBar Documentation";
+          url = "https://foo.bar/test";
+        };
+      };
+    };
+
+    # needed, but not available
+    foobar-cli = null;
+  };
+
+  # NOTE: same structure as programs
+  nixos.modules.services = {
+  };
+}

--- a/templates/project/example.nix
+++ b/templates/project/example.nix
@@ -1,0 +1,4 @@
+{ ... }:
+{
+  programs.foobar.enable = true;
+}

--- a/templates/project/module.nix
+++ b/templates/project/module.nix
@@ -1,0 +1,6 @@
+{ lib, ... }:
+{
+  options.programs.foobar = {
+    enable = lib.mkEnableOption "foobar";
+  };
+}

--- a/templates/project/test.nix
+++ b/templates/project/test.nix
@@ -1,0 +1,27 @@
+{
+  sources,
+  ...
+}:
+{
+  name = "foobar";
+
+  nodes = {
+    machine =
+      { ... }:
+      {
+        imports = [
+          sources.modules.ngipkgs
+          sources.modules.programs.foobar
+          sources.examples.Foobar.foobar
+        ];
+      };
+  };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      start_all()
+
+      machine.succeed("foobar --help")
+    '';
+}


### PR DESCRIPTION
This adds a template for projects which can easily be copied to `projects/`. It also adds the template to the flake check to make sure that it's typed correctly. 

Related: https://github.com/ngi-nix/ngipkgs/issues/573