### PR TITLE
Fix flake nixosModules

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,9 @@
           makemake = import ./infra/makemake { inherit inputs; };
         };
 
-        nixosModules = classic'.ngipkgsModules;
+        nixosModules = {
+          default.nixpkgs.overlays = [ overlay ];
+        } // lib'.flattenAttrs "." classic'.nixos-modules;
 
         # Overlays a package set (e.g. Nixpkgs) with the packages defined in this flake.
         overlays.default = overlay;


### PR DESCRIPTION
`nixosModules` was changed to a list in previous refactors, but it should be an attribute set of modules instead, so users can select individual projects to enable, according to their needs.

This PR restores the previous behaviour.