### PR TITLE
infra/secrets: Update Cachix token

### DIFF
--- a/infra/secrets.json
+++ b/infra/secrets.json
@@ -1,40 +1,35 @@
 {
-	"cachix": "ENC[AES256_GCM,data:9lRbA0Hky8yLmS0gnsFU9bRL2bJRcOq3qy3mo0/1xGFxrhx0zVRmP5gshIZT/QYivPIM7FaI0Cn9IEYFVzKGvwpsy+mpEmwDg2DIk2DhRweBpPWYGn8X49WfAHs4a6YCwCIUfDyIM22Q2FE8AiVsRw2hBOUep5/VwDfw1u4HrCgLaUfNuJ8eJTwBVz/H9hzGBXMD5Qo=,iv:6zaZ8We5bA1rkOztdjqL3in0RfS7OgWXWGq11fIU4n0=,tag:gwGVvjiO+ZA6UfHD/7EKYA==,type:str]",
-	"amazon": {
-		"aws_access_key_id": "ENC[AES256_GCM,data:zumbm01b0HsBJ6vdEzqf70Svu8Q=,iv:BSY/mtgdEYRRTbAC1ozXLKA0NeXnDHIkw1LMKq5vGo4=,tag:PPwZ2C3euhM1TsDXMMI8jQ==,type:str]",
-		"aws_secret_access_key": "ENC[AES256_GCM,data:U97lCA4VazMRtTqyuG0vNHY3B9UCId7DKHuZdMg5INRm1jgvKYnhmg==,iv:tumYVcYJetcw+NERFp1dU8Thb9cAlsofTrgRTPxNohg=,tag:WMWWv8gM81uZnyzZzwIV4A==,type:str]"
-	},
-	"github": {
-		"ngi-nix-bot": {
-			"password": "ENC[AES256_GCM,data:xXaNO5K7aOll2wWtts2Izg==,iv:Gwv/aP/sA8XBI/42ZUhVvZxl9+GdGHy+I+0iqPiRP8E=,tag:51AOE+8s5wNRUGrt3EiYAw==,type:str]",
-			"totp-secret": "ENC[AES256_GCM,data:OCOt4UvlgMVyrCLnCWFqmg==,iv:x9fFWbs0s4tGwXz6aRBwDOv5T01tpm1oCSoSpjAZvlc=,tag:ZSPTo+lKxBy5OZHdxlNRWQ==,type:str]"
-		}
-	},
-	"cache": "ENC[AES256_GCM,data:HaKFhsm4lYsNxg7BQYFJ+ORuJHhu/EHryATqbMz8ivXXqNG/SovWxH5pNEvPN4/BnPFpTcbGToB6YY1ioOskZcwWLpVe2E2isL3ZG7QlFPLlCs5KfAlm6866nKFJahuUCJGCbGJOik3Wr3Z9MkGa,iv:Vayv2rICeEmjvQWo7htuQ146Ns5IHpV4jb3fldMLmf0=,tag:3MjKcCqzqP11EjZeObNNFw==,type:str]",
-	"sops": {
-		"shamir_threshold": 1,
-		"kms": null,
-		"gcp_kms": null,
-		"azure_kv": null,
-		"hc_vault": null,
-		"age": [
-			{
-				"recipient": "age1c0g6s6daxy79dlm9uqczwlkh0hvjpghw5h8zzljc3vs275rvvqus30hv9l",
-				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIM2dxaW5tVTYxSmxnTmFP\nMG1OSTJQK1FYb3VOSTRzeEJjeXdPbjJLdW1JCk1jS3NLK01NTVl3eGw3RlkyblVI\nWHYzRFkreDZaTkJSeXQzVHJWaVVCRlUKLS0tIFBMUHIyOU1xdVArZjZsOXN2Uk5I\nYllaY3EvMjdlakNPaXdMaE9lUDZ2MDAK9Ei4bGy2qOljtUdz2s98xFxVbN7urn/9\ndPygmMQXd5QTubVjR55wi18kYCcTDq3Rosq7DQIqQ98sNW/pTH8OMA==\n-----END AGE ENCRYPTED FILE-----\n"
-			},
-			{
-				"recipient": "age1c0g6s6daxy79dlm9uqczwlkh0hvjpghw5h8zzljc3vs275rvvqus30hv9l",
-				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCV2UwZ1k2aUF3MlBBVDlD\nYUI3NzcxSmIwUDZxQk5id3B3SVhMVnRxMUNzCmVaaEFMTXZHWGdlMnpTLzBLenlT\nQk43V1VvNDNjR25udlJtR1ZENElDaTQKLS0tIFRyTTgybTZBaTUzbWpTKytaaUxn\nRTBJV0Z4dGQvaEI5Ump3T2s5SE9ZZDQKVBQDPGW/8l97gzgp/vXS87UFR0J8PyZJ\nCpXjXB+luiYbeSRjJ2b5bZ2JrsLB7wVZzpYo2cU7aXKyyV47TzhULw==\n-----END AGE ENCRYPTED FILE-----\n"
-			},
-			{
-				"recipient": "age1ewus3xraznqv6xc2ptua2qjqrjyhfd8uugu08wjduushj3uhgqwsqd6vkk",
-				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArWGp2Rm1PVWtKT3l2Ui9z\nRzZmZ3IzYVdzRGt4dHdvWGxVNnZtZzVlQldrCjA1VHpvNC9ObXUyRWpGMmpaYXR2\nQW1oWk9YWjMxQy9VMkN1YXNzZXpFNUEKLS0tIHF5NHoraGRHU25NejRCQndBektr\nRWprT0N6QkdCOHcwTTdWTmx6bXhaZ2cKxQuE56bznnJJDhgKPuyu+JAQHbswQV9n\nChOwGxdHLzViKvmgVCqx84UjBujCtlwTNCDxe1hotjeQnfqIVWpkUA==\n-----END AGE ENCRYPTED FILE-----\n"
-			}
-		],
-		"lastmodified": "2024-06-11T23:40:44Z",
-		"mac": "ENC[AES256_GCM,data:+OSq0qVJUchyr2J06qycwGYSOvsR+jW23CPWtGClVdOI+rWzYX/YhPmm6UAIQ15QXU+RD9HrhEN+asLZu2GRaeifqJfuaCioArMr981n0vcCc27H/3HrdwtS9akhWRmocwONRcZ02MIpjhNOzL1G3lKjy6dBcpJN2XSnEH8cOco=,iv:9ad1gLUrrJqW1AKjfWqHz4YSiKCpso3sizufaEaeRbE=,tag:uOqiFYuzYCUMxhiSHvAr+Q==,type:str]",
-		"pgp": null,
-		"unencrypted_suffix": "_unencrypted",
-		"version": "3.8.1"
-	}
+  "cachix": "ENC[AES256_GCM,data:WQ/veLYnABoBzETqf0DNegQummAcI0Ch0MyjEks4Yz/+6UPbv/m91xLquqYzaGEJWWCsiqssjYlDmP4K1CkJp9jMa/KQXoKIccjklDa4ARBQqmQ3aW1QPx8hg/lQyUpf+WMeU9JyOVQ/9TUJrLu9xk2wnV8EocFngFypM4ZNMvLHznyuJh6Ab4RgwdyHULxGzZuD7jU=,iv:WiVb2HD5g01CA4Eeo4qcsvBZVrvvzur+ow755VfCQzg=,tag:6GZFjBGt+CjNOf1schY52g==,type:str]",
+  "amazon": {
+    "aws_access_key_id": "ENC[AES256_GCM,data:zumbm01b0HsBJ6vdEzqf70Svu8Q=,iv:BSY/mtgdEYRRTbAC1ozXLKA0NeXnDHIkw1LMKq5vGo4=,tag:PPwZ2C3euhM1TsDXMMI8jQ==,type:str]",
+    "aws_secret_access_key": "ENC[AES256_GCM,data:U97lCA4VazMRtTqyuG0vNHY3B9UCId7DKHuZdMg5INRm1jgvKYnhmg==,iv:tumYVcYJetcw+NERFp1dU8Thb9cAlsofTrgRTPxNohg=,tag:WMWWv8gM81uZnyzZzwIV4A==,type:str]"
+  },
+  "github": {
+    "ngi-nix-bot": {
+      "password": "ENC[AES256_GCM,data:xXaNO5K7aOll2wWtts2Izg==,iv:Gwv/aP/sA8XBI/42ZUhVvZxl9+GdGHy+I+0iqPiRP8E=,tag:51AOE+8s5wNRUGrt3EiYAw==,type:str]",
+      "totp-secret": "ENC[AES256_GCM,data:OCOt4UvlgMVyrCLnCWFqmg==,iv:x9fFWbs0s4tGwXz6aRBwDOv5T01tpm1oCSoSpjAZvlc=,tag:ZSPTo+lKxBy5OZHdxlNRWQ==,type:str]"
+    }
+  },
+  "cache": "ENC[AES256_GCM,data:HaKFhsm4lYsNxg7BQYFJ+ORuJHhu/EHryATqbMz8ivXXqNG/SovWxH5pNEvPN4/BnPFpTcbGToB6YY1ioOskZcwWLpVe2E2isL3ZG7QlFPLlCs5KfAlm6866nKFJahuUCJGCbGJOik3Wr3Z9MkGa,iv:Vayv2rICeEmjvQWo7htuQ146Ns5IHpV4jb3fldMLmf0=,tag:3MjKcCqzqP11EjZeObNNFw==,type:str]",
+  "sops": {
+    "shamir_threshold": 1,
+    "age": [
+      {
+        "recipient": "age1c0g6s6daxy79dlm9uqczwlkh0hvjpghw5h8zzljc3vs275rvvqus30hv9l",
+        "enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIM2dxaW5tVTYxSmxnTmFP\nMG1OSTJQK1FYb3VOSTRzeEJjeXdPbjJLdW1JCk1jS3NLK01NTVl3eGw3RlkyblVI\nWHYzRFkreDZaTkJSeXQzVHJWaVVCRlUKLS0tIFBMUHIyOU1xdVArZjZsOXN2Uk5I\nYllaY3EvMjdlakNPaXdMaE9lUDZ2MDAK9Ei4bGy2qOljtUdz2s98xFxVbN7urn/9\ndPygmMQXd5QTubVjR55wi18kYCcTDq3Rosq7DQIqQ98sNW/pTH8OMA==\n-----END AGE ENCRYPTED FILE-----\n"
+      },
+      {
+        "recipient": "age1c0g6s6daxy79dlm9uqczwlkh0hvjpghw5h8zzljc3vs275rvvqus30hv9l",
+        "enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCV2UwZ1k2aUF3MlBBVDlD\nYUI3NzcxSmIwUDZxQk5id3B3SVhMVnRxMUNzCmVaaEFMTXZHWGdlMnpTLzBLenlT\nQk43V1VvNDNjR25udlJtR1ZENElDaTQKLS0tIFRyTTgybTZBaTUzbWpTKytaaUxn\nRTBJV0Z4dGQvaEI5Ump3T2s5SE9ZZDQKVBQDPGW/8l97gzgp/vXS87UFR0J8PyZJ\nCpXjXB+luiYbeSRjJ2b5bZ2JrsLB7wVZzpYo2cU7aXKyyV47TzhULw==\n-----END AGE ENCRYPTED FILE-----\n"
+      },
+      {
+        "recipient": "age1ewus3xraznqv6xc2ptua2qjqrjyhfd8uugu08wjduushj3uhgqwsqd6vkk",
+        "enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArWGp2Rm1PVWtKT3l2Ui9z\nRzZmZ3IzYVdzRGt4dHdvWGxVNnZtZzVlQldrCjA1VHpvNC9ObXUyRWpGMmpaYXR2\nQW1oWk9YWjMxQy9VMkN1YXNzZXpFNUEKLS0tIHF5NHoraGRHU25NejRCQndBektr\nRWprT0N6QkdCOHcwTTdWTmx6bXhaZ2cKxQuE56bznnJJDhgKPuyu+JAQHbswQV9n\nChOwGxdHLzViKvmgVCqx84UjBujCtlwTNCDxe1hotjeQnfqIVWpkUA==\n-----END AGE ENCRYPTED FILE-----\n"
+      }
+    ],
+    "lastmodified": "2025-05-19T10:19:02Z",
+    "mac": "ENC[AES256_GCM,data:gfdpEzjlXJKSQi6bAEqI5Dx6XiIOTw1E5Awso36yI93/LYPd0sJ8FUhZp/0WaCmyYLrJYSShxr+VsQpqogLyLEtl1hE7yMYUZC6PBqs7SyEuoheLUQQFyH9s8tGvDy24AJ604iNgnbOwXOV3hMj/qZfuQYT1VbCx3MMmwJrNYsI=,iv:52mVTDNwZqipX2BcsL+3t3jq9nhykcsxXxCuabJWh9I=,tag:SuE9Cc+UuNo7hScny4l7Lw==,type:str]",
+    "unencrypted_suffix": "_unencrypted",
+    "version": "3.10.2"
+  }
 }


### PR DESCRIPTION
Temporary workaround for #1035 while ownership transfer is pending.

To diff the unencrypted files (with bash):

```bash
diff \
  <(git show origin/main:infra/secrets.json | sops -d --filename-override infra/secrets.json /dev/stdin) \
  <(git show 49e2c181aaa:infra/secrets.json | sops -d --filename-override infra/secrets.json /dev/stdin)
```

[Looks like I have sops 3.10.2 now](https://github.com/ngi-nix/ngipkgs/pull/1036/files#diff-4ee00ab238eda0462253ad92af370b6b124c50b7f95259bb32b0c1e7b0d28d75R33), up from 3.8.1. 24.11 has 3.9 and 25.05 has 3.10. Hope that's not a problem... If I understand correctly, `makemake` uses unstable, so it should be fine.