### PR TITLE
Cleanup monorepo code

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -180,22 +180,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1747485343,
-        "narHash": "sha256-YbsZyuRE1tobO9sv0PUwg81QryYo3L1F3R3rF9bcG38=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "9b5ac7ad45298d58640540d0323ca217f32a6762",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat_2",
@@ -264,7 +248,6 @@
         "dream2nix": "dream2nix",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-stable": "nixpkgs-stable",
         "pre-commit-hooks": "pre-commit-hooks",
         "sops-nix": "sops-nix",
         "systems": "systems"

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,6 @@
   inputs.dream2nix.url = "github:nix-community/dream2nix";
   inputs.flake-utils.inputs.systems.follows = "systems";
   inputs.flake-utils.url = "github:numtide/flake-utils";
-  inputs.nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-24.11";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   inputs.pre-commit-hooks.inputs.nixpkgs.follows = "nixpkgs";
   inputs.pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
@@ -22,10 +21,7 @@
       self,
       nixpkgs,
       flake-utils,
-      sops-nix,
       pre-commit-hooks,
-      dream2nix,
-      buildbot-nix,
       ...
     }@inputs:
     let
@@ -36,11 +32,8 @@
       inherit (classic') lib lib';
 
       inherit (lib)
-        attrValues
         concatMapAttrs
         filterAttrs
-        mapAttrs
-        recursiveUpdate
         ;
 
       overlay = classic'.overlays.default;
@@ -68,8 +61,6 @@
           };
 
           inherit (classic) pkgs ngipkgs optionsDoc;
