### PR TITLE
proximity-matcher Add package & project

### DIFF
--- a/pkgs/by-name/proximity-matcher/package.nix
+++ b/pkgs/by-name/proximity-matcher/package.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+}:
+
+let
+  py-tlsh = python3Packages.tlsh.overrideAttrs (oa: rec {
+    pname = "py-tlsh";
+    version = "4.7.2";
+
+    src = fetchFromGitHub {
+      owner = "trendmicro";
+      repo = "tlsh";
+      tag = version;
+      hash = "sha256-fmec8E0LblmBpleHRsJPWO7S3cIbBtFVcHsYQJY/Pns=";
+    };
+
+    postConfigure = ''
+      cd ..
+      find py_ext -maxdepth 1 -type f -exec mv -t $PWD {} \;
+      mv -t $PWD py_ext/pypi_package/*
+      rmdir py_ext/pypi_package
+      rmdir py_ext
+    '';
+  });
+in
+python3Packages.buildPythonPackage {
+  pname = "proximity-matcher";
+  version = "0-unstable-2023-12-23";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "armijnhemel";
+    repo = "proximity_matcher_webservice";
+    rev = "45675b2abab3596b9bc676fc3e6d643c12528850";
+    hash = "sha256-1MKJhAE9twxFOjdSUd+SaX+6hsuGG6o9NJ2IIGvKGos=";
+  };
+
+  build-system = with python3Packages; [
+    poetry-core
+  ];
+
+  dependencies =
+    [
+      py-tlsh
+    ]
+    ++ (with python3Packages; [
+      click
+      flask
+      gevent
+      gunicorn
+      pyyaml
+      requests
+    ]);
+
+  pythonRelaxDeps = [
+    "flask"
+    "gevent"
+    "gunicorn"
+  ];
+
+  postInstall = ''
+    for example in prepare_tlsh_hashes test_licenses walk_software_heritage_blobs; do
+      install -Dm755 examples/software_heritage_licenses/"$example".py $out/bin/"$example"
+    done
+  '';
+
+  # required for gunicorn (which is called as an executable from python) to work
+  makeWrapperArgs = [
+    "--prefix PYTHONPATH : $out${python3Packages.python.sitePackages}"
+  ];
+
+  pythonImportsCheck = [
+    "proximity_matcher_webservice"
+  ];
+
+  meta = {
+    description = "Webservice for proximity matching based on TLSH and vantage point trees";
+    homepage = "https://github.com/armijnhemel/proximity_matcher_webservice";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+  };
+}

--- a/projects/proximity-matcher/default.nix
+++ b/projects/proximity-matcher/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  pkgs,
+  sources,
+}@args:
+{
+  metadata = {
+    summary = ''
+      Webservice for proximity matching based on TLSH and vantage point trees.
+    '';
+    subgrants = [
+      # Not listed online?
+    ];
+  };
+
+  nixos.modules.services = {
+    proximity-matcher = {
+      name = "proximity-matcher";
+      module = ./module.nix;
+      examples.basic = {
+        module = ./example.nix;
+        description = ''
+          Sets up proximity-matcher with a basic configuration for TLSH and a location with known hashes.
+        '';
+        tests.basic = import ./test.nix args;
+      };
+      links = {
+        readme = {
+          text = "Project README";
+          url = "https://github.com/armijnhemel/proximity_matcher_webservice/blob/main/README.md";
+        };
+      };
+    };
+  };
+}

--- a/projects/proximity-matcher/example.nix
+++ b/projects/proximity-matcher/example.nix
@@ -1,0 +1,8 @@
+{ ... }:
+{
+  services.proximity-matcher = {
+    enable = true;
+    hashesPicklePath = "/var/lib/proximity-matcher/hashes.pickle";
+    hashesPath = "/var/lib/proximity-matcher/hashes";
+  };
+}

--- a/projects/proximity-matcher/module.nix
+++ b/projects/proximity-matcher/module.nix
@@ -1,0 +1,96 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.proximity-matcher;
+in
+{
+  options.services.proximity-matcher = {
+    enable = lib.mkEnableOption "proximity-matcher";
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.proximity-matcher;
+      description = "The package to use.";
+    };
+    listenAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = "The address the webservice should listen on.";
+    };
+    listenPort = lib.mkOption {
+      type = lib.types.port;
+      default = 5000;
+      description = "The port the webservice should listen on.";
+    };
+    hashesPicklePath = lib.mkOption {
+      type = lib.types.path;
+      description = "Path to the pickle with TLSH hashes.";
+    };
+    hashesPath = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Path to a file with TLSH hashes, formatted as one hash per line.
+
+        It is only used with the optimized version of the server.
+      '';
+    };
+    optimized = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Whether to use the optimized version of the server.";
+    };
+    workers = lib.mkOption {
+      type = lib.types.int;
+      default = 4;
+      description = "The number of workers gunicorn should use.";
+    };
+    timeout = lib.mkOption {
+      type = lib.types.int;
+      default = 60;
+      description = "The timeout in seconds for workers of the optimized server.";
+    };
+  };
+  config = {
+    systemd.services.proximity-matcher = lib.mkIf cfg.enable {
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      environment = {
+        PROXIMITY_CONFIGURATION = pkgs.writeText "proximity_config.py" (
+          ''
+            TLSH_PICKLE_FILE = '${cfg.hashesPicklePath}'
+          ''
+          + lib.optionalString (!(isNull cfg.hashesPath)) ''
+            KNOWN_TLSH_HASHES = '${cfg.hashesPath}'
+          ''
+        );
+      };
+      serviceConfig = {
+        ExecStart = "${
+          lib.getExe' (pkgs.python3.withPackages (_: [ cfg.package ])) "gunicorn"
+        } -w ${toString cfg.workers} -b ${cfg.listenAddress}:${toString cfg.listenPort} --preload${lib.optionalString cfg.optimized " -t ${toString cfg.timeout}"} proximity_matcher_webservice.proximity_server${lib.optionalString cfg.optimized "_opt"}:app";
+
+        # from systemd-analyze --no-pager security proximity-matcher.service
+        CapabilityBoundingSet = null;
+        DynamicUser = true;
+        MemoryDenyWriteExecute = true;
+        PrivateDevices = true;
+        PrivateUsers = true;
+        ProtectHome = true;
+        ProtectKernelLogs = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = "@system-service";
+      };
+    };
+  };
+}

--- a/projects/proximity-matcher/test.nix
+++ b/projects/proximity-matcher/test.nix
@@ -1,0 +1,55 @@
+{
+  sources,
+  ...
+}:
+{
+  name = "proximity-matcher";
+
+  nodes = {
+    machine =
+      {
+        config,
+        lib,
+        pkgs,
+        ...
+      }:
+      {
+        imports = [
+          sources.modules.ngipkgs
+          sources.modules.services.proximity-matcher
+          sources.examples.proximity-matcher.basic
+        ];
+
+        environment.systemPackages = with pkgs; [
+          jq
+        ];
+
+        # Generate some data for testing
+        systemd.services.proximity-matcher_setup = {
+          wantedBy = [ "multi-user.target" ];
+          before = [ "proximity-matcher.service" ];
+          script = ''
+            mkdir -p /var/lib/proximity-matcher
+            cd /var/lib/proximity-matcher
+            mkdir testfiles
+            cp ${config.services.proximity-matcher.package.src}/LICENSE testfiles
+            ${lib.getExe' config.services.proximity-matcher.package "prepare_tlsh_hashes"} -i testfiles -o hashes
+            ${lib.getExe' config.services.proximity-matcher.package "create-vpt-pickle"} -i hashes -o hashes.pickle
+          '';
+        };
+      };
+  };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      start_all()
+
+      machine.wait_for_open_port(5000)
+      machine.succeed(
+        r"""curl -s http://127.0.0.1:5000/tlsh/$(cat ${nodes.machine.services.proximity-matcher.hashesPath})""" \
+        " | jq -cS ." \
+        r""" | grep -E '^{"distance":0,"match":true,"tlsh":"'"$(cat ${nodes.machine.services.proximity-matcher.hashesPath})"'"}$'"""
+      )
+    '';
+}


### PR DESCRIPTION
Closes #550
Closes #587

`metadata.subgrants` of the project is still empty, cus I couldn't find the information for that.

Mostly imported from [upstream's Nix code](https://github.com/armijnhemel/proximity_matcher_webservice), except:

- Instead of building `py-tlsh` as a completely new package by fetching it from Pypi, we can override the existing package from Nixpkgs with the corresponding source. It involves moving some files around for the packaging code from the repo to work, because the pypi version has a slightly different config & package name(?), but it seems to work fine
- Had to relax some of the Python deps, due to the source's age
- Added a basic `pythonImportsCheck` test for the module
- In the module, instead of requiring a pre-assembled python env, just make a `python3.withPackages` with the module
- Use `lib.getExe'` for referring to executable paths where appropriate
- Split upstream's VM test file into an example config + a test that verifies that the config works
- Fix hardcoded paths in the test to instead use the values set in the config