### PR TITLE
overview: don't escape option descriptions

### DIFF
--- a/overview/default.nix
+++ b/overview/default.nix
@@ -84,7 +84,7 @@ let
             <table>
               <tr>
                 <td>Description:</td>
-                <td>${lib.escapeXML option.description}</td>
+                <td>${option.description}</td>
               </tr>
               <tr>
                 <td>Type:</td>


### PR DESCRIPTION
This puts us at risk of XSS by an attacker submitting malicious option descriptions to Nixpkgs/NGIpkgs. At the same time the xml escaping fucks up some description texts, as what we'd actually need is Markdown escaping.

I'd argue that the former is a managable risk, while the latter is unaccaptable.

Before:
![tmp mUOCs2rnkB](https://github.com/user-attachments/assets/1d4024a5-ccf5-419e-9bfe-589bf1405492)

After:
![tmp bomlRULMzL](https://github.com/user-attachments/assets/41941c13-a946-42f3-80cf-0fb62a6e8730)
