### PR TITLE
ci(test-demo-vm): add ubuntu 25.04 to test matrix and remove ubuntu:devel

### DIFF
--- a/.github/workflows/test-demo.yaml
+++ b/.github/workflows/test-demo.yaml
@@ -20,7 +20,7 @@ jobs:
           - "debian:unstable"
           - "ubuntu:24.04"
           - "ubuntu:24.10"
-          - "ubuntu:devel"
+          - "ubuntu:25.04"
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Taken from https://github.com/ngi-nix/ngipkgs/pull/1050