### PR TITLE
overview: provide download and copy buttons for demo code

### DIFF
--- a/overview/default.nix
+++ b/overview/default.nix
@@ -124,7 +124,7 @@ let
                     ${toJSON (readFile filename)}
                   </script>
                 ''}
-                📋 Copy
+                ⿻ Copy
             </button>
           </div>
         </div>

--- a/overview/default.nix
+++ b/overview/default.nix
@@ -114,17 +114,15 @@ let
           {{ include_code("${language}", "${filename}" ${optionalString relative ", relative_path=True"}) }}
           <div class="code-buttons">
             ${optionalString downloadable ''
-              <a class="button download" href="${filename}" download>⭳ Download</a>
+              <a class="button download" href="${filename}" download>Download</a>
             ''}
-            <button
-              class="button"
-              onclick="copyToClipboard(this, '${filename}')">
+            <button class="button copy" onclick="copyToClipboard(this, '${filename}')">
                 ${optionalString (!relative) ''
                   <script type="application/json">
                     ${toJSON (readFile filename)}
                   </script>
                 ''}
-                ⿻ Copy
+                Copy
             </button>
           </div>
         </div>

--- a/overview/default.nix
+++ b/overview/default.nix
@@ -101,6 +101,16 @@ let
   markdownToHtml = markdown: "{{ markdown_to_html(${toJSON markdown}) }}";
 
   render = {
+    # A code snippet that is both copyable and downloadable as a file
+    codeFile.one = filename: ''
+      <div class="code-block">
+        {{ include_code("nix", "${filename}", relative_path=True) }}
+        <div class="code-buttons">
+          <a class="button download" href="${filename}" download>Download</a>
+          <button class="button" onclick="copyToClipboard(this, '${filename}')">Copy</button>
+        </div>
+      </div>
+    '';
     options = rec {
       one =
         prefixLength: option:
@@ -274,7 +284,7 @@ let
             <strong>Download this Nix file to your computer.</strong>
             It obtains the NGIpkgs source code and declares a basic service configuration
             to be run in a virtual machine.
-            {{ include_code("nix", "default.nix", relative_path=True) }}
+            ${render.codeFile.one "default.nix"}
           </li>
           <li>
             <strong>Build the virtual machine</strong> defined in <code>default.nix</code> and run it:
@@ -377,7 +387,19 @@ let
         <link rel="stylesheet" href="/style.css">
       </head>
       <body>
-      ${args.content}
+        ${args.content}
+        <script>
+          async function copyToClipboard(button, url) {
+            const response = await fetch(url);
+            if (!response.ok) {
+              throw new Error("Failed to fetch file: " + response.statusText);
+            }
+            const textContent = await response.text();
+            await navigator.clipboard.writeText(textContent);
+            button.textContent = "Copied ✓";
+            setTimeout(() => button.textContent = "Copy", 2000);
+          }
+        </script>
       </body>
       </html>
     '';

--- a/overview/default.nix
+++ b/overview/default.nix
@@ -114,7 +114,7 @@ let
           {{ include_code("${language}", "${filename}" ${optionalString relative ", relative_path=True"}) }}
           <div class="code-buttons">
             ${optionalString downloadable ''
-              <a class="button download" href="${filename}" download>Download</a>
+              <a class="button download" href="${filename}" download>⭳ Download</a>
             ''}
             <button
               class="button"
@@ -124,7 +124,7 @@ let
                     ${toJSON (readFile filename)}
                   </script>
                 ''}
-                Copy
+                📋 Copy
             </button>
           </div>
         </div>

--- a/overview/style.css
+++ b/overview/style.css
@@ -286,6 +286,42 @@ code, pre {
   overflow-x: auto;
 }
 
+.code-block {
+  position: relative;
+}
+
+.code-buttons {
+  position: absolute;
+  top: 0.5em;
+  right: 1em;
+}
+
+.button {
+  display: inline-block;
+  padding: 0.1em 0.4em;
+  background-color: transparent;
+  color: white;
+  text-align: center;
+  text-decoration: none;
+  border-radius: 5px;
+  border: solid 1px gray;
+  background-color: gray;
+  margin: 0;
+  font-size: 0.8rem;
+}
+
+.button.download {
+  background-color: green;
+}
+
+.button:hover {
+  background-color: darkgrey;
+}
+
+.button.download:hover {
+  background-color: darkgreen;
+}
+
 details > summary > h2, details > summary > h3 {
     display: inline;
 }

--- a/overview/style.css
+++ b/overview/style.css
@@ -310,11 +310,19 @@ code, pre {
   font-size: 0.8rem;
 }
 
+.button.copy:before {
+  content: "⿻";
+}
+
+.button.download:before {
+  content: "⭳";
+}
+
 .button.download {
   background-color: green;
 }
 
-.button:hover {
+.button.copy:hover {
   background-color: darkgrey;
 }
 


### PR DESCRIPTION
The massive CSS class is due to the download button having to be an `a` element, as it wouldn't work without JS otherwise…

Closes #865 #866 

![tmp iJS6s2EZ7B](https://github.com/user-attachments/assets/ff071dbd-f496-4c5a-843b-d3c73b9eee0d)
