### PR TITLE
flake.nix: don't check examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,11 +234,7 @@ The following information is needed to [open an issue for a new NGI project](htt
 1. Check that the code is valid by running the test locally:
 
    ```
-   # examples
-   $ nix build .#checks.x86_64-linux.projects/<project_name>/nixos/examples/<example_name>
-   
-   # tests
-   $ nix build .#checks.x86_64-linux.projects/<project_name>/nixos/tests/<test_name>
+   nix build .#checks.x86_64-linux.projects/<project_name>/nixos/tests/<test_name>
    ```
 
 1. Run the Nix code formatter with `nix fmt`

--- a/flake.nix
+++ b/flake.nix
@@ -61,8 +61,6 @@
       # TODO: get rid of these, it's extremely confusing to import the seemingly same thing twice
       rawNgiProjects = classic'.projects;
 
-      rawExamples = lib'.flattenAttrs "/" classic'.examples;
-
       rawNixosModules = lib'.flattenAttrs "." (
         lib.foldl recursiveUpdate { } (
           attrValues (mapAttrs (_: project: project.nixos.modules) rawNgiProjects)
@@ -75,39 +73,13 @@
         default.nixpkgs.overlays = [ overlay ];
       } // rawNixosModules;
 
-      mkNixosSystem =
-        config:
-        nixosSystem {
-          modules =
-            [
-              config
-              {
-                nixpkgs.hostPlatform = "x86_64-linux";
-                system.stateVersion = "23.05";
-
-                # The examples that the flake exports are not meant to be used/booted directly.
-                # See <https://github.com/ngi-nix/ngipkgs/issues/128> for more information.
-                boot = {
-                  initrd.enable = false;
-                  kernel.enable = false;
-                  loader.grub.enable = false;
-                };
-              }
-            ]
-            # TODO: this needs to take a different shape,
-            # otherwise the transformation to obtain it is confusing
-            ++ classic'.extendedNixosModules;
-        };
-
       toplevel = machine: machine.config.system.build.toplevel;
 
       # Finally, define the system-agnostic outputs.
       systemAgnosticOutputs = {
-        nixosConfigurations =
-          # TODO: remove these, noone will (or can even, realistically) use them
-          mapAttrs (_: mkNixosSystem) rawExamples // {
-            makemake = import ./infra/makemake { inherit inputs; };
-          };
+        nixosConfigurations = {
+          makemake = import ./infra/makemake { inherit inputs; };
+        };
 
         inherit nixosModules;
 
@@ -181,12 +153,8 @@
                       checksForNixosTests = concatMapAttrs (testName: test: {
                         "projects/${projectName}/nixos/tests/${testName}" = test;
                       }) project.nixos.tests;
-
-                      checksForNixosExamples = concatMapAttrs (exampleName: example: {
-                        "projects/${projectName}/nixos/examples/${exampleName}" = toplevel (mkNixosSystem example.module);
-                      }) project.nixos.examples;
                     in
-                    checksForNixosTests // checksForNixosExamples;
+                    checksForNixosTests;
                 in
                 concatMapAttrs checksForProject classic.projects;
 


### PR DESCRIPTION
This is mostly legacy code which is no longer needed since examples are checked by tests.