### PR TITLE
libresoc: python39 -> python312

### DIFF
--- a/pkgs/by-name/libresoc-nmigen/bigfloat.nix
+++ b/pkgs/by-name/libresoc-nmigen/bigfloat.nix
@@ -1,10 +1,10 @@
 {
   lib,
-  python39Packages,
+  python3Packages,
   fetchFromGitHub,
   mpfr,
 }:
-python39Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage rec {
   pname = "bigfloat";
   version = "0.4.0";
   pyproject = true;
@@ -16,12 +16,12 @@ python39Packages.buildPythonPackage rec {
     hash = "sha256-HgbwA0YksF/LDiD8WrcQZKilU6J94zSkgIyR+UUf+do=";
   };
 
-  build-system = with python39Packages; [
+  build-system = with python3Packages; [
     cython
     setuptools
   ];
 
-  propagatedBuildInputs = [ mpfr ] ++ (with python39Packages; [ six ]);
+  propagatedBuildInputs = [ mpfr ] ++ (with python3Packages; [ six ]);
 
   meta = {
     description = "Arbitrary-precision correctly-rounded floating-point arithmetic, via MPFR.";

--- a/pkgs/by-name/libresoc-nmigen/ieee754fpu.nix
+++ b/pkgs/by-name/libresoc-nmigen/ieee754fpu.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  python39Packages,
+  python3Packages,
   fetchFromLibresoc,
   bigfloat,
   sfpy,
@@ -9,7 +9,7 @@
   nmigen,
   pytest-output-to-files,
 }:
-python39Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage rec {
   pname = "ieee754fpu";
   version = "unstable-2024-03-31";
 
@@ -33,7 +33,7 @@ python39Packages.buildPythonPackage rec {
       sfpy
       bigfloat
     ]
-    ++ (with python39Packages; [
+    ++ (with python3Packages; [
       pytestCheckHook
       pytest-xdist
     ]);

--- a/pkgs/by-name/libresoc-nmigen/ieee754fpu.nix
+++ b/pkgs/by-name/libresoc-nmigen/ieee754fpu.nix
@@ -11,7 +11,8 @@
 }:
 python3Packages.buildPythonPackage rec {
   pname = "ieee754fpu";
-  version = "unstable-2024-03-31";
+  version = "0-unstable-2024-03-31";
+  pyproject = true;
 
   src = fetchFromLibresoc {
     inherit pname;
@@ -22,6 +23,10 @@ python3Packages.buildPythonPackage rec {
   prePatch = ''
     touch ./src/ieee754/part{,_ass,_cat,_repl}/__init__.py
   '';
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
 
   propagatedBuildInputs = [ nmutil ];
 

--- a/pkgs/by-name/libresoc-nmigen/libresoc-c4m-jtag.nix
+++ b/pkgs/by-name/libresoc-nmigen/libresoc-c4m-jtag.nix
@@ -1,12 +1,12 @@
 {
   lib,
   fetchFromLibresoc,
-  python39,
-  python39Packages,
+  python3,
+  python3Packages,
   nmigen-soc,
   nmigen,
 }:
-python39Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage rec {
   pname = "c4m-jtag";
   version = "unstable-2024-03-31";
   realVersion = "0.3.dev243+g${lib.substring 0 7 src.rev}";
@@ -21,7 +21,7 @@ python39Packages.buildPythonPackage rec {
     export SETUPTOOLS_SCM_PRETEND_VERSION="${realVersion}"
   '';
 
-  nativeBuildInputs = with python39Packages; [ setuptools-scm ];
+  nativeBuildInputs = with python3Packages; [ setuptools-scm ];
   propagatedBuildInputs = [ nmigen-soc ];
 
   pythonImportsCheck = [ "c4m.nmigen.jtag.tap" ];

--- a/pkgs/by-name/libresoc-nmigen/libresoc-c4m-jtag.nix
+++ b/pkgs/by-name/libresoc-nmigen/libresoc-c4m-jtag.nix
@@ -1,10 +1,9 @@
 {
   lib,
   fetchFromLibresoc,
-  python3,
   python3Packages,
   nmigen-soc,
-  nmigen,
+  modgrammar,
 }:
 python3Packages.buildPythonPackage rec {
   pname = "c4m-jtag";
@@ -23,7 +22,10 @@ python3Packages.buildPythonPackage rec {
   '';
 
   nativeBuildInputs = with python3Packages; [ setuptools-scm ];
-  propagatedBuildInputs = [ nmigen-soc ];
+  propagatedBuildInputs = [
+    nmigen-soc
+    modgrammar
+  ];
 
   pythonImportsCheck = [ "c4m.nmigen.jtag.tap" ];
 

--- a/pkgs/by-name/libresoc-nmigen/libresoc-c4m-jtag.nix
+++ b/pkgs/by-name/libresoc-nmigen/libresoc-c4m-jtag.nix
@@ -10,6 +10,7 @@ python3Packages.buildPythonPackage rec {
   pname = "c4m-jtag";
   version = "unstable-2024-03-31";
   realVersion = "0.3.dev243+g${lib.substring 0 7 src.rev}";
+  pyproject = true;
 
   src = fetchFromLibresoc {
     inherit pname;

--- a/pkgs/by-name/libresoc-nmigen/libresoc-pyelftools.nix
+++ b/pkgs/by-name/libresoc-nmigen/libresoc-pyelftools.nix
@@ -6,6 +6,7 @@
 python3Packages.pyelftools.overrideAttrs (_: rec {
   name = "pyelftools";
   version = "unstable-2024-03-31";
+  pyproject = true;
 
   # upstream Libre-SOC uses a mirror,
   # and while this would be best handled as github.com/Libre-SOC-mirrors copy,

--- a/pkgs/by-name/libresoc-nmigen/libresoc-pyelftools.nix
+++ b/pkgs/by-name/libresoc-nmigen/libresoc-pyelftools.nix
@@ -1,9 +1,9 @@
 {
   lib,
-  python39Packages,
+  python3Packages,
   fetchFromGitHub,
 }:
-python39Packages.pyelftools.overrideAttrs (_: rec {
+python3Packages.pyelftools.overrideAttrs (_: rec {
   name = "pyelftools";
   version = "unstable-2024-03-31";
 

--- a/pkgs/by-name/libresoc-nmigen/mdis.nix
+++ b/pkgs/by-name/libresoc-nmigen/mdis.nix
@@ -6,11 +6,14 @@
 python3Packages.buildPythonPackage rec {
   pname = "mdis";
   version = "0.5.1";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-gvXtP8NO5XPDAs0XMbGknG79FscN/7lxqmF1kg3nhxg=";
   };
+
+  build-system = with python3Packages; [ setuptools ];
 
   meta = {
     description = "Python dispatching library";

--- a/pkgs/by-name/libresoc-nmigen/mdis.nix
+++ b/pkgs/by-name/libresoc-nmigen/mdis.nix
@@ -1,9 +1,9 @@
 {
   lib,
-  python39Packages,
+  python3Packages,
   fetchPypi,
 }:
-python39Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage rec {
   pname = "mdis";
   version = "0.5.1";
 

--- a/pkgs/by-name/libresoc-nmigen/modgrammar.nix
+++ b/pkgs/by-name/libresoc-nmigen/modgrammar.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  python3,
+  fetchPypi,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "modgrammar";
+  version = "0.10";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-uVfMnMW8xNo7B5XWPTPUIc8o2xhqyrdPg4R96DEfoJo=";
+  };
+
+  build-system = [
+    python3.pkgs.setuptools
+    python3.pkgs.wheel
+  ];
+
+  pythonImportsCheck = [
+    "modgrammar"
+  ];
+
+  meta = {
+    description = "Modular grammar-parsing engine";
+    homepage = "https://pypi.org/project/modgrammar/";
+    license = lib.licenses.bsd2;
+    mainProgram = "modgrammar";
+  };
+}

--- a/pkgs/by-name/libresoc-nmigen/nmigen-soc.nix
+++ b/pkgs/by-name/libresoc-nmigen/nmigen-soc.nix
@@ -1,10 +1,10 @@
 {
   lib,
-  python39Packages,
+  python3Packages,
   fetchFromGitLab,
   nmigen,
 }:
-python39Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage rec {
   pname = "nmigen-soc";
   version = "unstable-2024-03-31";
   # python setup.py --version
@@ -22,8 +22,8 @@ python39Packages.buildPythonPackage rec {
     rev = "fd2aaa336283cff2e46f489bf3897780cd217b8b"; # HEAD @ version date
   };
 
-  nativeBuildInputs = with python39Packages; [ setuptools-scm ];
-  propagatedBuildInputs = with python39Packages; [
+  nativeBuildInputs = with python3Packages; [ setuptools-scm ];
+  propagatedBuildInputs = with python3Packages; [
     nmigen
     setuptools
   ];
@@ -32,7 +32,7 @@ python39Packages.buildPythonPackage rec {
     export SETUPTOOLS_SCM_PRETEND_VERSION="${realVersion}"
   '';
 
-  nativeCheckInputs = with python39Packages; [ pytestCheckHook ];
+  nativeCheckInputs = with python3Packages; [ pytestCheckHook ];
 
   meta = {
     description = "Python toolbox for building complex digital hardware";

--- a/pkgs/by-name/libresoc-nmigen/nmigen-soc.nix
+++ b/pkgs/by-name/libresoc-nmigen/nmigen-soc.nix
@@ -9,6 +9,7 @@ python3Packages.buildPythonPackage rec {
   version = "unstable-2024-03-31";
   # python setup.py --version
   realVersion = "0.1.dev243+g${lib.substring 0 7 src.rev}";
+  pyproject = true;
 
   # NOTE(jleightcap): libresoc's nmigen-soc fork has been renamed to https://github.com/amaranth-lang/amaranth-soc.
   # suffers from the same rename issue as the previous commit with renaming issue as nmigen/amaranth

--- a/pkgs/by-name/libresoc-nmigen/nmigen.nix
+++ b/pkgs/by-name/libresoc-nmigen/nmigen.nix
@@ -2,12 +2,12 @@
   lib,
   fetchFromGitLab,
   git,
-  python39Packages,
+  python3Packages,
   symbiyosys,
   yices,
   yosys,
 }:
-python39Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage rec {
   pname = "nmigen";
   version = "0-unstable-2022-09-27";
   realVersion = "0.3.dev243+g${lib.substring 0 7 src.rev}";
@@ -31,11 +31,11 @@ python39Packages.buildPythonPackage rec {
     export SETUPTOOLS_SCM_PRETEND_VERSION="${realVersion}"
   '';
 
-  nativeBuildInputs = [ git ] ++ (with python39Packages; [ setuptools-scm ]);
+  nativeBuildInputs = [ git ] ++ (with python3Packages; [ setuptools-scm ]);
 
   propagatedBuildInputs =
     [ yosys ]
-    ++ (with python39Packages; [
+    ++ (with python3Packages; [
       jinja2
       pyvcd
     ]);
@@ -44,7 +44,7 @@ python39Packages.buildPythonPackage rec {
     symbiyosys
     yices
     yosys
-  ] ++ (with python39Packages; [ pytestCheckHook ]);
+  ] ++ (with python3Packages; [ pytestCheckHook ]);
 
   # TODO: upstream nixpkgs Amaranth package uses a patch for Python >3.8 compatibility in setuptools:
   # https://github.com/amaranth-lang/amaranth/commit/64771a065a280fa683c1e6692383bec4f59f20fa.patch

--- a/pkgs/by-name/libresoc-nmigen/nmigen.nix
+++ b/pkgs/by-name/libresoc-nmigen/nmigen.nix
@@ -11,6 +11,7 @@ python3Packages.buildPythonPackage rec {
   pname = "nmigen";
   version = "0-unstable-2022-09-27";
   realVersion = "0.3.dev243+g${lib.substring 0 7 src.rev}";
+  pyproject = true;
 
   # libresoc's nmigen fork has been renamed to https://github.com/amaranth-lang/amaranth
   # amaranth is packaged in nixpkgs but we can't just override a few of the attributes the way we did for pyelftools,
@@ -45,6 +46,10 @@ python3Packages.buildPythonPackage rec {
     yices
     yosys
   ] ++ (with python3Packages; [ pytestCheckHook ]);
+
+  pythonRelaxDeps = [
+    "pyvcd"
+  ];
 
   # TODO: upstream nixpkgs Amaranth package uses a patch for Python >3.8 compatibility in setuptools:
   # https://github.com/amaranth-lang/amaranth/commit/64771a065a280fa683c1e6692383bec4f59f20fa.patch

--- a/pkgs/by-name/libresoc-nmigen/nmutil.nix
+++ b/pkgs/by-name/libresoc-nmigen/nmutil.nix
@@ -1,13 +1,13 @@
 {
   lib,
   fetchFromLibresoc,
-  python39Packages,
+  python3Packages,
   symbiyosys,
   yices,
   nmigen,
   pytest-output-to-files,
 }:
-python39Packages.buildPythonPackage {
+python3Packages.buildPythonPackage {
   pname = "libresoc-nmutil"; # Libre-SOC's bespoke fork
   version = "0-unstable-2022-11-16";
 
@@ -27,7 +27,7 @@ python39Packages.buildPythonPackage {
       symbiyosys
       yices
     ]
-    ++ (with python39Packages; [
+    ++ (with python3Packages; [
       pyvcd
     ]);
 
@@ -37,7 +37,7 @@ python39Packages.buildPythonPackage {
       symbiyosys
       yices
     ]
-    ++ (with python39Packages; [
+    ++ (with python3Packages; [
       pytestCheckHook
       pytest-xdist
       pytest-output-to-files

--- a/pkgs/by-name/libresoc-nmigen/nmutil.nix
+++ b/pkgs/by-name/libresoc-nmigen/nmutil.nix
@@ -10,6 +10,7 @@
 python3Packages.buildPythonPackage {
   pname = "libresoc-nmutil"; # Libre-SOC's bespoke fork
   version = "0-unstable-2022-11-16";
+  pyproject = true;
 
   src = fetchFromLibresoc {
     pname = "nmutil";
@@ -21,6 +22,10 @@ python3Packages.buildPythonPackage {
   postPatch = ''
     sed -i "s/read_ilang/read_rtlil/g" build/lib/nmutil/*.py src/nmutil/*.py
   '';
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
 
   propagatedNativeBuildInputs =
     [

--- a/pkgs/by-name/libresoc-nmigen/openpower-isa.nix
+++ b/pkgs/by-name/libresoc-nmigen/openpower-isa.nix
@@ -18,7 +18,8 @@ in
 pythonPackages.buildPythonPackage rec {
   name = "libresoc-openpower-isa";
   pname = "openpower-isa";
-  version = "unstable-2024-03-31";
+  version = "0-unstable-2024-03-31";
+  pyproject = true;
 
   src = fetchFromLibresoc {
     inherit pname;
@@ -50,6 +51,10 @@ pythonPackages.buildPythonPackage rec {
     ./prefixed-openpower-isa-tools.patch
   ];
 
+  build-system = with pythonPackages; [
+    setuptools
+  ];
+
   # Native is the build machine architecture (e.g. x86_64 linux)
   # This will run a python emulator of the target architecture, which is PowerPC for this project
   # The assembler has to run on native but target PowerPC assembly
@@ -68,6 +73,10 @@ pythonPackages.buildPythonPackage rec {
       ply
       pygdbmi
     ]);
+
+  pythonRelaxDeps = [
+    "pygdbmi"
+  ];
 
   # TODO: potential upstream work
   postInstall =

--- a/pkgs/by-name/libresoc-nmigen/openpower-isa.nix
+++ b/pkgs/by-name/libresoc-nmigen/openpower-isa.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  python39,
+  python3,
   fetchFromLibresoc,
   pkgsCross,
   writeShellApplication,
@@ -12,8 +12,8 @@
   mdis,
 }:
 let
-  python = python39;
-  pythonPackages = python39.pkgs;
+  python = python3;
+  pythonPackages = python3.pkgs;
 in
 pythonPackages.buildPythonPackage rec {
   name = "libresoc-openpower-isa";

--- a/pkgs/by-name/libresoc-nmigen/package.nix
+++ b/pkgs/by-name/libresoc-nmigen/package.nix
@@ -1,7 +1,7 @@
 {
   newScope,
   fetchFromGitHub,
-  python39,
+  python3,
 }:
 let
   python =
@@ -28,14 +28,14 @@ let
         });
       };
     in
-    python39.override {
+    python3.override {
       inherit packageOverrides;
       self = python;
     };
 
   callPackage = newScope {
-    python39 = python;
-    python39Packages = python.pkgs;
+    python3 = python;
+    python3Packages = python.pkgs;
   };
 
   lib = callPackage ./lib.nix { };

--- a/pkgs/by-name/libresoc-nmigen/package.nix
+++ b/pkgs/by-name/libresoc-nmigen/package.nix
@@ -42,7 +42,7 @@ let
   inherit (lib) fetchFromLibresoc;
 
   libresoc-c4m-jtag = callPackage ./libresoc-c4m-jtag.nix {
-    inherit fetchFromLibresoc nmigen nmigen-soc;
+    inherit fetchFromLibresoc nmigen-soc modgrammar;
   };
   libresoc-ieee754fpu = callPackage ./ieee754fpu.nix {
     inherit
@@ -75,6 +75,7 @@ let
     inherit fetchFromLibresoc;
   };
   pytest-output-to-files = callPackage ./pytest-output-to-files.nix { inherit fetchFromLibresoc; };
+  modgrammar = callPackage ./modgrammar.nix { };
 in
 callPackage ./soc.nix {
   inherit

--- a/pkgs/by-name/libresoc-nmigen/power-instruction-analyzer.nix
+++ b/pkgs/by-name/libresoc-nmigen/power-instruction-analyzer.nix
@@ -7,7 +7,7 @@
 python3Packages.buildPythonPackage rec {
   pname = "power-instruction-analyzer";
   version = "0.2.0";
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchFromLibresoc {
     inherit pname;

--- a/pkgs/by-name/libresoc-nmigen/power-instruction-analyzer.nix
+++ b/pkgs/by-name/libresoc-nmigen/power-instruction-analyzer.nix
@@ -1,10 +1,10 @@
 {
   lib,
-  python39Packages,
+  python3Packages,
   rustPlatform,
   fetchFromLibresoc,
 }:
-python39Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage rec {
   pname = "power-instruction-analyzer";
   version = "0.2.0";
   format = "pyproject";

--- a/pkgs/by-name/libresoc-nmigen/pytest-output-to-files.nix
+++ b/pkgs/by-name/libresoc-nmigen/pytest-output-to-files.nix
@@ -1,9 +1,9 @@
 {
   lib,
   fetchFromLibresoc,
-  python39Packages,
+  python3Packages,
 }:
-python39Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage rec {
   pname = "pytest-output-to-files";
   version = "unstable-2024-03-31";
 
@@ -13,7 +13,7 @@ python39Packages.buildPythonPackage rec {
     hash = "sha256-ES8zZ9s6wGcqw60NoN4tZf/Dq/sBvl+UDYrXuOgfMxI=";
   };
 
-  nativeCheckInputs = with python39Packages; [ pytestCheckHook ];
+  nativeCheckInputs = with python3Packages; [ pytestCheckHook ];
 
   meta = {
     description = "A pytest plugin that shortens test output with the full output stored in files";

--- a/pkgs/by-name/libresoc-nmigen/pytest-output-to-files.nix
+++ b/pkgs/by-name/libresoc-nmigen/pytest-output-to-files.nix
@@ -6,6 +6,7 @@
 python3Packages.buildPythonPackage rec {
   pname = "pytest-output-to-files";
   version = "unstable-2024-03-31";
+  pyproject = true;
 
   src = fetchFromLibresoc {
     inherit pname;
@@ -13,6 +14,7 @@ python3Packages.buildPythonPackage rec {
     hash = "sha256-ES8zZ9s6wGcqw60NoN4tZf/Dq/sBvl+UDYrXuOgfMxI=";
   };
 
+  build-system = with python3Packages; [ setuptools ];
   nativeCheckInputs = with python3Packages; [ pytestCheckHook ];
 
   meta = {

--- a/pkgs/by-name/libresoc-nmigen/sfpy.nix
+++ b/pkgs/by-name/libresoc-nmigen/sfpy.nix
@@ -1,9 +1,9 @@
 {
   lib,
-  python39Packages,
+  python3Packages,
   fetchFromGitHub,
 }:
-python39Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage rec {
   pname = "sfpy";
   version = "0.6.0";
   pyproject = true;
@@ -21,7 +21,7 @@ python39Packages.buildPythonPackage rec {
       --replace-fail "make pic" "make"
   '';
 
-  build-system = with python39Packages; [
+  build-system = with python3Packages; [
     cython_0
     setuptools
   ];

--- a/pkgs/by-name/libresoc-nmigen/soc.nix
+++ b/pkgs/by-name/libresoc-nmigen/soc.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  python39Packages,
+  python3Packages,
   fetchFromLibresoc,
   yosys,
   libresoc-c4m-jtag,
@@ -10,7 +10,7 @@
   power-instruction-analyzer,
   pytest-output-to-files,
 }:
-python39Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage rec {
   name = "soc";
   pname = name;
   version = "unstable-2024-03-31";
@@ -34,14 +34,14 @@ python39Packages.buildPythonPackage rec {
     libresoc-openpower-isa
     nmigen-soc
     yosys
-  ] ++ (with python39Packages; [ cached-property ]);
+  ] ++ (with python3Packages; [ cached-property ]);
 
   nativeCheckInputs =
     [
       power-instruction-analyzer
       pytest-output-to-files
     ]
-    ++ (with python39Packages; [
+    ++ (with python3Packages; [
       pytest-xdist
       pytestCheckHook
     ]);

--- a/pkgs/by-name/libresoc-nmigen/soc.nix
+++ b/pkgs/by-name/libresoc-nmigen/soc.nix
@@ -14,6 +14,7 @@ python3Packages.buildPythonPackage rec {
   name = "soc";
   pname = name;
   version = "unstable-2024-03-31";
+  pyproject = true;
 
   src = fetchFromLibresoc {
     inherit pname;

--- a/pkgs/by-name/libresoc-verilog/pinmux.nix
+++ b/pkgs/by-name/libresoc-verilog/pinmux.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   fetchFromLibresoc,
-  python39,
+  python3,
 }:
 stdenv.mkDerivation rec {
   name = "libresoc-pinmux";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-Tux2RvcRmlpXMsHwve/+5rOyBRSThg9MVW2NGP3ZJxs=";
   };
 
-  nativeBuildInputs = [ python39 ];
+  nativeBuildInputs = [ python3 ];
 
   buildPhase = ''
     runHook preBuild


### PR DESCRIPTION
Extracted from #800. Let's see if this works without bumping flake locks.