### PR TITLE
openXC7: Import upstream packages, add project

### DIFF
--- a/pkgs/by-name/openxc7/nix/fasm/default.nix
+++ b/pkgs/by-name/openxc7/nix/fasm/default.nix
@@ -1,0 +1,54 @@
+# https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/python.section.md
+
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  cmake,
+  textx,
+  cython,
+  fetchpatch,
+}:
+
+buildPythonPackage rec {
+  name = "fasm";
+  version = "0.0.2.r98.g9a73d70";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    inherit name;
+    owner = "openxc7";
+    repo = "fasm";
+    rev = "2f57ccb1727a120e8cacbb95c578f3c71bdcc95a";
+    hash = "sha256-ZytcNJvXs+GUSIrf4dtYl+Hc5kEQmeJP+3BQOmQImIw=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    cython
+  ];
+
+  propagatedBuildInputs = [
+    textx
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  # Broken upstream.
+  # https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=python-fasm-git#n76
+  doCheck = false;
+
+  meta = with lib; {
+    changelog = "https://github.com/chipsalliance/fasm/releases/tag/${version}";
+    homepage = "https://github.com/chipsalliance/fasm/";
+    description = "FPGA Assembly (FASM) Parser and Generator";
+    license = licenses.asl20;
+    maintainers = with maintainers; [
+      jleightcap
+      hansfbaier
+    ];
+  };
+}

--- a/pkgs/by-name/openxc7/nix/nextpnr-xilinx-chipdb.nix
+++ b/pkgs/by-name/openxc7/nix/nextpnr-xilinx-chipdb.nix
@@ -1,0 +1,81 @@
+{
+  stdenv,
+  nixpkgs,
+  backend,
+  nextpnr-xilinx,
+  prjxray,
+  pypy310,
+  coreutils,
+  findutils,
+  gnused,
+  gnugrep,
+  ...
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nextpnr-xilinx-chipdb";
+  version = nextpnr-xilinx.version;
+  inherit backend;
+
+  src = "${nextpnr-xilinx.outPath}/share/nextpnr/external/prjxray-db";
+  # Don't try to unpack src, it already exists
+  dontUnpack = true;
+
+  buildInputs = [
+    prjxray
+    nextpnr-xilinx
+    pypy310
+    coreutils
+    findutils
+    gnused
+    gnugrep
+  ];
+  buildPhase = ''
+    mkdir -p $out
+    find ${src}/ -type d -name "*-*" -mindepth 1 -maxdepth 2 |\
+      sed -e 's,.*/\(.*\)-.*$,\1,g' -e 's,\./,,g' |\
+      sort |\
+      uniq >\
+    $out/footprints.txt
+
+    touch $out/built-footprints.txt
+
+    for i in `cat $out/footprints.txt`
+    do
+        if   [[ $i = xc7a* ]]; then ARCH=artix7 
+        elif [[ $i = xc7k* ]]; then ARCH=kintex7
+        elif [[ $i = xc7s* ]]; then ARCH=spartan7
+        elif [[ $i = xc7z* ]]; then ARCH=zynq7
+        else 
+          echo "unsupported architecture for footprint $i"
+          exit 1
+        fi
+
+        if [[ $ARCH != "${backend}" ]]; then
+          continue
+        fi
+
+        FIRST_SPEEDGRADE_DIR=`ls -d ${src}/$ARCH/$i-* | sort -n | head -1`
+        FIRST_SPEEDGRADE=`echo $FIRST_SPEEDGRADE_DIR | tr '/' '\n' | tail -1`
+        pypy3.10 ${nextpnr-xilinx}/share/nextpnr/python/bbaexport.py --device $FIRST_SPEEDGRADE --bba $i.bba 2>&1
+        bbasm -l $i.bba $out/$i.bin
+        echo $i >> $out/built-footprints.txt
+    done
+
+    mv -f $out/built-footprints.txt $out/footprints.txt
+
+    # make the chipdb directory available
+    mkdir -p $out/bin
+    cat > $out/bin/get_chipdb_${backend}.sh <<EOF
+    #!${nixpkgs.runtimeShell}
+    echo -n $out
+    EOF
+    chmod 755 $out/bin/get_chipdb_${backend}.sh
+  '';
+
+  # TODO(jleightcap): the above buildPhase is adapated from a `builder`; which combines the process of
+  # compiling assets along with installing those assets to `$out`.
+  # These steps should be untangled, ideally - for now just use the buildPhase and disable the (empty)
+  # installPhase.
+  dontInstall = true;
+}

