### PR TITLE
Heads: Make allowlist configurable

### DIFF
--- a/pkgs/by-name/heads/deps.nix
+++ b/pkgs/by-name/heads/deps.nix
@@ -45,6 +45,20 @@
     "t430-maximized"
     "t480-hotp-maximized"
     "t480-maximized"
+    "UNMAINTAINED_kgpe-d16_server"
+    "UNMAINTAINED_kgpe-d16_server-whiptail"
+    "UNMAINTAINED_kgpe-d16_workstation"
+    "UNMAINTAINED_kgpe-d16_workstation-usb_keyboard"
+    "UNTESTED_nitropad-ns50"
+    "UNTESTED_t440p-hotp-maximized"
+    "UNTESTED_t440p-maximized"
+    "UNTESTED_t530-hotp-maximized"
+    "UNTESTED_t530-maximized"
+    "UNTESTED_talos-2"
+    "UNTESTED_w541-hotp-maximized"
+    "UNTESTED_w541-maximized"
+    "UNTESTED_z220-cmt-hotp-maximized"
+    "UNTESTED_z220-cmt-maximized"
     "w530-hotp-maximized"
     "w530-maximized"
     "x220-hotp-maximized"
@@ -287,6 +301,11 @@
       name = "linux-6.1.8.tar.xz";
       url = "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.1.8.tar.xz";
       hash = "sha256-tgu1Ori6NwonBFSxHpPUGvKRJvxyvW7eUXZz4uV7gW0=";
+    }
+    {
+      name = "linux-6.6.16.tar.xz";
+      url = "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.6.16.tar.xz";
+      hash = "sha256-sh1XlaO+rU8RKRZCMiL6qKD1GeQgHfND4+uI3J5KqjA=";
     }
     {
       name = "LVM2.2.03.23.tgz";

--- a/pkgs/by-name/heads/package.nix
+++ b/pkgs/by-name/heads/package.nix
@@ -415,6 +415,15 @@ let
         broken = board == "librem_l1um";
       };
     });
+
+  generateBoards =
+    allowedBoards:
+    lib.attrsets.listToAttrs (
+      lib.lists.map (board: {
+        name = "${board}";
+        value = generic board;
+      }) (lib.lists.intersectLists deps.boards allowedBoards)
+    );
 in
 lib.makeScope newScope (
   self:
@@ -426,10 +435,8 @@ lib.makeScope newScope (
       "qemu-coreboot-fbwhiptail-tpm1-hotp"
     ];
   in
-  lib.attrsets.listToAttrs (
-    lib.lists.map (board: {
-      name = "${board}";
-      value = generic board;
-    }) (lib.lists.intersectLists deps.boards allowedBoards)
-  )
+  {
+    inherit allowedBoards generateBoards;
+  }
+  // generateBoards allowedBoards
 )

--- a/pkgs/by-name/heads/print-heads-variables.mak
+++ b/pkgs/by-name/heads/print-heads-variables.mak
@@ -2,6 +2,7 @@
 
 BOARD ?= qemu-coreboot-fbwhiptail-tpm1
 CONFIG := $(src)/boards/$(BOARD)/$(BOARD).config
+pwd := $(src)
 
 VARS_OLD := $(.VARIABLES)
 

--- a/projects/Heads/example.nix
+++ b/projects/Heads/example.nix
@@ -1,4 +1,7 @@
 { ... }:
 {
-  programs.heads.enable = true;
+  programs.heads = {
+    enable = true;
+    boards = [ "qemu-coreboot-fbwhiptail-tpm1-hotp" ];
+  };
 }

--- a/projects/Heads/example.nix
+++ b/projects/Heads/example.nix
@@ -3,5 +3,6 @@
   programs.heads = {
     enable = true;
     boards = [ "qemu-coreboot-fbwhiptail-tpm1-hotp" ];
+    # The ROM image will be symlinked under /etc/heads/qemu-coreboot-fbwhiptail-tpm1-hotp.rom
   };
 }

--- a/projects/Heads/module.nix
+++ b/projects/Heads/module.nix
@@ -9,14 +9,33 @@ let
 in
 {
   # Note: Heads produces ROM images intended to be flashed onto real hardware.
-  # This module only exists to allow automated testing of a QEMU-targeting
-  # Heads ROM.
+  # This module only exists to expose the build images at fixed locations.
   options.programs.heads = {
-    enable = lib.mkEnableOption "symlinking the Heads ROM for qemu-coreboot-fbwhiptail-tpm1-hotp";
+    enable = lib.options.mkEnableOption "symlinking of the selected Heads boards' ROMs under /etc/heads";
+    boards = lib.options.mkOption {
+      description = ''
+        Heads board targets that should be built & symlinked.
+
+        Note: Using this option, you can specify boards that aren't currently provided or tested by NGIpkgs.
+        This will cause a heavy build process to run on your system, which may end in a build failure.
+      '';
+      type = lib.types.listOf lib.types.str;
+      default = pkgs.heads.allowedBoards;
+    };
   };
 
   config = lib.mkIf cfg.enable {
-    environment.etc."qemu-coreboot-fbwhiptail-tpm1-hotp.rom".source =
-      "${pkgs.heads.qemu-coreboot-fbwhiptail-tpm1-hotp}/${pkgs.heads.qemu-coreboot-fbwhiptail-tpm1-hotp.passthru.romName}";
+    environment.etc =
+      let
+        headsPkgs = pkgs.heads.generateBoards cfg.boards;
+      in
+      lib.attrsets.listToAttrs (
+        lib.lists.map (board: {
+          name = "heads/${board}.rom";
+          value = {
+            source = "${headsPkgs.${board}}/${headsPkgs.${board}.passthru.romName}";
+          };
+        }) cfg.boards
+      );
   };
 }

--- a/projects/Heads/module.nix
+++ b/projects/Heads/module.nix
@@ -11,7 +11,7 @@ in
   # Note: Heads produces ROM images intended to be flashed onto real hardware.
   # This module only exists to expose the build images at fixed locations.
   options.programs.heads = {
-    enable = lib.options.mkEnableOption "symlinking of the selected Heads boards' ROMs under /etc/heads";
+    enable = lib.options.mkEnableOption "symlinking of the selected Heads boards' ROMs under /etc/heads/\${board}.rom";
     boards = lib.options.mkOption {
       description = ''
         Heads board targets that should be built & symlinked.

--- a/projects/Heads/test.nix
+++ b/projects/Heads/test.nix
@@ -62,7 +62,7 @@ in
                 -vga std \
                 -m 256M \
                 -serial stdio \
-                --bios /etc/qemu-coreboot-fbwhiptail-tpm1-hotp.rom \
+                --bios /etc/heads/qemu-coreboot-fbwhiptail-tpm1-hotp.rom \
                 -object rng-random,filename=/dev/urandom,id=rng0 \
                 -device virtio-rng-pci,rng=rng0 \
                 -netdev user,id=u1 -device e1000,netdev=u1 \


### PR DESCRIPTION
This should allow controlling

1. on a package level, which boards will have their corresponding derivations generated
2. on a module level, which boards will have their built ROMs symlinked in the system

To make this even more permissive, I'm currently updating the `updateDepsScript` to stop ignoring board targets marked with `UNMAINTAINED` and `UNTESTED` so we can `lib.lists.intersectLists` against the full list of boards. When (if?) we eventually expand our allowlist, we would just filter them out in the default `allowedBoards` again. But when users request them to be build, then I think there's no reason to deny them that attempt. Whether or not it'll work would be their concern though :slightly_smiling_face:.