### PR TITLE
Add project-triaging issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/task-triage.yaml
+++ b/.github/ISSUE_TEMPLATE/task-triage.yaml
@@ -1,0 +1,34 @@
+name: Triage Project
+description: Create a triaging task for an NGI project
+title: "Triage <PROJECT NAME>"
+labels: ["good first issue"]
+projects: ["Nix@NGI"]
+body:
+  - type: textarea
+    id: instructions
+    attributes:
+      label: Instructions
+      value: |
+        Collect relevant information about this project by following the instructions in the [NGI project issue template](https://github.com/ngi-nix/ngipkgs/issues/new?template=project-triaging.yaml).
+    validations:
+      required: true
+  - type: markdown
+    id: notes_markdown
+    attributes:
+      value: |
+        ## Additional information
+
+        In the following text area, put:
+
+        - Any information that can help with the task
+        - Things that need to be done after the project has been triaged
+
+        If no such thing exists, you can leave it empty.
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      placeholder: |
+        - Issue #123 has some data on the project
+        - Previous packaging attempt has been done in https://...
+        - After the project is triaged, close #42


### PR DESCRIPTION
Can be tested in [task-triage.yaml](https://github.com/eljamm/ngipkgs/issues/new?template=task-triage.yaml). Also, see [this example](https://github.com/eljamm/ngipkgs/issues/621) for how the result looks like.