### PR TITLE
projects/PeerTube: Add peertube-cli

### DIFF
--- a/projects/PeerTube/default.nix
+++ b/projects/PeerTube/default.nix
@@ -33,7 +33,9 @@
         module = ./programs/peertube-cli/module.nix;
         examples.basic-cli = {
           module = ./programs/peertube-cli/examples/basic.nix;
-          description = "CLI configuration";
+          description = ''
+            Enable peertube-cli, a tool for remotely managing PeerTube instances
+          '';
           tests.basic-cli = import ./programs/peertube-cli/tests/basic.nix args;
         };
         links = {

--- a/projects/PeerTube/default.nix
+++ b/projects/PeerTube/default.nix
@@ -27,14 +27,32 @@
     };
   };
 
-  nixos.modules.services = {
-    peertube = {
-      name = "peertube";
-      module = ./services/peertube/module.nix;
-      examples.basic = {
-        module = ./services/peertube/examples/basic.nix;
-        description = "Basic configuration mainly used for testing purposes.";
-        tests.peertube-plugins = import ./services/peertube/tests/peertube-plugins.nix args;
+  nixos.modules = {
+    programs = {
+      peertube-cli = {
+        module = ./programs/peertube-cli/module.nix;
+        examples.basic-cli = {
+          module = ./programs/peertube-cli/examples/basic.nix;
+          description = "CLI configuration";
+          tests.basic-cli = import ./programs/peertube-cli/tests/basic.nix args;
+        };
+        links = {
+          docs = {
+            text = "Documentation";
+            url = "https://docs.joinpeertube.org/maintain/tools#remote-peertube-cli";
+          };
+        };
+      };
+    };
+
+    services = {
+      peertube = {
+        module = ./services/peertube/module.nix;
+        examples.basic = {
+          module = ./services/peertube/examples/basic.nix;
+          description = "Basic configuration mainly used for testing purposes";
+          tests.peertube-plugins = import ./services/peertube/tests/peertube-plugins.nix args;
+        };
       };
     };
   };

--- a/projects/PeerTube/programs/peertube-cli/examples/basic.nix
+++ b/projects/PeerTube/programs/peertube-cli/examples/basic.nix
@@ -1,0 +1,3 @@
+{
+  programs.peertube-cli.enable = true;
+}

--- a/projects/PeerTube/programs/peertube-cli/module.nix
+++ b/projects/PeerTube/programs/peertube-cli/module.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.peertube-cli;
+in
+{
+  options.programs.peertube-cli = {
+    enable = lib.mkEnableOption "peertube-cli";
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = with pkgs; [
+      peertube.cli
+    ];
+  };
+}

--- a/projects/PeerTube/programs/peertube-cli/tests/basic.nix
+++ b/projects/PeerTube/programs/peertube-cli/tests/basic.nix
@@ -1,0 +1,28 @@
+{
+  sources,
+  ...
+}:
+
+{
+  name = "peertube-cli";
+
+  nodes = {
+    machine =
+      { ... }:
+      {
+        imports = [
+          sources.modules.ngipkgs
+          sources.modules.programs.peertube-cli
+          sources.examples.PeerTube.basic-cli
+        ];
+      };
+  };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      start_all()
+
+      machine.succeed("peertube-cli --version")
+    '';
+}


### PR DESCRIPTION
Part of #821

The example and test aren't just called "basic", because they're merged with the service ones.