--- a/pkgs/by-name/openxc7/nix/nextpnr-xilinx.nix
+++ b/pkgs/by-name/openxc7/nix/nextpnr-xilinx.nix
@@ -1,0 +1,60 @@
+{
+  stdenv,
+  cmake,
+  git,
+  lib,
+  fetchFromGitHub,
+  python312Packages,
+  python312,
+  eigen,
+  llvmPackages,
+  ...
+}:
+stdenv.mkDerivation rec {
+  pname = "nextpnr-xilinx";
+  version = "0.8.2";
+
+  src = fetchFromGitHub {
+    owner = "openXC7";
+    repo = "nextpnr-xilinx";
+    rev = "3374e5a62b54dc346fd5f85188ed24075ddfd5fb";
+    hash = "sha256-gW3Z3Cd5/gfX7k/ekRHtPVlbhKszWah1L+HggMFKakA=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    git
+  ];
+  buildInputs = [
+    python312Packages.boost
+    python312
+    eigen
+  ] ++ (lib.optionals stdenv.cc.isClang [ llvmPackages.openmp ]);
+
+  cmakeFlags = [
+    "-DCURRENT_GIT_VERSION=${lib.substring 0 7 src.rev}"
+    "-DARCH=xilinx"
+    "-DBUILD_GUI=OFF"
+    "-DBUILD_TESTS=OFF"
+    "-DUSE_OPENMP=ON"
+    "-Wno-deprecated"
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp nextpnr-xilinx bbasm $out/bin/
+    mkdir -p $out/share/nextpnr/external
+    cp -rv ../xilinx/external/prjxray-db $out/share/nextpnr/external/
+    cp -rv ../xilinx/external/nextpnr-xilinx-meta $out/share/nextpnr/external/
+    cp -rv ../xilinx/python/ $out/share/nextpnr/python/
+    cp ../xilinx/constids.inc $out/share/nextpnr
+  '';
+
+  meta = with lib; {
+    description = "Place and route tool for FPGAs";
+    homepage = "https://github.com/openXC7/nextpnr-xilinx";
+    license = licenses.isc;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/by-name/openxc7/nix/prjxray.nix
+++ b/pkgs/by-name/openxc7/nix/prjxray.nix
@@ -1,0 +1,58 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  git,
+  python312Packages,
+  eigen,
+  python312,
+  ...
+}:
+stdenv.mkDerivation rec {
+  pname = "prjxray";
+  version = "bdbc665852b82f589ff775a8f6498542dbec0a07";
+
+  src = fetchFromGitHub {
+    owner = "f4pga";
+    repo = "prjxray";
+    rev = "bdbc665852b82f589ff775a8f6498542dbec0a07";
+    fetchSubmodules = true;
+    hash = "sha256-lV4o62lS7CMG0EYPhp9bTB4fg0hOixy8CC8yGxKhGQE=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    git
+  ];
+  buildInputs = [
+    python312Packages.boost
+    python312
+    eigen
+  ];
+
+  patchPhase = ''
+    sed -i 's/cmake /cmake -Wno-deprecated /g' Makefile
+    sed -i '29 itarget_compile_options(libprjxray PUBLIC "-Wno-deprecated")' lib/CMakeLists.txt
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -v tools/xc7frames2bit tools/bitread tools/xc7patch $out/bin
+    cp -v $srcs/utils/fasm2frames.py $out/bin/fasm2frames
+    chmod 755 $out/bin/fasm2frames
+    cp -v $srcs/utils/bit2fasm.py $out/bin/bit2fasm
+    chmod 755 $out/bin/bit2fasm
+    mkdir -p $out/usr/share/python3/
+    cp -rv $srcs/prjxray $out/usr/share/python3/
+  '';
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Xilinx series 7 FPGA bitstream documentation";
+    homepage = "https://github.com/f4pga/prjxray";
+    license = licenses.isc;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/by-name/openxc7/nix/yosys-synlig.nix
+++ b/pkgs/by-name/openxc7/nix/yosys-synlig.nix
@@ -1,0 +1,91 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  pkg-config,
+  antlr4,
+  capnproto,
+  readline,
+  surelog,
+  uhdm,
+  yosys,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "yosys-synlig";
+  plugin = "synlig";
+
+  # The module has automatic regular releases, with date + short git hash
+  GIT_VERSION = "2024-03-13-d844d8d";
+
+  # Derive our package version from GIT_VERSION, remove hash, just keep date.
+  version = builtins.concatStringsSep "-" (lib.take 3 (builtins.splitVersion finalAttrs.GIT_VERSION));
+
+  src = fetchFromGitHub {
+    owner = "chipsalliance";
+    repo = "synlig";
+    rev = "${finalAttrs.GIT_VERSION}";
+    hash = "sha256-PODeQL8n34Ekq4NQJ5/w9pTkfkBc77osZc7JzEOUk6I=";
+    fetchSubmodules = false; # we use all dependencies from nix
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    antlr4.runtime.cpp
+    capnproto
+    readline
+    surelog
+    uhdm
+    yosys
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    # Remove assumptions that submodules are available.
+    rm -f third_party/Build.*.mk
+
+    # Create a stub makefile include that delegates the parameter-gathering
+    # to yosys-config
+    cat > third_party/Build.yosys.mk << "EOF"
+    t  := yosys
+    ts := ''$(call GetTargetStructName,''${t})
+
+    ''${ts}.src_dir   := ''$(shell yosys-config --datdir/include)
+    ''${ts}.mod_dir   := ''${TOP_DIR}third_party/yosys_mod/
+    EOF
+
+    make -j $NIX_BUILD_CORES build@systemverilog-plugin \
+            LDFLAGS="''$(yosys-config --ldflags --ldlibs)"
+    runHook postBuild
+  '';
+
+  # Check that the plugin can be loaded successfully and parse simple file.
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    echo "module litmustest(); endmodule;" > litmustest.sv
+    yosys -p "plugin -i build/release/systemverilog-plugin/systemverilog.so;\
+              read_systemverilog litmustest.sv"
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/yosys/plugins
+    cp ./build/release/systemverilog-plugin/systemverilog.so \
+           $out/share/yosys/plugins/systemverilog.so
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "SystemVerilog support plugin for Yosys";
+    homepage = "https://github.com/chipsalliance/synlig";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hzeller ];
+    platforms = platforms.all;
+  };
+})

