### PR TITLE
overview: rebuild the rendering flow so that we can use markdown strings

### DIFF
--- a/overview/render-template.py
+++ b/overview/render-template.py
@@ -1,0 +1,16 @@
+import sys
+from jinja2 import Template
+from markdown_it import MarkdownIt
+
+jinja2_template_file = sys.argv[1]
+output_file = sys.argv[2]
+
+md = MarkdownIt("commonmark")
+
+with open(jinja2_template_file) as file:
+  jinja2_template = Template(file.read())
+
+rendered = jinja2_template.render(markdown_to_html=md.render)
+
+with open(output_file, "w") as file:
+  file.write(rendered)


### PR DESCRIPTION
As discussed with @fricklerhandwerk 

![tmp WTMliGJu6y](https://github.com/user-attachments/assets/9eddf90c-8a32-4f26-892b-48d60535ac97)

This brings back markdown formatting in option descriptions.