### PR TITLE
overview: don't collapse demo instructions

### DIFF
--- a/overview/default.nix
+++ b/overview/default.nix
@@ -261,10 +261,7 @@ let
         servicePort = (builtins.head openPorts);
       in
       ''
-        ${heading 2 "demo" "Demo"}
-        <details>
-        <summary>Run service in a VM</summary>
-
+        ${heading 2 "demo" "Try the service in a VM"}
         <ol>
           <li>
             <strong>Install Nix</strong>
@@ -303,7 +300,6 @@ let
               Open a web browser at <a href="http://localhost:${toString servicePort}">http://localhost:${toString servicePort}</a> .
           </li>
         </ol>
-        </details>
       '';
   };
 


### PR DESCRIPTION
otherwise linking to the anchor makes no sense, as one won't actually
see what is being linked to.