### PR TITLE
xrsh: add shell demo

### DIFF
--- a/projects/xrsh/default.nix
+++ b/projects/xrsh/default.nix
@@ -33,5 +33,11 @@
     };
   };
 
+  nixos.examples.demo-shell = {
+    module = ./programs/xrsh/examples/basic.nix;
+    description = "xrsh demo";
+    test.basic = import ./programs/xrsh/tests/basic.nix args;
+  };
+
   nixos.modules.services.xrsh = null;
 }

--- a/projects/xrsh/default.nix
+++ b/projects/xrsh/default.nix
@@ -25,18 +25,12 @@
   nixos.modules.programs = {
     xrsh = {
       module = ./programs/xrsh/module.nix;
-      examples.basic = {
+      examples.demo-shell = {
         module = ./programs/xrsh/examples/basic.nix;
-        description = "Basic example of using xrsh";
+        description = "xrsh example";
         tests.basic = import ./programs/xrsh/tests/basic.nix args;
       };
     };
-  };
-
-  nixos.examples.demo-shell = {
-    module = ./programs/xrsh/examples/basic.nix;
-    description = "xrsh demo";
-    test.basic = import ./programs/xrsh/tests/basic.nix args;
   };
 
   nixos.modules.services.xrsh = null;

--- a/projects/xrsh/programs/xrsh/module.nix
+++ b/projects/xrsh/programs/xrsh/module.nix
@@ -27,5 +27,11 @@ in
     environment.variables = {
       XRSH_PORT = toString cfg.port;
     };
+    demo-shell.xrsh = {
+      programs = {
+        xrsh = cfg.package;
+      };
+      env.XRSH_PORT = "8090";
+    };
   };
 }

--- a/projects/xrsh/programs/xrsh/tests/basic.nix
+++ b/projects/xrsh/programs/xrsh/tests/basic.nix
@@ -12,7 +12,7 @@
         imports = [
           sources.modules.ngipkgs
           sources.modules.programs.xrsh
-          sources.examples.xrsh.basic
+          sources.examples.xrsh.demo-shell
         ];
       };
   };

--- a/projects/xrsh/programs/xrsh/tests/basic.nix
+++ b/projects/xrsh/programs/xrsh/tests/basic.nix
@@ -2,7 +2,6 @@
   sources,
   ...
 }:
-
 {
   name = "xrsh";
 
@@ -20,13 +19,16 @@
 
   testScript =
     { nodes, ... }:
+    let
+      XRSH_PORT = toString nodes.machine.config.programs.xrsh.port;
+    in
     ''
       start_all()
 
       machine.succeed("xrsh >&2 &")
 
       # xrsh serves defaultly on :8080
-      machine.wait_for_open_port(8090)
-      machine.succeed("curl -i 0.0.0.0:8090")
+      machine.wait_for_open_port(${XRSH_PORT})
+      machine.succeed("curl -i 0.0.0.0:${XRSH_PORT}")
     '';
 }


### PR DESCRIPTION
closes: #1111 

nit-change: replaces hard-coded port with a modular variable XRSH_PORT

concerns:

- currently depends on 
   - #1115 
   - #1134  by @eljamm 

- @fricklerhandwerk, you had proposed that demo examples should ideally be the same as those used in the program/service module example. I have tried to implement that herein. However, `overview` displays both as different examples or rather, independently. I think it's redundant for a smoother user experience. How do you propose we approach this?

![image](https://github.com/user-attachments/assets/49df9b19-d3cd-424b-a637-57a64d9f2b91)