--- a/pkgs/by-name/openxc7/package.nix
+++ b/pkgs/by-name/openxc7/package.nix
@@ -7,6 +7,7 @@
   writeShellApplication,
   bashInteractive,
   ghdl,
+  gnat-bootstrap,
   makeWrapper,
   openfpgaloader,
   pkgs,
@@ -143,5 +144,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     inherit (shellScript.meta) mainProgram;
     platforms = lib.platforms.linux;
+    # ghdl -> gnat -> gnat-bootstrap only available for very specific platforms
+    # Mark broken if bootstrapping gnat is unavailable, to keep CI green
+    broken = !lib.meta.availableOn stdenvNoCC.hostPlatform gnat-bootstrap;
   };
 })

--- a/pkgs/by-name/openxc7/package.nix
+++ b/pkgs/by-name/openxc7/package.nix
@@ -31,30 +31,46 @@ let
       ;
   };
   nextpnr-xilinx-chipdb = {
-    artix7 = callPackage ./nix/nextpnr-xilinx-chipdb.nix {
-      backend = "artix7";
-      nixpkgs = pkgs;
-      inherit nextpnr-xilinx;
-      inherit prjxray;
-    };
-    kintex7 = callPackage ./nix/nextpnr-xilinx-chipdb.nix {
-      backend = "kintex7";
-      nixpkgs = pkgs;
-      inherit nextpnr-xilinx;
-      inherit prjxray;
-    };
-    spartan7 = callPackage ./nix/nextpnr-xilinx-chipdb.nix {
-      backend = "spartan7";
-      nixpkgs = pkgs;
-      inherit nextpnr-xilinx;
-      inherit prjxray;
-    };
-    zynq7 = callPackage ./nix/nextpnr-xilinx-chipdb.nix {
-      backend = "zynq7";
-      nixpkgs = pkgs;
-      inherit nextpnr-xilinx;
-      inherit prjxray;
-    };
+    artix7 =
+      (callPackage ./nix/nextpnr-xilinx-chipdb.nix {
+        backend = "artix7";
+        nixpkgs = pkgs;
+        inherit nextpnr-xilinx;
+        inherit prjxray;
+      }).overrideAttrs
+        (oa: {
+          pname = "${oa.pname}-artix7";
+        });
+    kintex7 =
+      (callPackage ./nix/nextpnr-xilinx-chipdb.nix {
+        backend = "kintex7";
+        nixpkgs = pkgs;
+        inherit nextpnr-xilinx;
+        inherit prjxray;
+      }).overrideAttrs
+        (oa: {
+          pname = "${oa.pname}-kintex7";
+        });
+    spartan7 =
+      (callPackage ./nix/nextpnr-xilinx-chipdb.nix {
+        backend = "spartan7";
+        nixpkgs = pkgs;
+        inherit nextpnr-xilinx;
+        inherit prjxray;
+      }).overrideAttrs
+        (oa: {
+          pname = "${oa.pname}-spartan7";
+        });
+    zynq7 =
+      (callPackage ./nix/nextpnr-xilinx-chipdb.nix {
+        backend = "zynq7";
+        nixpkgs = pkgs;
+        inherit nextpnr-xilinx;
+        inherit prjxray;
+      }).overrideAttrs
+        (oa: {
+          pname = "${oa.pname}-zynq7";
+        });
   };
 
   # Adapted from upstream's flake.nix outputs.devShell
