### PR TITLE
ci: use branch's ngipkgs when testing demo

### DIFF
--- a/.github/workflows/test-demo.sh
+++ b/.github/workflows/test-demo.sh
@@ -39,17 +39,16 @@ echo -e "\n-> Building VM ..."
 # https://github.com/NixOS/nix/issues/6820
 if [ "$NIX_VERSION" -ge 22400 ]; then
     echo "Using Nix installed by Linux package manager"
-    nix-build /default.nix
+    nix-build --arg ngipkgs "import /ngipkgs {}" /default.nix
 else
     echo "Using Nix from Nixpkgs unstable"
 
     nixpkgs_revision=$(
-        nix-instantiate --eval --attr sources.nixpkgs.rev https://github.com/ngi-nix/ngipkgs/archive/master.tar.gz \
+        nix-instantiate --eval --attr sources.nixpkgs.rev /ngipkgs \
         | jq --raw-output
     )
     NIXPKGS="https://github.com/NixOS/nixpkgs/archive/$nixpkgs_revision.tar.gz"
-    
-    nix-shell --include nixpkgs="$NIXPKGS" --packages nix --run "nix-build /default.nix"
+    nix-shell --include nixpkgs="$NIXPKGS" --packages nix --run "nix-build --arg ngipkgs \"import /ngipkgs {}\" /default.nix"
 fi
 
 echo -e "\n-> Launching VM ..."

--- a/.github/workflows/test-demo.sh
+++ b/.github/workflows/test-demo.sh
@@ -1,18 +1,6 @@
 #!/usr/bin/env bash
 
-# nix build .#overview
-# podman run --privileged \
-#   --volume ./result/project/Cryptpad/default.nix:/default.nix \
-#   --volume .github/workflows/test-demo.sh:/test-demo.sh <DISTRO> /bin/bash \
-#   -c "bash /test-demo.sh <DISTRO>"
-
-set -euo pipefail
-
-DISTRO="$1"
-# shellcheck disable=SC2089,2026
-NIX_CONFIG='substituters = https://cache.nixos.org/ https://ngi.cachix.org/'$'\n''trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ngi.cachix.org-1:n+CAL72ROC3qQuLxIHpV+Tw5t42WhXmMhprAGkRSrOw='
-export NIX_CONFIG
-
+set -eo pipefail
 
 echo -e "\n-> Installing Nix ..."
 # Debian/Ubuntu

--- a/.github/workflows/test-demo.yaml
+++ b/.github/workflows/test-demo.yaml
@@ -37,6 +37,6 @@ jobs:
           docker run
           --privileged
           --volume ./result/project/Cryptpad/default.nix:/default.nix
-          --volume "$(pwd)/.github/workflows/test-demo.sh:/test-demo.sh"
+          --volume "$(pwd):/ngipkgs"
           ${{ matrix.distro }}
-          /bin/bash -c "bash /test-demo.sh ${{ matrix.distro }}"
+          /bin/bash -c "bash /ngipkgs/.github/workflows/test-demo.sh ${{ matrix.distro }}"

--- a/.github/workflows/test-demo.yaml
+++ b/.github/workflows/test-demo.yaml
@@ -33,10 +33,16 @@ jobs:
         run: nix build .#overview
 
       - name: Run and test VM
+        env:
+          DISTRO: ${{ matrix.distro }}
+          NIX_CONFIG: |
+            extra-substituters = https://ngi.cachix.org/
+            extra-trusted-public-keys = ngi.cachix.org-1:n+CAL72ROC3qQuLxIHpV+Tw5t42WhXmMhprAGkRSrOw=
         run: >
           docker run
           --privileged
           --volume ./result/project/Cryptpad/default.nix:/default.nix
           --volume "$(pwd):/ngipkgs"
-          ${{ matrix.distro }}
-          /bin/bash -c "bash /ngipkgs/.github/workflows/test-demo.sh ${{ matrix.distro }}"
+          -e DISTRO="$DISTRO"
+          "$DISTRO"
+          /bin/bash -c "bash /ngipkgs/.github/workflows/test-demo.sh"


### PR DESCRIPTION
Else it will always fail, since the PR's changes aren't in NGIpkgs' main branch.