### PR TITLE
Refactor module composition

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -272,6 +272,7 @@ rec {
       pkgs
       sources
       extendedNixosModules
+      system
       ;
   };
 

--- a/default.nix
+++ b/default.nix
@@ -129,6 +129,8 @@ rec {
       ngipkgs =
         { ... }:
         {
+          # TODO: properly separate the demo modules from production code
+          imports = [ ./overview/demo/shell.nix ];
           nixpkgs.overlays = [ overlays.default ];
         };
     }

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,8 @@
           makemake = import ./infra/makemake { inherit inputs; };
         };
 
-        nixosModules = classic'.ngipkgsModules;
+        # WARN: this is currently unstable and subject to change in the future
+        nixosModules = classic'.nixos-modules;
 
         # Overlays a package set (e.g. Nixpkgs) with the packages defined in this flake.
         overlays.default = overlay;

--- a/overview/demo/default.nix
+++ b/overview/demo/default.nix
@@ -1,14 +1,15 @@
 {
   lib,
   pkgs,
+  system,
   sources,
   extendedNixosModules,
 }:
 let
-  demo-system =
+  eval =
     demo-module:
     import (sources.nixpkgs + "/nixos/lib/eval-config.nix") {
-      system = "x86_64-linux";
+      inherit system;
       modules = [
         demo-module
         (sources.nixpkgs + "/nixos/modules/profiles/qemu-guest.nix")
@@ -23,8 +24,8 @@ in
   demo-vm =
     module:
     pkgs.writeShellScript "demo-vm" ''
-      exec ${(demo-system module).config.system.build.vm}/bin/run-nixos-vm "$@"
+      exec ${(eval module).config.system.build.vm}/bin/run-nixos-vm "$@"
     '';
 
-  demo-shell = module: (demo-system module).config.shells.bash.activate;
+  demo-shell = module: (eval module).config.shells.bash.activate;
 }

--- a/overview/demo/vm/default.nix
+++ b/overview/demo/vm/default.nix
@@ -8,6 +8,8 @@
   services.getty.helpLine = ''
 
     Welcome to NGIpkgs!
+
+    - To exit the demo VM, run: `sudo poweroff`
   '';
 
   system.stateVersion = "25.05";

--- a/overview/demo/vm/users.nix
+++ b/overview/demo/vm/users.nix
@@ -5,10 +5,6 @@
     initialPassword = "nixos";
   };
 
-  users.users.root = {
-    initialPassword = "root";
-  };
-
   security.sudo.wheelNeedsPassword = false;
   services.getty.autologinUser = "nixos";
 }


### PR DESCRIPTION
## Changes

- Refactor module composition: 
  - expose `nixos-modules` to the flake's `nixosModules`
    - supersedes https://github.com/ngi-nix/ngipkgs/pull/1080
    - I've opted to adding a note saying that this is experimental as opposed to removing the modules, but we should look into properly designing this, as mentioned in https://github.com/ngi-nix/ngipkgs/pull/1080#discussion_r2126451763
  - Import `demo-shell` in ngipkgs module
    - This makes it possible to use `demo-shell` inside the NixOS tests, which we're gonna need for experimenting with https://github.com/ngi-nix/ngipkgs/issues/1028
    - Note: we should look into separating this from production code, but this is a good step forward
- Small refactors
 
Needed for: #1118 #1123

Worked on this with @themadbit 