### PR TITLE
cryptpad: fix demo port forwarding using same port numbers

### DIFF
--- a/overview/default.nix
+++ b/overview/default.nix
@@ -289,7 +289,7 @@ let
         };
         openPorts = demoSystem.config.networking.firewall.allowedTCPPorts;
         # The port that is forwarded to the host so that the user can access the demo service.
-        servicePort = (builtins.head openPorts) + 10000;
+        servicePort = (builtins.head openPorts);
       in
       ''
         ${heading 2 "demo" "Run a demo deployment locally"}

--- a/overview/demo/default.nix
+++ b/overview/demo/default.nix
@@ -46,6 +46,9 @@ let
 
             services.openssh = {
               enable = true;
+              ports = [
+                10022
+              ];
               settings = {
                 PasswordAuthentication = true;
                 PermitEmptyPasswords = "yes";
@@ -71,7 +74,7 @@ let
               forwardPorts = map (port: {
                 from = "host";
                 guest.port = port;
-                host.port = port + 10000;
+                host.port = port;
                 proto = "tcp";
               }) config.networking.firewall.allowedTCPPorts;
             };


### PR DESCRIPTION
This is a alternative to #1000 . Disadvantage of this approach comparing to #1000 is that we need to run all public facing services on non-standard ports.

Closes: #970
