### PR TITLE
Make contributors admins on buildbot

### DIFF
--- a/infra/makemake/buildbot.nix
+++ b/infra/makemake/buildbot.nix
@@ -18,6 +18,10 @@ in
         "fricklerhandwerk"
         "Janik-Haag"
         "lorenzleutgeb"
+        "eljamm"
+        "erictapen"
+        "imincik"
+        "OPNA2608"
       ];
       workersFile = secret "workers";
       github = {

--- a/infra/makemake/configuration.nix
+++ b/infra/makemake/configuration.nix
@@ -124,6 +124,10 @@
       enable = true;
       settings.PasswordAuthentication = false;
     };
+    prometheus.exporters.node = {
+      enable = true;
+      openFirewall = true;
+    };
   };
 
   fileSystems = {


### PR DESCRIPTION
This will:
* Make Kerstin/Fedi/Ivan/Cosima admins on buildbot
* Enable prometheus node exporter on makemake so we have metrics about host utilisation