### PR TITLE
Cryptpad: test demo in NixOS VM test 

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -180,6 +180,9 @@ rec {
       inputs = sources;
       modules = nixos-modules;
       inherit examples;
+      utils = {
+        inherit demo-vm demo-shell;
+      };
     };
   };
 

--- a/default.nix
+++ b/default.nix
@@ -180,9 +180,7 @@ rec {
       inputs = sources;
       modules = nixos-modules;
       inherit examples;
-      utils = {
-        inherit demo-vm demo-shell;
-      };
+      utils = { inherit demo; };
     };
   };
 
@@ -278,9 +276,4 @@ rec {
       system
       ;
   };
-
-  inherit (demo)
-    demo-vm
-    demo-shell
-    ;
 }

--- a/overview/default.nix
+++ b/overview/default.nix
@@ -383,11 +383,11 @@ let
       demoFile =
         if project.nixos.examples ? demo then
           (pkgs.writeText "default.nix" (
-            render.demoGlue.one "demo-vm" (readFile project.nixos.examples.demo.module)
+            render.demoGlue.one "demo.vm" (readFile project.nixos.examples.demo.module)
           ))
         else if project.nixos.examples ? demo-shell then
           (pkgs.writeText "default.nix" (
-            render.demoGlue.one "demo-shell" (readFile project.nixos.examples.demo-shell.module)
+            render.demoGlue.one "demo.shell" (readFile project.nixos.examples.demo-shell.module)
           ))
         else
           null;

--- a/overview/demo/default.nix
+++ b/overview/demo/default.nix
@@ -22,12 +22,9 @@ rec {
 
   vm =
     module:
-    pkgs.writeShellApplication {
-      name = "demo-vm";
-      text = ''
-        exec ${(eval module).config.system.build.vm}/bin/run-nixos-vm "$@"
-      '';
-    };
+    pkgs.writeShellScript "demo-vm" ''
+      exec ${(eval module).config.system.build.vm}/bin/run-nixos-vm "$@"
+    '';
 
   shell = module: (eval module).config.shells.bash.activate;
 }

--- a/overview/demo/default.nix
+++ b/overview/demo/default.nix
@@ -5,7 +5,7 @@
   sources,
   extendedNixosModules,
 }:
-let
+rec {
   eval =
     demo-module:
     import (sources.nixpkgs + "/nixos/lib/eval-config.nix") {
@@ -19,9 +19,8 @@ let
       ] ++ extendedNixosModules;
       specialArgs = { inherit sources; };
     };
-in
-{
-  demo-vm =
+
+  vm =
     module:
     pkgs.writeShellApplication {
       name = "demo-vm";
@@ -30,5 +29,5 @@ in
       '';
     };
 
-  demo-shell = module: (eval module).config.shells.bash.activate;
+  shell = module: (eval module).config.shells.bash.activate;
 }

--- a/overview/demo/default.nix
+++ b/overview/demo/default.nix
@@ -23,9 +23,12 @@ in
 {
   demo-vm =
     module:
-    pkgs.writeShellScript "demo-vm" ''
-      exec ${(eval module).config.system.build.vm}/bin/run-nixos-vm "$@"
-    '';
+    pkgs.writeShellApplication {
+      name = "demo-vm";
+      text = ''
+        exec ${(eval module).config.system.build.vm}/bin/run-nixos-vm "$@"
+      '';
+    };
 
   demo-shell = module: (eval module).config.shells.bash.activate;
 }