@@ -136,6 +152,20 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru.packages = {
+    inherit
+      nextpnr-xilinx
+      prjxray
+      fasm
+      ;
+    inherit (nextpnr-xilinx-chipdb)
+      artix7
+      kintex7
+      spartan7
+      zynq7
+      ;
+  };
 
   meta = {
     description = "Open-source FPGA toolchain for AMD/Xilinx Series 7 chips";

--- a/pkgs/by-name/openxc7/package.nix
+++ b/pkgs/by-name/openxc7/package.nix
@@ -1,0 +1,147 @@
+{
+  stdenvNoCC,
+  lib,
+  callPackage,
+  fetchFromGitHub,
+  fetchpatch,
+  writeShellApplication,
+  bashInteractive,
+  ghdl,
+  makeWrapper,
+  openfpgaloader,
+  pkgs,
+  pypy310,
+  python3Packages,
+  yosys,
+  yosys-ghdl,
+}:
+
+let
+  # Adapted from upstream's flake.nix outputs.packages
+  nextpnr-xilinx = callPackage ./nix/nextpnr-xilinx.nix { };
+  prjxray = callPackage ./nix/prjxray.nix { };
+  fasm = callPackage ./nix/fasm {
+    inherit fetchpatch;
+    inherit (python3Packages)
+      buildPythonPackage
+      pythonOlder
+      textx
+      cython
+      ;
+  };
+  nextpnr-xilinx-chipdb = {
+    artix7 = callPackage ./nix/nextpnr-xilinx-chipdb.nix {
+      backend = "artix7";
+      nixpkgs = pkgs;
+      inherit nextpnr-xilinx;
+      inherit prjxray;
+    };
+    kintex7 = callPackage ./nix/nextpnr-xilinx-chipdb.nix {
+      backend = "kintex7";
+      nixpkgs = pkgs;
+      inherit nextpnr-xilinx;
+      inherit prjxray;
+    };
+    spartan7 = callPackage ./nix/nextpnr-xilinx-chipdb.nix {
+      backend = "spartan7";
+      nixpkgs = pkgs;
+      inherit nextpnr-xilinx;
+      inherit prjxray;
+    };
+    zynq7 = callPackage ./nix/nextpnr-xilinx-chipdb.nix {
+      backend = "zynq7";
+      nixpkgs = pkgs;
+      inherit nextpnr-xilinx;
+      inherit prjxray;
+    };
+  };
+
+  # Adapted from upstream's flake.nix outputs.devShell
+  shellScript = writeShellApplication {
+    name = "openxc7-env";
+    runtimeInputs =
+      [
+        fasm
+        prjxray
+        nextpnr-xilinx
+
+        yosys
+        ghdl
+        yosys-ghdl
+        openfpgaloader
+        pypy310
+      ]
+      ++ (with python3Packages; [
+        pyyaml
+        textx
+        simplejson
+        intervaltree
+      ]);
+    runtimeEnv = {
+      "NEXTPNR_XILINX_DIR" = "${nextpnr-xilinx}";
+      "NEXTPNR_XILINX_PYTHON_DIR" = "${nextpnr-xilinx}/share/nextpnr/python/";
+      "PRJXRAY_DB_DIR" = "${nextpnr-xilinx}/share/nextpnr/external/prjxray-db";
+      "PRJXRAY_PYTHON_DIR" = "${prjxray}/usr/share/python3/";
+      "PYTHONPATH" = lib.strings.concatStringsSep ":" [
+        "${prjxray}/usr/share/python3"
+        (python3Packages.makePythonPath (
+          [
+            fasm
+          ]
+          ++ (with python3Packages; [
+            textx
+            arpeggio
+            pyyaml
+            simplejson
+            intervaltree
+            sortedcontainers
+          ])
+        ))
+      ];
+      "PYPY3" = lib.getExe pypy310;
+      "SPARTAN7_CHIPDB" = "${nextpnr-xilinx-chipdb.spartan7}";
+      "ARTIX7_CHIPDB" = "${nextpnr-xilinx-chipdb.artix7}";
+      "KINTEX7_CHIPDB" = "${nextpnr-xilinx-chipdb.kintex7}";
+      "ZYNQ7_CHIPDB" = "${nextpnr-xilinx-chipdb.zynq7}";
+    };
+    text = ''
+      exec ${lib.getExe bashInteractive} "$@"
+    '';
+  };
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "openxc7";
+  version = "0.8.2-unstable-2025-03-14";
+
+  # We can't use upstream's files via fetched src without introducing IFD
+  # or pushing the building onto the user - which makes internet-less VM testing
+  # hard. This is only here to show the base from which the above code was
+  # copied from.
+  src = fetchFromGitHub {
+    owner = "openXC7";
+    repo = "toolchain-nix";
+    rev = "f358781e5c21a59ab9c8c10f03beb81d8f8e468a";
+    hash = "sha256-KwFHIGKzY5SdXPbhXj9LcHRlj2MPHVrmam8QECzWysY=";
+  };
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 ${lib.getExe shellScript} $out/bin/${shellScript.meta.mainProgram}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Open-source FPGA toolchain for AMD/Xilinx Series 7 chips";
+    homepage = "https://github.com/openXC7/toolchain-nix";
+    # for the toolchain repo, individual packages have their appropriate licenses
+    license = lib.licenses.mit;
+    inherit (shellScript.meta) mainProgram;
+    platforms = lib.platforms.linux;
+  };
+})

