### PR TITLE
Fix typos in naming of programs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -124,9 +124,14 @@ rec {
 
   project-models = import ./projects/models.nix { inherit lib pkgs sources; };
 
-  templates.project = project-models.project (
-    import ./templates/project { inherit lib pkgs sources; }
-  );
+  # we mainly care about the types being checked
+  templates.project =
+    let
+      project-metadata =
+        (project-models.project (import ./templates/project { inherit lib pkgs sources; })).metadata;
+    in
+    # fake derivation for flake check
+    pkgs.writeText "dummy" (lib.strings.toJSON project-metadata);
 
   # TODO: find a better place for this
   metrics = with lib; {

--- a/flake.nix
+++ b/flake.nix
@@ -212,8 +212,7 @@
                 };
                 "infra/makemake" = toplevel self.nixosConfigurations.makemake;
                 "infra/overview" = self.packages.${system}.overview;
-                # fake derivation for flake check
-                "infra/templates" = pkgs.writeText "dummy" (lib.strings.toJSON classic'.templates.project);
+                "infra/templates" = classic.templates.project;
               };
             in
             checksForInfrastructure // checksForAllProjects // checksForAllPackages;

--- a/templates/project/default.nix
+++ b/templates/project/default.nix
@@ -46,7 +46,7 @@
       examples.basic = {
         module = ./programs/_programName_/examples/basic.nix;
         description = "";
-        tests.basic = ./programs/_programName_/tests/basic.nix;
+        tests.basic = import ./programs/_programName_/tests/basic.nix args;
       };
       # Add relevant links to the program (if they're available)
       # else, remove the `links` attribute below
@@ -88,7 +88,7 @@
       examples.basic = {
         module = ./services/_serviceName_/examples/basic.nix;
         description = "";
-        tests.basic = ./services/_serviceName_/tests/basic.nix;
+        tests.basic = import ./services/_serviceName_/tests/basic.nix args;
       };
       # Add relevant links to the service (if they're available)
       # else, remove the `links` attribute below

--- a/templates/project/programs/_programName_/tests/basic.nix
+++ b/templates/project/programs/_programName_/tests/basic.nix
@@ -12,8 +12,8 @@
       {
         imports = [
           sources.modules.ngipkgs
-          sources.modules.services._programName_
-          sources.examples._ProjectName_._programName_
+          sources.modules.programs._programName_
+          sources.examples._ProjectName_._testName_  # i.e _ProjectName_.basic
         ];
       };
   };

--- a/templates/project/programs/_programName_/tests/basic.nix
+++ b/templates/project/programs/_programName_/tests/basic.nix
@@ -13,7 +13,7 @@
         imports = [
           sources.modules.ngipkgs
           sources.modules.programs._programName_
-          sources.examples._ProjectName_._testName_  # i.e _ProjectName_.basic
+          sources.examples._ProjectName_._testName_ # i.e _ProjectName_.basic
         ];
       };
   };

--- a/templates/project/programs/_programName_/tests/basic.nix
+++ b/templates/project/programs/_programName_/tests/basic.nix
@@ -13,7 +13,7 @@
         imports = [
           sources.modules.ngipkgs
           sources.modules.programs._programName_
-          sources.examples._ProjectName_._testName_ # i.e _ProjectName_.basic
+          sources.examples._ProjectName_._exampleName_ # i.e _ProjectName_.basic
         ];
       };
   };

--- a/templates/project/services/_serviceName_/tests/basic.nix
+++ b/templates/project/services/_serviceName_/tests/basic.nix
@@ -13,7 +13,7 @@
         imports = [
           sources.modules.ngipkgs
           sources.modules.programs._serviceName_
-          sources.examples._ProjectName_._serviceName_
+          sources.examples._ProjectName_._exampleName_ # i.e _ProjectName_.basic
         ];
       };
   };


### PR DESCRIPTION
- Add tests `import...args` declaration