### PR TITLE
treewide: use `lib'.moduleLocFromOptionString` to locate re-exported modules

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
         flake = self;
         system = null;
       };
-      inherit (classic') lib lib';
+      inherit (classic') lib extension;
 
       inherit (lib)
         concatMapAttrs
@@ -42,6 +42,8 @@
 
       # Finally, define the system-agnostic outputs.
       systemAgnosticOutputs = {
+        lib = extension;
+
         nixosConfigurations = {
           makemake = import ./infra/makemake { inherit inputs; };
         };

--- a/maintainers/templates/project/default.nix
+++ b/maintainers/templates/project/default.nix
@@ -68,17 +68,17 @@
     _serviceName_ = {
       name = "service name";
       # Check if the service exists in https://search.nixos.org/options?
-      # If it does, click on one of its options and copy the text in the `Declared in` field
-      # into the `module` attribute:
+      # If it does, click on one of its options and copy the text in the `Name` field
+      # into the `module` attribute (use the root option name):
       #
       # ```nix
-      # module = "${sources.inputs.nixpkgs}/<DECLARED_IN_TEXT>";
+      # module = lib.moduleLocFromOptionString "<NAME>";
       # ```
       #
       # Example (Cryptpad):
       #
       # ```nix
-      # module = "${sources.inputs.nixpkgs}/nixos/modules/services/web-apps/cryptpad.nix";
+      # module = lib.moduleLocFromOptionString "services.cryptpad";
       # ```
       #
       # Note: we can either use the module in nixpkgs or make one ourselves

--- a/overview/default.nix
+++ b/overview/default.nix
@@ -1,7 +1,6 @@
 # NOTE: run a live overview watcher by executing `devmode`, inside a nix shell
 {
   lib,
-  lib',
   options,
   nixpkgs ? self.inputs.nixpkgs,
   pkgs,
@@ -89,7 +88,7 @@ let
       let
         # string comparison is faster than collecting attribute paths as lists
         spec = attrNames (
-          lib'.flattenAttrs "." (
+          lib.flattenAttrs "." (
             foldl' recursiveUpdate { } (
               mapAttrsToList (name: value: { ${name} = value; }) project.nixos.modules
             )

--- a/projects/Agorakit/default.nix
+++ b/projects/Agorakit/default.nix
@@ -12,7 +12,7 @@
 
   nixos = {
     modules.services.agorakit = {
-      module = "${sources.inputs.nixpkgs}/nixos/modules/services/web-apps/agorakit.nix";
+      module = lib.moduleLocFromOptionString "services.agorakit";
       examples.basic = null;
     };
     tests.basic = import "${sources.inputs.nixpkgs}/nixos/tests/web-apps/agorakit.nix" args;

--- a/projects/Canaille/default.nix
+++ b/projects/Canaille/default.nix
@@ -15,7 +15,7 @@
   nixos.modules.services = {
     canaille = {
       name = "Canaille";
-      module = "${sources.inputs.nixpkgs}/nixos/modules/services/security/canaille.nix";
+      module = lib.moduleLocFromOptionString "services.canaille";
       examples.basic = {
         module = ./services/Canaille/examples/basic.nix;
         description = "";

--- a/projects/Draupnir/default.nix
+++ b/projects/Draupnir/default.nix
@@ -24,7 +24,7 @@
 
   nixos = {
     modules.services.draupnir = {
-      module = "${sources.inputs.nixpkgs}/nixos/modules/services/matrix/draupnir.nix";
+      module = lib.moduleLocFromOptionString "services.draupnir";
       examples.basic = null;
     };
     tests.draupnir = "${sources.inputs.nixpkgs}/nixos/tests/matrix/draupnir.nix";

--- a/projects/Flarum/default.nix
+++ b/projects/Flarum/default.nix
@@ -37,7 +37,7 @@
   nixos.modules.services = {
     flarum = {
       name = "flarum";
-      module = "${sources.inputs.nixpkgs}/nixos/modules/services/web-apps/flarum.nix";
+      module = lib.moduleLocFromOptionString "services.flarum";
       examples.basic = {
         module = ./services-example.nix;
         description = "";

--- a/projects/Forgejo/default.nix
+++ b/projects/Forgejo/default.nix
@@ -32,7 +32,7 @@
 
   nixos.modules.services = {
     forgejo = {
-      module = "${sources.inputs.nixpkgs}/nixos/modules/services/misc/forgejo.nix";
+      module = lib.moduleLocFromOptionString "services.forgejo";
       examples.basic = null;
     };
   };

--- a/projects/GNUTaler/default.nix
+++ b/projects/GNUTaler/default.nix
@@ -43,7 +43,7 @@
 
   nixos.modules.services = {
     taler = {
-      module = "${sources.inputs.nixpkgs}/nixos/modules/services/finance/taler/module.nix";
+      module = lib.moduleLocFromOptionString "services.taler";
       examples.basic = {
         # See https://github.com/NixOS/nixpkgs/blob/master/nixos/tests/taler/common/nodes.nix
         module = ./examples/basic/default.nix;

--- a/projects/Galene/default.nix
+++ b/projects/Galene/default.nix
@@ -14,7 +14,7 @@
   nixos.modules.services = {
     galene = {
       name = "galene";
-      module = "${sources.inputs.nixpkgs}/nixos/modules/services/web-apps/galene.nix";
+      module = lib.moduleLocFromOptionString "services.galene";
       examples.galene = {
         module = ./example.nix;
         description = "";

--- a/projects/Gancio/default.nix
+++ b/projects/Gancio/default.nix
@@ -12,7 +12,7 @@
   };
   nixos.modules.services = {
     gancio = {
-      module = "${sources.inputs.nixpkgs}/nixos/modules/services/web-apps/gancio.nix";
+      module = lib.moduleLocFromOptionString "services.gancio";
       examples.gancio = {
         module = ./example.nix;
         description = "";

--- a/projects/Mastodon/default.nix
+++ b/projects/Mastodon/default.nix
@@ -15,7 +15,7 @@
   };
   nixos = {
     modules.services.mastodon = {
-      module = "${sources.inputs.nixpkgs}/nixos/modules/services/web-apps/mastodon.nix";
+      module = lib.moduleLocFromOptionString "services.mastodon";
       examples.basic = null;
     };
     tests = {

--- a/projects/Misskey/default.nix
+++ b/projects/Misskey/default.nix
@@ -15,7 +15,7 @@
   nixos.modules.services = {
     misskey = {
       name = "Misskey";
-      module = "${sources.inputs.nixpkgs}/nixos/modules/services/web-apps/misskey.nix";
+      module = lib.moduleLocFromOptionString "services.misskey";
       examples.basic = {
         module = ./services/misskey/examples/basic.nix;
         description = "";

--- a/projects/Namecoin/default.nix
+++ b/projects/Namecoin/default.nix
@@ -5,8 +5,8 @@
 }:
 {
   nixos = {
-    modules.services.namecoind.module = "${sources.inputs.nixpkgs}/nixos/modules/services/networking/namecoind.nix";
-    modules.services.ncdns.module = "${sources.inputs.nixpkgs}/nixos/modules/services/networking/ncdns.nix";
+    modules.services.namecoind.module = lib.moduleLocFromOptionString "services.namecoind";
+    modules.services.ncdns.module = lib.moduleLocFromOptionString "services.ncdns";
     modules.programs.electrum-nmc = null;
     # the namecoind service module does not add namecoin commands to the environment
     modules.programs.namecoin = null;

--- a/projects/Omnom/default.nix
+++ b/projects/Omnom/default.nix
@@ -15,7 +15,7 @@
   nixos.modules.services = {
     omnom = {
       # https://github.com/asciimoo/omnom/blob/master/config/config.go
-      module = "${sources.inputs.nixpkgs}/nixos/modules/services/misc/omnom.nix";
+      module = lib.moduleLocFromOptionString "services.omnom";
       examples.base = {
         module = ./example.nix;
         description = "Basic Omnom configuration, mainly used for testing purposes";

--- a/projects/OpenWebCalendar/default.nix
+++ b/projects/OpenWebCalendar/default.nix
@@ -8,7 +8,7 @@
   metadata.subgrants = [ "OpenWebCalendar" ];
   nixos.modules.services.open-web-calendar = {
     name = "open-web-calendar";
-    module = "${sources.inputs.nixpkgs}/nixos/modules/services/web-apps/open-web-calendar.nix";
+    module = lib.moduleLocFromOptionString "services.open-web-calendar";
     examples.basic = null;
     links = {
       development = {

--- a/projects/Pixelfed/default.nix
+++ b/projects/Pixelfed/default.nix
@@ -23,7 +23,7 @@
 
   nixos.modules.services = {
     pixelfed = {
-      module = "${sources.inputs.nixpkgs}/nixos/modules/services/web-apps/pixelfed.nix";
+      module = lib.moduleLocFromOptionString "services.pixelfed";
       examples.basic = {
         module = ./example.nix;
         description = "";

--- a/projects/Rosenpass/default.nix
+++ b/projects/Rosenpass/default.nix
@@ -43,7 +43,7 @@
   nixos.modules.services = {
     rosenpass = {
       name = "rosenpass";
-      module = "${sources.inputs.nixpkgs}/nixos/modules/services/networking/rosenpass.nix";
+      module = lib.moduleLocFromOptionString "services.rosenpass";
       examples.basic = {
         module = ./services/basic/examples/basic.nix;
         description = "";

--- a/projects/SCION/default.nix
+++ b/projects/SCION/default.nix
@@ -47,7 +47,7 @@
   nixos.modules.services = {
     scion = {
       name = "scion";
-      module = "${sources.inputs.nixpkgs}/nixos/modules/services/networking/scion/scion.nix";
+      module = lib.moduleLocFromOptionString "services.scion";
       # TODO: unbreak
       # tests.scion = "${sources.inputs.nixpkgs}/nixos/tests/scion/freestanding-deployment/default.nix";
     };

--- a/projects/Wireguard/default.nix
+++ b/projects/Wireguard/default.nix
@@ -31,7 +31,7 @@
 
   nixos.modules.services = {
     wireguard = {
-      module = "${sources.inputs.nixpkgs}/nixos/modules/services/networking/wireguard.nix";
+      module = lib.moduleLocFromOptionString "networking.wireguard";
       examples.basic = null;
     };
   };

--- a/projects/gnunet/default.nix
+++ b/projects/gnunet/default.nix
@@ -21,7 +21,7 @@
   nixos.modules.services = {
     gnunet = {
       name = "gnunet";
-      module = "${sources.inputs.nixpkgs}/nixos/modules/services/networking/gnunet.nix";
+      module = lib.moduleLocFromOptionString "services.gnunet";
       examples.basic = {
         module = ./services/gnunet/examples/basic.nix;
         description = "";

--- a/projects/ntpd-rs/default.nix
+++ b/projects/ntpd-rs/default.nix
@@ -25,7 +25,7 @@
   nixos.modules.services = {
     ntpd-rs = {
       name = "ntpd-rs";
-      module = "${sources.inputs.nixpkgs}/nixos/modules/services/networking/ntp/ntpd-rs.nix";
+      module = lib.moduleLocFromOptionString "services.ntpd-rs";
       examples.basic = null;
       # See https://github.com/NixOS/nixpkgs/blob/nixos-unstable/nixos/tests/ntpd-rs.nix for examples
     };


### PR DESCRIPTION
part of #960