### PR TITLE
Package Mox as a service

### DIFF
--- a/projects/Mox/default.nix
+++ b/projects/Mox/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  pkgs,
+  sources,
+}@args:
+
+{
+  metadata = {
+    summary = "Modern full-featured open source secure mail server";
+    subgrants = [
+      "Mox"
+      "Mox-API"
+      "Mox-Automation"
+    ];
+    links = {
+      install = {
+        text = "Mox Install Documentation";
+        url = "https://www.xmox.nl/install/";
+      };
+      source = {
+        text = "Mox Github Repository";
+        url = "https://github.com/mjl-/mox";
+      };
+    };
+  };
+
+  nixos.modules.programs = {
+    mox = {
+      name = "mox";
+      module = ./programs/mox/module.nix;
+      examples.basic = {
+        module = ./programs/mox/examples/basic.nix;
+        description = "Use Mox subcommands to manage/debug the Mox server";
+        tests.basic = import ./programs/mox/tests/basic.nix args;
+      };
+    };
+  };
+
+  nixos.modules.services = {
+    mox = {
+      name = "mox";
+      module = ./services/mox/module.nix;
+      examples.basic = {
+        module = ./services/mox/examples/basic.nix;
+        description = "Mox server with optional hostname and user";
+        tests.basic = import ./services/mox/tests/basic.nix args;
+      };
+    };
+  };
+}

--- a/projects/Mox/programs/mox/examples/basic.nix
+++ b/projects/Mox/programs/mox/examples/basic.nix
@@ -1,0 +1,5 @@
+{ ... }:
+
+{
+  programs.mox.enable = true;
+}

--- a/projects/Mox/programs/mox/module.nix
+++ b/projects/Mox/programs/mox/module.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.mox;
+in
+{
+  options.programs.mox = {
+    enable = lib.mkEnableOption "mox";
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = with pkgs; [
+      mox
+    ];
+  };
+}

--- a/projects/Mox/programs/mox/tests/basic.nix
+++ b/projects/Mox/programs/mox/tests/basic.nix
@@ -1,0 +1,29 @@
+{
+  sources,
+  ...
+}:
+
+{
+  name = "Mox";
+
+  nodes = {
+    machine =
+      { ... }:
+      {
+        imports = [
+          sources.modules.ngipkgs
+          sources.modules.programs.mox
+          sources.examples.Mox.basic
+        ];
+      };
+  };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      start_all()
+
+      # List available SMTP config examples
+      machine.succeed("mox config example")
+    '';
+}

--- a/projects/Mox/services/mox/examples/basic.nix
+++ b/projects/Mox/services/mox/examples/basic.nix
@@ -4,4 +4,10 @@
   services.mox.enable = true;
   services.mox.hostname = "mail";
   services.mox.user = "admin@example.com";
+  services.mox.openFirewall = true;
+  services.mox.openPorts = [
+    25
+    80
+    443
+  ];
 }

--- a/projects/Mox/services/mox/examples/basic.nix
+++ b/projects/Mox/services/mox/examples/basic.nix
@@ -1,0 +1,7 @@
+{ ... }:
+
+{
+  services.mox.enable = true;
+  services.mox.hostname = "mail";
+  services.mox.user = "admin@example.com";
+}

--- a/projects/Mox/services/mox/examples/basic.nix
+++ b/projects/Mox/services/mox/examples/basic.nix
@@ -5,9 +5,7 @@
   services.mox.hostname = "mail";
   services.mox.user = "admin@example.com";
   services.mox.openFirewall = true;
-  services.mox.openPorts = [
-    25
-    80
-    443
-  ];
+  services.mox.ports.http = 80;
+  services.mox.ports.https = 443;
+  services.mox.ports.smtp = 25;
 }

--- a/projects/Mox/services/mox/module.nix
+++ b/projects/Mox/services/mox/module.nix
@@ -13,6 +13,7 @@ in
       # NOTE: The module uses contextual generated config files for the mox server.
       #       This is currently the most reproducible way to get mox running. However, it might
       #       be possible to use a declarative approach when the sconf config file is supported.
+      #       If addition configuration is needed, please edit the file and restert the service.
 
       enable = lib.mkEnableOption "Mox";
       package = lib.mkPackageOption pkgs "mox" { };
