### PR TITLE
update issue template and instructions for project metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/task-metadata.md
+++ b/.github/ISSUE_TEMPLATE/task-metadata.md
@@ -1,7 +1,7 @@
 ---
 name: "Task: Implement project metadata"
 about: "Task for adding in-code metadata for an NGI project"
-title: "Implement project metadata for <PROJECT_NAME>"
+title: "Implement project metadata for PROJECT_NAME"
 projects: Nix@NGI
 type: task
 labels: ''
@@ -10,9 +10,11 @@ assignees: ''
 
 ### Instructions
 
-<!-- Replace <PROJECT_NAME> in the title and the body of this issue with the project's name. -->
-
-<!-- Replace `<PROJECT_ISSUE_NUMBER>` with the issue number that contains the project's triaged information.
+<!-- Replace `PROJECT_ISSUE_NUMBER` with the issue number that contains the project's triaged information.
 If one doesn't exist, create it by following the instructions in the [contributor documentation](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#triaging-an-ngi-project). -->
 
-Given #<PROJECT_ISSUE_NUMBER> for metadata about the application, follow the instructions in the [contributor documentation](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#addingexposing-an-ngi-project) and implement project metadata for <PROJECT_NAME>.
+Use metadata about the application from its tracking issue:
+
+- PROJECT_ISSUE_NUMBER
+
+and follow the instructions in the [contributor documentation](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#exposing-an-ngi-project).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -379,17 +379,20 @@ For services, click on the module name to reveal more details, then copy the nam
 >
 > Example: Searching for Oku (web browser) might also return Okular (document viewver), which share a similar names, but which are totally unrelated.
 
-## Adding/Exposing an NGI project
+## Exposing an NGI project
 
-1. Copy the project template to the projects directory:
+In order to display a project on <ngi.nixos.org>, its metadata must be added to this repository's source code in a certain format.
+
+1. Copy the [project template](./maintainers/templates/project) to the projects directory:
 
    ```
    cp -r maintainers/templates/project projects/<project_name>
    ```
 
-1. Search for `NGI Project: <project_name>` in the [Ngipkgs issues](https://github.com/ngi-nix/ngipkgs/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22NGI%20Project%22) page.
-   If a page with that name exists, use the information available there in the next step.
-1. Follow the instructions inside the `projects/<project_name>/default.nix` file and fill in the missing data about the project.
+1. Follow the instructions inside the [`projects/<project_name>/default.nix`](./maintainers/templates/project/default.nix) file, and fill in the data based on the project's tracking issue.
+
+   Project tracking issues are labeled with [`NGI Project`](https://github.com/ngi-nix/ngipkgs/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22NGI%20Project%22).
+
 1. Check that the code is valid by running the test locally:
 
    ```


### PR DESCRIPTION
- not using angle brackets allows replacing by double-clicking for
  seleciton
- GitHub will expand issue numbers in a list item, so we only need to
  fill the number in the issue body
- added some rationale to the instructions so they are easier to consume
  with less context