### PR TITLE
overview: only ever generate html, remove pandoc as dependency

### DIFF
--- a/overview/fixup.sed
+++ b/overview/fixup.sed
@@ -1,4 +1,0 @@
-# vnu complains about self-closing tags `<meta ... />` and `<link ... />`
-# in pandoc's output. See <https://github.com/jgm/pandoc/discussions/9345>.
-# Use sed to rewrite those tags.
-s#<\(link\|meta\) \(.*\) />#<\1 \2>#


### PR DESCRIPTION
For now this means that we can't render syntax highlighting in examples anymore.

The motivation for this is that markdown+raw_html shows some annoying edge cases, that make the code hard to work with.

Some examples:
- Markdown renders text indented by exactly 4 spaces as a code block, which is annoying when nesting HTML
- In some cases it's impossible to force text not to be rendered as a paragraph (HTML p element).