### PR TITLE
projects/holo: init

### DIFF
--- a/projects/holo/default.nix
+++ b/projects/holo/default.nix
@@ -26,4 +26,5 @@
   };
 
   # TODO: add service module
+  nixos.modules.services.holo-daemon = null;
 }

--- a/projects/holo/default.nix
+++ b/projects/holo/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  pkgs,
+  sources,
+}@args:
+
+{
+  metadata = {
+    summary = "Holo is a suite of routing protocols designed to address the needs of modern networks";
+    subgrants = [
+      "HoloRouting"
+    ];
+  };
+
+  nixos.modules.programs = {
+    holo = {
+      name = "holo";
+      # if a project has `packages`, add them inside the `module.nix` file
+      module = ./programs/holo/module.nix;
+      examples.basic = {
+        module = ./programs/holo/examples/basic.nix;
+        description = "Enable holo to install the holo-cli package";
+        tests.basic = import ./programs/holo/tests/basic.nix args;
+      };
+    };
+  };
+
+  # TODO: add service module
+}

--- a/projects/holo/default.nix
+++ b/projects/holo/default.nix
@@ -19,7 +19,7 @@
       module = ./programs/holo/module.nix;
       examples.basic = {
         module = ./programs/holo/examples/basic.nix;
-        description = "Enable holo to install the holo-cli package";
+        description = "Enable the holo program";
         tests.basic = import ./programs/holo/tests/basic.nix args;
       };
     };

--- a/projects/holo/programs/holo/examples/basic.nix
+++ b/projects/holo/programs/holo/examples/basic.nix
@@ -1,0 +1,5 @@
+{ ... }:
+
+{
+  programs.holo.enable = true;
+}

--- a/projects/holo/programs/holo/module.nix
+++ b/projects/holo/programs/holo/module.nix
@@ -1,0 +1,21 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.holo;
+in
+{
+  options.programs.holo = {
+    enable = lib.mkEnableOption "holo";
+    package = lib.mkPackageOption pkgs "holo-cli" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = with pkgs; [
+      cfg.package
+    ];
+  };
+}

--- a/projects/holo/programs/holo/tests/basic.nix
+++ b/projects/holo/programs/holo/tests/basic.nix
@@ -1,0 +1,28 @@
+{
+  sources,
+  ...
+}:
+
+{
+  name = "Program Name";
+
+  nodes = {
+    machine =
+      { ... }:
+      {
+        imports = [
+          sources.modules.ngipkgs
+          sources.modules.programs.holo
+          sources.examples.holo.basic
+        ];
+      };
+  };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      start_all()
+
+      machine.succeed("holo-cli --version")
+    '';
+}

--- a/projects/holo/programs/holo/tests/basic.nix
+++ b/projects/holo/programs/holo/tests/basic.nix
@@ -4,7 +4,7 @@
 }:
 
 {
-  name = "Program Name";
+  name = "holo";
 
   nodes = {
     machine =


### PR DESCRIPTION
Holo the package was added in 3af2d5fad2d59c57dc1d4acf4d85ada3890172ff but then later migrated to Nixpkgs.

Its page is here: https://nlnet.nl/project/HoloRouting
Related: https://github.com/ngi-nix/ngipkgs/issues/338#issuecomment-2921557533
Closes: https://github.com/ngi-nix/ngipkgs/issues/1154