--- a/projects/openXC7/default.nix
+++ b/projects/openXC7/default.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  pkgs,
+  sources,
+}@args:
+{
+  metadata = {
+    summary = ''
+      Improve hardware support for open source FPGA tooling
+    '';
+    subgrants = [
+      "openXC7"
+    ];
+  };
+
+  nixos.modules.programs = {
+    openxc7 = {
+      name = "openXC7";
+      module = ./module.nix;
+      examples.openxc7 = {
+        module = ./example.nix;
+        description = "";
+        tests.compile-example = import ./test.nix args;
+      };
+    };
+  };
+}

--- a/projects/openXC7/example.nix
+++ b/projects/openXC7/example.nix
@@ -1,0 +1,7 @@
+{ ... }:
+{
+  programs.openxc7.enable = true;
+
+  # You should still setup a development shell for any project that needs these
+  # tools, to get basic things like make etc.
+}

--- a/projects/openXC7/module.nix
+++ b/projects/openXC7/module.nix
@@ -1,0 +1,18 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.programs.openxc7;
+in
+{
+  options.programs.openxc7 = {
+    enable = lib.mkEnableOption "openXC7 environment";
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = with pkgs; [ openxc7 ];
+  };
+}

--- a/projects/openXC7/test.nix
+++ b/projects/openXC7/test.nix
@@ -1,0 +1,48 @@
+{
+  sources,
+  ...
+}:
+{
+  name = "openxc7";
+
+  nodes = {
+    machine =
+      { pkgs, ... }:
+      {
+        imports = [
+          sources.modules.ngipkgs
+          sources.modules.programs.openxc7
+          sources.examples.openXC7.openxc7
+        ];
+
+        # Running OOM while building
+        virtualisation.memorySize = 4096;
+
+        environment = {
+          etc."demo-projects".source = pkgs.fetchFromGitHub {
+            owner = "openXC7";
+            repo = "demo-projects";
+            rev = "bceb172c3e11841e3289b0f604aed8ca1f15bbd5";
+            hash = "sha256-gO9avqJnebp4AmziEjdj7OkYdJRE3wjhx+cdwBhxcZQ=";
+          };
+
+          systemPackages = with pkgs; [
+            # Demo project needs make to run the build
+            gnumake
+          ];
+        };
+      };
+  };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      start_all()
+
+      # We need it writable
+      machine.succeed("cp -Lr --no-preserve=all /etc/demo-projects /root/demo-projects >&2")
+
+      # Build an example
+      machine.succeed("openxc7-env -c -- 'make -C /root/demo-projects/blinky-qmtech >&2'")
+    '';
+}


