### PR TITLE
Mobilizon: init

### DIFF
--- a/projects/Mobilizon/default.nix
+++ b/projects/Mobilizon/default.nix
@@ -1,0 +1,28 @@
+{
+  pkgs,
+  lib,
+  sources,
+}@args:
+{
+  metadata = {
+    summary = '''';
+    subgrants = [
+      "Mobilizon"
+      "Empowering-Mobilizon"
+      "Mobilizon-UX"
+    ];
+  };
+  nixos.modules.services = {
+    mobilizon = {
+      name = "mobilizon";
+      module = "${sources.inputs.nixpkgs}/nixos/modules/services/web-apps/mobilizon.nix";
+      examples.prod = {
+        module = ./example.nix;
+        description = "A basic setup to run Mobilizon in an production environment";
+      };
+      links = {
+      };
+    };
+  };
+  nixos.tests.basic = import "${sources.inputs.nixpkgs}/nixos/tests/mobilizon.nix" args;
+}

--- a/projects/Mobilizon/example.nix
+++ b/projects/Mobilizon/example.nix
@@ -1,0 +1,67 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+
+  services.mobilizon = {
+    enable = true;
+    settings =
+      let
+        # These are helper functions, that allow us to use all the features of the Mix configuration language.
+        # - mkAtom and mkRaw both produce "raw" strings, which are not enclosed by quotes.
+        # - mkGetEnv allows for convenient calls to System.get_env/2
+        inherit ((pkgs.formats.elixirConf { }).lib) mkAtom mkRaw mkGetEnv;
+      in
+      {
+        ":mobilizon" = {
+
+          # General information about the instance
+          ":instance" = {
+            name = "My mobilizon instance";
+            description = "A descriptive text that is going to be shown on the start page.";
+            hostname = "your-mobilizon-domain.com";
+            email_from = "mail@your-mobilizon-domain.com";
+            email_reply_to = "mail@your-mobilizon-domain.com";
+          };
+
+          # SMTP configuration
+          "Mobilizon.Web.Email.Mailer" = {
+            adapter = mkAtom "Swoosh.Adapters.SMTP";
+            relay = "your.smtp.server";
+            # usually 25, 465 or 587
+            port = 587;
+            username = "mail@your-mobilizon-domain.com";
+            # See "Providing a SMTP password" below
+            password = mkGetEnv { envVariable = "SMTP_PASSWORD"; };
+            tls = mkAtom ":always";
+            allowed_tls_versions = [
+              (mkAtom ":tlsv1")
+              (mkAtom ":\"tlsv1.1\"")
+              (mkAtom ":\"tlsv1.2\"")
+            ];
+            retries = 1;
+            no_mx_lookups = false;
+            auth = mkAtom ":always";
+          };
+
+        };
+      };
+  };
+
+  # In order for Nginx to be publicly accessible, the firewall needs to be configured.
+  networking.firewall.allowedTCPPorts = [
+    80 # HTTP
+    443 # HTTPS
+  ];
+
+  # For using the Let's Encrypt TLS certificates for HTTPS,
+  # you have to accept their TOS and supply an email address.
+  security.acme = {
+    acceptTerms = true;
+    defaults.email = "letsencrypt@your-mobilizon-domain.com";
+  };
+
+}


### PR DESCRIPTION
I remembered that ages ago I wrote https://docs.mobilizon.org/3.%20System%20administration/install/nixos/ which is still usable, so I thought I could translate this into an easy example.

This isn't ready yet as the example needs some more steps for secret provisioning, see the link.