### PR TITLE
overview: convert markdown option descriptions to HTML using pandoc via IFD

### DIFF
--- a/overview/default.nix
+++ b/overview/default.nix
@@ -15,6 +15,7 @@ let
     filter
     isList
     readFile
+    toFile
     substring
     toJSON
     toString
@@ -75,6 +76,15 @@ let
     packages = project: attrValues project.packages;
   };
 
+  # This function utilises IFD to harness the power of pandoc
+  markdownToHtml =
+    markdown:
+    readFile (
+      pkgs.runCommand "html" { nativeBuildInputs = with pkgs; [ pandoc ]; } ''
+        pandoc --from=markdown --to=html ${toFile "md" markdown} > $out
+      ''
+    );
+
   render = {
     options = rec {
       one =
@@ -91,7 +101,7 @@ let
           </dt>
           <dd class="option-body">
             <div class="option-description">
-            ${option.description}
+            ${markdownToHtml option.description}
             </div>
             <dl>
               <dt>Type:</dt>


### PR DESCRIPTION
So the motivation here is that we have option descriptions in markdown and we need to render them. At the same time we want to use the niceties of Nix for composition of the HTML file. Something like `markdownToHtml :: String -> String` would be very useful, but it seems to only be implementable via IFD currently, which is sequential and crazy slow on first build.

My alternative very hacky solution that I have in mind is to compose some intermediate representation of the HTML page with Nix that contains command invocations in some kind of template:

```
<li>{{ echo '## some markdown' | pandoc --from markdown --to html }}</li>
```

These command invocations could then be replaced by their output in a last build step. Shouldn't be hard too implement in Python. This would give us a lot of flexibility in tooling for tiny bits of the page.

So basically write our own build recipe and realise that in the last step.