### PR DESCRIPTION
Closes #552

https://github.com/openXC7/toolchain-nix contains upstream's Nix code for the toolchain, but we can't just `fetchFromGitHub` that & pass everything through as-is

- We can't do `import` or `callPackage` any of the downloaded files, because that would re-introduce IFD to the repo after it was previously removed from it treewide.
- We *could* just copy the src into `out` and make a shell script that wraps Nix to run `nix develop` inside of the downloaded checkout, but
  1. `nix` is dumb and sees `nix develop /nix/store/...` as "oh, you want me to build a derivation based on this store path… sorry, i can't parse this into a derivation!", necessitating some directory changing shenanigans
  2. It makes it impossible to test that setup in a VM, since that would require internet access for Nix to resolve URLs for downloads… unless we re-introduce IFD and finangle the VM environment to have everything pre-downloaded maybe?

So that left me with one option: Copy the relevant files from the repo into here, and replicate some setup code from the flake to build a wrapper that adds things to the environment, similar to a development shell (whose output we can't just use as-is, because the generated file in the store is commented with "this is an implementation detail, do not have any expectations for this path).

As a result, `src` is kinda useless, only serving as a pointer to what version of the repo the code was copied from.

Formatting of the copied files differs from upstream due to our pre-commit hook forcing a reformatting.

Really not happy with any of this, but given the situation described above, it is what it is…