@@ -35,6 +36,21 @@ in
         type = lib.types.str;
         description = "*Required* Email user as (user@domain) to be created.";
       };
+      openPorts = lib.mkOption {
+        type = lib.types.listOf lib.types.int;
+        default = [
+          25
+          80
+          143
+          443
+        ];
+        description = "Ports to be opened for the Mox Mail Server";
+      };
+      openFirewall = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Open firewall for Mox Mail Server";
+      };
     };
   };
 
@@ -42,6 +58,12 @@ in
     environment.systemPackages = [
       cfg.package
     ];
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      enable = true;
+      allowedTCPPorts = cfg.openPorts;
+      allowedUDPPorts = [ 53 ];
+    };
 
     users.users.mox = {
       isSystemUser = true;

--- a/projects/Mox/services/mox/module.nix
+++ b/projects/Mox/services/mox/module.nix
@@ -1,0 +1,87 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.mox;
+in
+{
+  options = {
+    services.mox = {
+      # NOTE: The module uses contextual generated config files for the mox server.
+      #       This is currently the most reproducible way to get mox running. However, it might
+      #       be possible to use a declarative approach when the sconf config file is supported.
+
+      enable = lib.mkEnableOption "Mox";
+      package = lib.mkPackageOption pkgs "mox" { };
+      configFile = lib.mkOption {
+        type = lib.types.str;
+        default = "/var/lib/mox/config/mox.conf";
+        description = ''
+          Mox `quickstart` generates configuration files to quickly set up a mox instance.
+          This, is by far the easiest and most reproducible way to get mox running. All output from `quickstart`
+          is written to `quickstart.log`, including initial admin accounts and passwords. In this module, options
+          hostname and user are passed to `quickstart` as arguments and the config file are generated in that context.
+        '';
+      };
+      hostname = lib.mkOption {
+        type = lib.types.str;
+        default = "mail";
+        description = "Hostname for the Mox Mail Server";
+      };
+      user = lib.mkOption {
+        type = lib.types.str;
+        description = "*Required* Email user as (user@domain) to be created.";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      cfg.package
+    ];
+
+    users.users.mox = {
+      isSystemUser = true;
+      name = "mox";
+      group = "mox";
+      home = "/var/lib/mox";
+      createHome = true;
+      description = "Mox Mail Server User";
+    };
+    users.groups.mox = { };
+
+    systemd.services.mox-setup = {
+      description = "Mox Setup";
+      wantedBy = [ "multi-user.target" ];
+      requires = [
+        "network-online.target"
+      ];
+      after = [
+        "network-online.target"
+      ];
+      before = [ "mox.service" ];
+      serviceConfig = {
+        WorkingDirectory = "/var/lib/mox";
+        Type = "oneshot";
+        RemainAfterExit = true;
+        User = "mox";
+        Group = "mox";
+        ExecStart = "${pkgs.mox}/bin/mox quickstart -hostname ${config.services.mox.hostname} ${config.services.mox.user}";
+      };
+    };
+
+    systemd.services.mox = {
+      wantedBy = [ "multi-user.target" ];
+      after = [ "mox-setup.service" ];
+      requires = [ "mox-setup.service" ];
+      serviceConfig = {
+        WorkingDirectory = "/var/lib/mox";
+        ExecStart = "${pkgs.mox}/bin/mox -config /var/lib/mox/config/mox.conf serve";
+        Restart = "always";
+      };
+    };
+  };
+}

--- a/projects/Mox/services/mox/tests/basic.nix
+++ b/projects/Mox/services/mox/tests/basic.nix
@@ -24,13 +24,6 @@
           nameserver 127.0.0.1
         '';
 
-        networking.firewall.allowedTCPPorts = [
-          25 # SMTP
-          80 # HTTP
-          143 # IMAP
-          443 # HTTPS
-        ];
-        networking.firewall.allowedUDPPorts = [ 53 ];
         networking.nameservers = [ "127.0.0.1" ];
         networking.hosts = {
           "127.0.0.1" = [

--- a/projects/Mox/services/mox/tests/basic.nix
+++ b/projects/Mox/services/mox/tests/basic.nix
@@ -13,7 +13,7 @@
         imports = [
           sources.modules.ngipkgs
           sources.modules.services.mox
-          sources.examples.Mox.mox
+          sources.examples.Mox.basic
         ];
 
         environment.systemPackages = with pkgs; [
@@ -53,7 +53,6 @@
               "\"com.\" redirect"
             ];
             local-data = [
-              "\"mail.example.com. IN A 127.0.0.1\""
               "\"com. IN NS localhost\""
               "\"localhost. IN A 127.0.0.1\""
             ];

--- a/projects/Mox/services/mox/tests/basic.nix
+++ b/projects/Mox/services/mox/tests/basic.nix
@@ -1,0 +1,111 @@
+{
+  sources,
+  pkgs,
+  ...
+}:
+{
+  name = "mox";
+
+  nodes = {
+    machine =
+      { ... }:
+      {
+        imports = [
+          sources.modules.ngipkgs
+          sources.modules.services.mox
+          sources.examples.Mox.mox
+        ];
+
+        environment.systemPackages = with pkgs; [
+          mox
+          unbound
+        ];
+        environment.etc."resolv.conf".text = ''
+          nameserver 127.0.0.1
+        '';
+
+        networking.firewall.allowedTCPPorts = [
+          25 # SMTP
+          80 # HTTP
+          143 # IMAP
+          443 # HTTPS
+        ];
+        networking.firewall.allowedUDPPorts = [ 53 ];
+        networking.nameservers = [ "127.0.0.1" ];
+        networking.hosts = {
+          "127.0.0.1" = [
+            "com."
+            "mail.example.com"
+            "example.com"
+          ];
+        };
+
+        # Use unbound as a local DNS resolver and dissable DNSSEC validation
+        # Listen only on the localhost interface both for IPv4 and IPv6
+        # Define a local zone for com. to redirect queries to localhost and provide a static response
+        # Define static DNS records
+        services.unbound = {
+          enable = true;
+          resolveLocalQueries = true;
+          enableRootTrustAnchor = false;
+          settings = {
+            server = {
+              interface = [ "127.0.0.1" ];
+              access-control = [
+                "127.0.0.1/8 allow"
+                "::1/128 allow"
+              ];
+            };
+            local-zone = [
+              "\"com.\" redirect"
+            ];
+            local-data = [
+              "\"mail.example.com. IN A 127.0.0.1\""
+              "\"com. IN NS localhost\""
+              "\"localhost. IN A 127.0.0.1\""
+            ];
+          };
+        };
+
+        systemd.services.mox-setup = {
+          description = "Mox Setup";
+          wantedBy = [ "multi-user.target" ];
+          requires = [
+            "network-online.target"
+            "unbound.service"
+          ];
+          after = [
+            "network-online.target"
+            "unbound.service"
+          ];
+        };
+      };
+  };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      start_all()
+
+      # Wait for machine to be available
+      machine.wait_for_unit("multi-user.target")
+
+      # Verify the mox service is running
+      machine.wait_for_unit("mox.service")
+
+      # Verify config file exists
+      machine.succeed("test -f /var/lib/mox/config/mox.conf")
+
+      # Verify mox user was created
+      machine.succeed("getent passwd mox")
+
+      # Check if ports are listening (assuming default SMTP port)
+      machine.wait_until_succeeds("ss -tln | grep ':25 '")
+
+      # Test running the mox command
+      machine.succeed("mox version")
+
+      # Check logs for any errors
+      machine.succeed("journalctl -u mox.service --no-pager | grep -v 'error|failed'")
+    '';
+}


### PR DESCRIPTION
Closes #576 #577 #578

- Exposed Mox as a service to resolve [issue(s)](https://github.com/ngi-nix/ngipkgs/issues/576).
- Initial tests are running, and a local rebuild of NixOS with the module included runs just fine.
i.e:

![image](https://github.com/user-attachments/assets/05d1e9d8-015a-42ca-b41f-4eb654e0ca82)

However, it fails to start/survive reboot with:

```
[themadbit@nixos:~]$ systemctl status mox
○ mox.service
     Loaded: loaded (/etc/systemd/system/mox.service; enabled; preset: ignored)
     Active: inactive (dead)

Mar 27 14:40:30 nixos systemd[1]: Dependency failed for mox.service.
Mar 27 14:40:30 nixos systemd[1]: mox.service: Job mox.service/start failed with result 'dependency'.
```
So, I'll leave this as a draft PR as I investigate further. Putting it out here in case you've had a similar headache  and know the painkiller :sweat_smile: 