### PR TITLE
cryptpad: fix demo port forwarding

### DIFF
--- a/projects/Cryptpad/demo.nix
+++ b/projects/Cryptpad/demo.nix
@@ -7,8 +7,8 @@
     settings = {
       httpPort = 9000;
       httpAddress = "0.0.0.0";
-      httpUnsafeOrigin = "http://localhost:${toString config.services.cryptpad.settings.httpPort}";
-      httpSafeOrigin = "http://localhost:${toString config.services.cryptpad.settings.httpPort}";
+      httpUnsafeOrigin = "http://localhost:19000";
+      httpSafeOrigin = "http://localhost:19000";
     };
   };
 }


### PR DESCRIPTION
With this change, using demo VM, I can open a document at `http://localhost:19000/sheet/` or `http://localhost:19000/api/config` and `http://localhost:19000/checkup/` can execute all 55 tests (few of them are failing, but the issues are not a problem for our use case).

List of failing `checkup` tests:


> httpUnsafeOrigin and httpSafeOrigin are equivalent. In order for CryptPad's security features to be as effective as intended they must be different. See cryptpad/config/config.js. Changes to cryptpad/config/config.js will require a server restart in order for [/api/config](http://localhost:19000/api/config) to be updated.

> http://localhost:19000/sheet/inner.html was served with incorrect Content-Security-Policy headers.
> A value of "'self' blob: http://localhost:19000" was expected for the frame-src directive.
> A value of "'self' blob: http://localhost:19000 http://localhost:19000 ws://localhost:19000" was expected for the connect-src directive. This rule restricts which URLs can be loaded by scripts. Overly permissive settings can allow users to be tracked using external resources, while overly restrictive settings may block pages from loading entirely.

> http://localhost:19000/ was served with incorrect Content-Security-Policy headers.
> A value of "'self' blob: http://localhost:19000" was expected for the frame-src directive.
> A value of "'self' blob: http://localhost:19000 http://localhost:19000 ws://localhost:19000" was expected for the connect-src directive. This rule restricts which URLs can be loaded by scripts. Overly permissive settings can allow users to be tracked using external resources, while overly restrictive settings may block pages from loading entirely.

Closes: #970