-
-          ngiProjects = classic.projects;
         in
         rec {
           packages = ngipkgs // {

--- a/projects/CryptoLyzer/default.nix
+++ b/projects/CryptoLyzer/default.nix
@@ -26,23 +26,7 @@
   # };
   nixos = {
     modules.programs.cryptolyzer = {
-      module =
-        {
-          config,
-          lib,
-          pkgs,
-          ...
-        }:
-        let
-          cfg = config.programs.cryptolyzer;
-        in
-        {
-          options.programs.cryptolyzer = {
-            enable = lib.mkEnableOption "CryptoLyzer";
-            package = lib.mkPackageOption pkgs.python3Packages "cryptolyzer" { };
-          };
-          config.environment.systemPackages = lib.mkIf cfg.enable [ cfg.package ];
-        };
+      module = ./module.nix;
       links = {
         development = {
           text = "Development environment with `pipenv`";

--- a/projects/CryptoLyzer/module.nix
+++ b/projects/CryptoLyzer/module.nix
@@ -1,0 +1,16 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.cryptolyzer;
+in
+{
+  options.programs.cryptolyzer = {
+    enable = lib.mkEnableOption "CryptoLyzer";
+    package = lib.mkPackageOption pkgs.python3Packages "cryptolyzer" { };
+  };
+  config.environment.systemPackages = lib.mkIf cfg.enable [ cfg.package ];
+}

--- a/projects/default.nix
+++ b/projects/default.nix
@@ -2,7 +2,6 @@
   lib,
   pkgs,
   sources,
-  types' ? import ./types.nix { inherit lib; },
 }:
 let
   inherit (builtins)
@@ -11,15 +10,12 @@ let
     trace
     ;
 
-  inherit (lib)
-    types
-    mkOption
-    ;
-
   inherit (lib.attrsets)
     concatMapAttrs
     mapAttrs
     ;
+
+  types = import ./types.nix { inherit lib; };
 
   baseDirectory = ./.;
 
@@ -43,82 +39,7 @@ let
     concatMapAttrs names (readDir baseDirectory);
 in
 {
-  options.projects = mkOption {
-    type =
-      with types;
-      attrsOf (
-        submodule (
-          { name, ... }:
-          {
-            options = {
-              name = mkOption {
-                type = with types; nullOr str;
-                default = name;
-              };
-              metadata = mkOption {
-                type =
-                  with types;
-                  nullOr (submodule {
-                    options = {
-                      summary = mkOption {
-                        type = nullOr str;
-                        default = null;
-                      };
-                      # TODO: convert all subgrants to `subgrant`, remove listOf
-                      subgrants = mkOption {
-                        type = either (listOf str) types'.subgrant;
-                        default = null;
-                      };
-                      links = mkOption {
-                        type = attrsOf types'.link;
-                        default = { };
-                      };
-                    };
-                  });
-                default = null;
-              };
-              binary = mkOption {
-                type = with types; attrsOf types'.binary;
-                default = { };
-              };
-              nixos = mkOption {
-                type =
-                  with types;
-                  submodule {
-                    options = {
-                      modules.services = mkOption {
-                        type = nullOr (attrsOf (nullOr types'.service));
-                        default = null;
-                      };
-                      modules.programs = mkOption {
-                        type = nullOr (attrsOf (nullOr types'.program));
-                        default = null;
-                      };
-                      # An application component may have examples using it in isolation,
-                      # but examples may involve multiple application components.
-                      # Having examples at both layers allows us to trace coverage more easily.
-                      # If this tends to be too cumbersome for package authors and we find a way obtain coverage information programmatically,
-                      # we can still reduce granularity and move all examples to the application level.
-                      examples = mkOption {
-                        type = nullOr (attrsOf types'.example);
-                        default = null;
-                      };
-                      # TODO: Tests should really only be per example, in order to clarify that we care about tested examples more than merely tests.
-                      #       But reality is such that most NixOS tests aren't based on self-contained, minimal examples, or if they are they can't be extracted easily.
-                      #       Without this field, many applications will appear entirely untested although there's actually *some* assurance that *something* works.
-                      #       Eventually we want to move to documentable tests exclusively, and then remove this field, but this may take a very long time.
-                      tests = mkOption {
-                        type = nullOr (attrsOf types'.test);
-                        default = null;
-                      };
-                    };
-                  };
-              };
-            };
-          }
-        )
-      );
-  };
+  options.projects = types.projects;
 
   config.projects = mapAttrs (
     name: directory: import directory { inherit lib pkgs sources; }

--- a/projects/types.nix
+++ b/projects/types.nix
@@ -201,11 +201,11 @@ rec {
                       };
                       # TODO: convert all subgrants to `subgrant`, remove listOf
                       subgrants = mkOption {
-                        type = either (listOf str) types'.subgrant;
+                        type = either (listOf str) subgrant;
                         default = null;
                       };
                       links = mkOption {
-                        type = attrsOf types'.link;
+                        type = attrsOf link;
                         default = { };
                       };
                     };
@@ -213,7 +213,7 @@ rec {
                 default = null;
               };
               binary = mkOption {
-                type = with types; attrsOf types'.binary;
+                type = with types; attrsOf binary;
                 default = { };
               };
               nixos = mkOption {
@@ -222,11 +222,11 @@ rec {
                   submodule {
                     options = {
                       modules.services = mkOption {
-                        type = nullOr (attrsOf (nullOr types'.service));
+                        type = nullOr (attrsOf (nullOr service));
                         default = null;
                       };
                       modules.programs = mkOption {
-                        type = nullOr (attrsOf (nullOr types'.program));
+                        type = nullOr (attrsOf (nullOr program));
                         default = null;
                       };
                       # An application component may have examples using it in isolation,
@@ -235,7 +235,7 @@ rec {
                       # If this tends to be too cumbersome for package authors and we find a way obtain coverage information programmatically,
                       # we can still reduce granularity and move all examples to the application level.
                       examples = mkOption {
-                        type = nullOr (attrsOf types'.example);
+                        type = nullOr (attrsOf example);
                         default = null;
                       };
                       # TODO: Tests should really only be per example, in order to clarify that we care about tested examples more than merely tests.
@@ -243,7 +243,7 @@ rec {
                       #       Without this field, many applications will appear entirely untested although there's actually *some* assurance that *something* works.
                       #       Eventually we want to move to documentable tests exclusively, and then remove this field, but this may take a very long time.
                       tests = mkOption {
-                        type = nullOr (attrsOf types'.test);
+                        type = nullOr (attrsOf test);
                         default = null;
                       };
                     };

--- a/projects/types.nix
+++ b/projects/types.nix
@@ -92,50 +92,6 @@ rec {
       }
     );
 
-  # TODO: plugins are actually component *extensions* that are of component-specific type,
-  #       and which compose in application-specific ways defined in the application module.
-  #       this also means that there's no fundamental difference between programs and services,
-  #       and even languages: libraries are just extensions of compilers.
-  # TODO: implement this, now that we're using the module system
-  plugin = with types; anything;
-
-  nonEmtpyAttrs =
-    elemType:
-    with types;
-    (
-      (attrsOf elemType)
-      // {
-        name = "nonEmtpyAttrs";
-        description = "non-empty attribute set";
-        check = x: lib.isAttrs x && x != { };
-      }
-    );
-
-  example =
-    with types;
-    submodule {
-      options = {
-        module = mkOption {
-          description = "the example must be a NixOS module in a file";
-          type = deferredModule;
-        };
-        description = mkOption {
-          description = "description of the example, ideally with further instructions on how to use it";
-          type = nullOr str;
-          default = null;
-        };
-        tests = mkOption {
-          description = "at least one test for the example";
-          type = nonEmtpyAttrs (nullOr test);
-        };
-        links = mkOption {
-          description = "links to related resources";
-          type = attrsOf link;
-          default = { };
-        };
-      };
-    };
-
   # TODO: port modular services to programs
   program =
     with types;
@@ -196,6 +152,50 @@ rec {
       }
     );
 
+  # TODO: plugins are actually component *extensions* that are of component-specific type,
+  #       and which compose in application-specific ways defined in the application module.
+  #       this also means that there's no fundamental difference between programs and services,
+  #       and even languages: libraries are just extensions of compilers.
+  # TODO: implement this, now that we're using the module system
+  plugin = with types; anything;
+
+  nonEmtpyAttrs =
+    elemType:
+    with types;
+    (
+      (attrsOf elemType)
+      // {
+        name = "nonEmtpyAttrs";
+        description = "non-empty attribute set";
+        check = x: lib.isAttrs x && x != { };
+      }
+    );
+
+  example =
+    with types;
+    submodule {
+      options = {
+        module = mkOption {
+          description = "the example must be a NixOS module in a file";
+          type = deferredModule;
+        };
+        description = mkOption {
+          description = "description of the example, ideally with further instructions on how to use it";
+          type = nullOr str;
+          default = null;
+        };
+        tests = mkOption {
+          description = "at least one test for the example";
+          type = nonEmtpyAttrs (nullOr test);
+        };
+        links = mkOption {
+          description = "links to related resources";
+          type = attrsOf link;
+          default = { };
+        };
+      };
+    };
+
   test = with types; either deferredModule package;
 
   projects = mkOption {
@@ -223,12 +223,12 @@ rec {
                   with types;
                   submodule {
                     options = {
-                      modules.services = mkOption {
-                        type = nullOr (attrsOf (nullOr service));
-                        default = null;
-                      };
                       modules.programs = mkOption {
                         type = nullOr (attrsOf (nullOr program));
+                        default = null;
+                      };
+                      modules.services = mkOption {
+                        type = nullOr (attrsOf (nullOr service));
                         default = null;
                       };
                       # An application component may have examples using it in isolation,

--- a/projects/types.nix
+++ b/projects/types.nix
@@ -9,6 +9,26 @@ let
     ;
 in
 rec {
+  metadata =
+    with types;
+    submodule {
+      options = {
+        summary = mkOption {
+          type = nullOr str;
+          default = null;
+        };
+        # TODO: convert all subgrants to `subgrant`, remove listOf
+        subgrants = mkOption {
+          type = either (listOf str) subgrant;
+          default = null;
+        };
+        links = mkOption {
+          type = attrsOf link;
+          default = { };
+        };
+      };
+    };
+
   subgrant =
     with types;
     submodule {
@@ -191,25 +211,7 @@ rec {
                 default = name;
               };
               metadata = mkOption {
-                type =
-                  with types;
-                  nullOr (submodule {
-                    options = {
-                      summary = mkOption {
-                        type = nullOr str;
-                        default = null;
-                      };
-                      # TODO: convert all subgrants to `subgrant`, remove listOf
-                      subgrants = mkOption {
-                        type = either (listOf str) subgrant;
-                        default = null;
-                      };
-                      links = mkOption {
-                        type = attrsOf link;
-                        default = { };
-                      };
-                    };
-                  });
+                type = with types; nullOr metadata;
                 default = null;
               };
               binary = mkOption {

--- a/projects/types.nix
+++ b/projects/types.nix
@@ -7,8 +7,10 @@ let
     types
     mkOption
     ;
+
+  types' = import ./types.nix { inherit lib; };
 in
-rec {
+{
   metadata =
     with types;
     submodule {
@@ -19,11 +21,11 @@ rec {
         };
         # TODO: convert all subgrants to `subgrant`, remove listOf
         subgrants = mkOption {
-          type = either (listOf str) subgrant;
+          type = either (listOf str) types'.subgrant;
           default = null;
         };
         links = mkOption {
-          type = attrsOf link;
+          type = attrsOf types'.link;
           default = { };
         };
       };
@@ -107,15 +109,15 @@ rec {
             type = deferredModule;
           };
           examples = mkOption {
-            type = attrsOf (nullOr example);
+            type = attrsOf (nullOr types'.example);
             default = { };
           };
           extensions = mkOption {
-            type = attrsOf (nullOr plugin);
+            type = attrsOf (nullOr types'.plugin);
             default = { };
           };
           links = mkOption {
-            type = attrsOf link;
+            type = attrsOf types'.link;
             default = { };
           };
         };
@@ -137,15 +139,15 @@ rec {
             type = deferredModule;
           };
           examples = mkOption {
-            type = nullOr (attrsOf (nullOr example));
+            type = nullOr (attrsOf (nullOr types'.example));
             default = null;
           };
           extensions = mkOption {
-            type = nullOr (attrsOf (nullOr plugin));
+            type = nullOr (attrsOf (nullOr types'.plugin));
             default = null;
           };
           links = mkOption {
-            type = attrsOf link;
+            type = attrsOf types'.link;
             default = { };
           };
         };
@@ -186,11 +188,11 @@ rec {
         };
         tests = mkOption {
           description = "at least one test for the example";
-          type = nonEmtpyAttrs (nullOr test);
+          type = types'.nonEmtpyAttrs (nullOr types'.test);
         };
         links = mkOption {
           description = "links to related resources";
-          type = attrsOf link;
+          type = attrsOf types'.link;
           default = { };
         };
       };
@@ -211,11 +213,11 @@ rec {
                 default = name;
               };
               metadata = mkOption {
-                type = with types; nullOr metadata;
+                type = with types; nullOr types'.metadata;
                 default = null;
               };
               binary = mkOption {
-                type = with types; attrsOf binary;
+                type = with types; attrsOf types'.binary;
                 default = { };
               };
               nixos = mkOption {
@@ -224,11 +226,11 @@ rec {
                   submodule {
                     options = {
                       modules.programs = mkOption {
-                        type = nullOr (attrsOf (nullOr program));
+                        type = nullOr (attrsOf (nullOr types'.program));
                         default = null;
                       };
                       modules.services = mkOption {
-                        type = nullOr (attrsOf (nullOr service));
+                        type = nullOr (attrsOf (nullOr types'.service));
                         default = null;
                       };
                       # An application component may have examples using it in isolation,
@@ -237,7 +239,7 @@ rec {
                       # If this tends to be too cumbersome for package authors and we find a way obtain coverage information programmatically,
                       # we can still reduce granularity and move all examples to the application level.
                       examples = mkOption {
-                        type = nullOr (attrsOf example);
+                        type = nullOr (attrsOf types'.example);
                         default = null;
                       };
                       # TODO: Tests should really only be per example, in order to clarify that we care about tested examples more than merely tests.
@@ -245,7 +247,7 @@ rec {
                       #       Without this field, many applications will appear entirely untested although there's actually *some* assurance that *something* works.
                       #       Eventually we want to move to documentable tests exclusively, and then remove this field, but this may take a very long time.
                       tests = mkOption {
-                        type = nullOr (attrsOf test);
+                        type = nullOr (attrsOf types'.test);
                         default = null;
                       };
                     };

--- a/projects/types.nix
+++ b/projects/types.nix
@@ -177,4 +177,81 @@ rec {
     );
 
   test = with types; either deferredModule package;
+
+  projects = mkOption {
+    type =
+      with types;
+      attrsOf (
+        submodule (
+          { name, ... }:
+          {
+            options = {
+              name = mkOption {
+                type = with types; nullOr str;
+                default = name;
+              };
+              metadata = mkOption {
+                type =
+                  with types;
+                  nullOr (submodule {
+                    options = {
+                      summary = mkOption {
+                        type = nullOr str;
+                        default = null;
+                      };
+                      # TODO: convert all subgrants to `subgrant`, remove listOf
+                      subgrants = mkOption {
+                        type = either (listOf str) types'.subgrant;
+                        default = null;
+                      };
+                      links = mkOption {
+                        type = attrsOf types'.link;
+                        default = { };
+                      };
+                    };
+                  });
+                default = null;
+              };
+              binary = mkOption {
+                type = with types; attrsOf types'.binary;
+                default = { };
+              };
+              nixos = mkOption {
+                type =
+                  with types;
+                  submodule {
+                    options = {
+                      modules.services = mkOption {
+                        type = nullOr (attrsOf (nullOr types'.service));
+                        default = null;
+                      };
+                      modules.programs = mkOption {
+                        type = nullOr (attrsOf (nullOr types'.program));
+                        default = null;
+                      };
+                      # An application component may have examples using it in isolation,
+                      # but examples may involve multiple application components.
+                      # Having examples at both layers allows us to trace coverage more easily.
+                      # If this tends to be too cumbersome for package authors and we find a way obtain coverage information programmatically,
+                      # we can still reduce granularity and move all examples to the application level.
+                      examples = mkOption {
+                        type = nullOr (attrsOf types'.example);
+                        default = null;
+                      };
+                      # TODO: Tests should really only be per example, in order to clarify that we care about tested examples more than merely tests.
+                      #       But reality is such that most NixOS tests aren't based on self-contained, minimal examples, or if they are they can't be extracted easily.
+                      #       Without this field, many applications will appear entirely untested although there's actually *some* assurance that *something* works.
+                      #       Eventually we want to move to documentable tests exclusively, and then remove this field, but this may take a very long time.
+                      tests = mkOption {
+                        type = nullOr (attrsOf types'.test);
+                        default = null;
+                      };
+                    };
+                  };
+              };
+            };
+          }
+        )
+      );
+  };
 }

--- a/projects/types.nix
+++ b/projects/types.nix
@@ -106,7 +106,7 @@ in
             default = name;
           };
           module = mkOption {
-            type = deferredModule;
+            type = path;
           };
           examples = mkOption {
             type = attrsOf (nullOr types'.example);
@@ -179,7 +179,7 @@ in
       options = {
         module = mkOption {
           description = "the example must be a NixOS module in a file";
-          type = deferredModule;
+          type = path;
         };
         description = mkOption {
           description = "description of the example, ideally with further instructions on how to use it";


### PR DESCRIPTION
- Make the data model types easier to read
- Use path instead of deferredModule for modules
- Cleanup unused code in flake