--- a/overview/demo/vm/virtualisation.nix
+++ b/overview/demo/vm/virtualisation.nix
@@ -1,7 +1,14 @@
 { config, ... }:
 {
   virtualisation = {
+    memorySize = 4096;
+    cores = 4;
     graphics = false;
+
+    qemu.options = [
+      "-cpu host"
+      "-enable-kvm"
+    ];
 
     # ssh + open service ports
     forwardPorts = map (port: {

--- a/overview/demo/vm/virtualisation.nix
+++ b/overview/demo/vm/virtualisation.nix
@@ -1,14 +1,7 @@
 { config, ... }:
 {
   virtualisation = {
-    memorySize = 4096;
-    cores = 4;
     graphics = false;
-
-    qemu.options = [
-      "-cpu host"
-      "-enable-kvm"
-    ];
 
     # ssh + open service ports
     forwardPorts = map (port: {

--- a/projects/Cryptpad/demo-test.nix
+++ b/projects/Cryptpad/demo-test.nix
@@ -30,7 +30,7 @@
     ''
       start_all()
 
-      machine.execute("demo-vm &")
-      machine.succeed("curl --fail --connect-timeout 10 http://localhost:9000/") # TODO: get port from config
+      machine.execute("demo-vm &>/dev/null &")
+      machine.succeed("curl --fail --retry 5 --connect-timeout 10 http://localhost:9000/") # TODO: get port from config
     '';
 }

--- a/projects/Cryptpad/demo-test.nix
+++ b/projects/Cryptpad/demo-test.nix
@@ -5,7 +5,9 @@
 {
   name = "cryptpad-demo";
 
+  # TODO: just for debugging, remove after
   skipTypeCheck = true;
+  skipLint = true;
   interactive.sshBackdoor.enable = true;
 
   nodes = {
@@ -13,7 +15,7 @@
       let
         demo-vm = sources.utils.demo-vm sources.examples.Cryptpad.demo;
       in
-      { ... }:
+      { config, ... }:
       {
         imports = [
           sources.modules.ngipkgs
@@ -21,6 +23,7 @@
 
         environment.systemPackages = [ demo-vm ];
 
+        # without this, qemu fails to allocate memory in the demo VM
         virtualisation.memorySize = 8192;
       };
   };
@@ -31,6 +34,7 @@
       start_all()
 
       machine.execute("demo-vm &>/dev/null &")
-      machine.succeed("curl --fail --retry 5 --connect-timeout 10 http://localhost:9000/") # TODO: get port from config
+      # TODO: get port from config
+      machine.succeed("curl --silent --retry 10 --retry-max-time 120 --retry-all-errors http://localhost:9000/")
     '';
 }

--- a/projects/Cryptpad/demo-test.nix
+++ b/projects/Cryptpad/demo-test.nix
@@ -12,16 +12,11 @@
 
   nodes = {
     machine =
-      let
-        demo-vm = sources.utils.demo.vm sources.examples.Cryptpad.demo;
-      in
       { config, ... }:
       {
         imports = [
           sources.modules.ngipkgs
         ];
-
-        environment.systemPackages = [ demo-vm ];
 
         # without this, qemu fails to allocate memory in the demo VM
         virtualisation.memorySize = 8192;
@@ -31,13 +26,14 @@
   testScript =
     { nodes, ... }:
     let
+      demo-vm = sources.utils.demo.vm sources.examples.Cryptpad.demo;
       demo-system = sources.utils.demo.eval sources.examples.Cryptpad.demo;
       servicePort = demo-system.config.services.cryptpad.settings.httpPort;
     in
     ''
       start_all()
 
-      machine.execute("demo-vm &>/dev/null &")
+      machine.execute("${demo-vm} &>/dev/null &")
       machine.succeed("curl --silent --retry 10 --retry-max-time 120 --retry-all-errors http://localhost:${toString servicePort}/")
     '';
 }

--- a/projects/Cryptpad/demo-test.nix
+++ b/projects/Cryptpad/demo-test.nix
@@ -13,7 +13,7 @@
   nodes = {
     machine =
       let
-        demo-vm = sources.utils.demo-vm sources.examples.Cryptpad.demo;
+        demo-vm = sources.utils.demo.vm sources.examples.Cryptpad.demo;
       in
       { config, ... }:
       {
@@ -30,11 +30,14 @@
 
   testScript =
     { nodes, ... }:
+    let
+      demo-system = sources.utils.demo.eval sources.examples.Cryptpad.demo;
+      servicePort = demo-system.config.services.cryptpad.settings.httpPort;
+    in
     ''
       start_all()
 
       machine.execute("demo-vm &>/dev/null &")
-      # TODO: get port from config
-      machine.succeed("curl --silent --retry 10 --retry-max-time 120 --retry-all-errors http://localhost:9000/")
+      machine.succeed("curl --silent --retry 10 --retry-max-time 120 --retry-all-errors http://localhost:${toString servicePort}/")
     '';
 }


### PR DESCRIPTION
Experiment for [Spike: Test all project demos · Issue #1028](https://github.com/ngi-nix/ngipkgs/issues/1028)

When the derivation is cached, testing only takes about [1 second](https://buildbot.ngi.nixos.org/#/builders/526/builds/153) in makemake, as opposed to minutes in GitHub CI.