### PR TITLE
openfire: 4.9.0 -> 4.9.2

### DIFF
--- a/pkgs/by-name/openfire/package.nix
+++ b/pkgs/by-name/openfire/package.nix
@@ -7,13 +7,13 @@
 }:
 maven.buildMavenPackage rec {
   pname = "openfire";
-  version = "4.9.0";
+  version = "4.9.2";
 
   src = fetchFromGitHub {
     owner = "igniterealtime";
     repo = "Openfire";
-    rev = "v${version}";
-    hash = "sha256-exZDH3wROQyw8WIQU1WZB3QoXseiSHueo3hiQrjQZGM=";
+    tag = "v${version}";
+    hash = "sha256-mnniMlLvz3Iq/MIWe/legVUVy1TIkNQzvagzgSbZ1is=";
   };
 
   mvnJdk = jdk_headless;


### PR DESCRIPTION
Resolves [issue](https://github.com/ngi-nix/ngipkgs/issues/653)
I avoided updating to `v5.0.0,` which is in alpha. It's better to bump to a stable release.