### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/project.md
+++ b/.github/ISSUE_TEMPLATE/project.md
@@ -19,4 +19,12 @@ assignees: ''
 Next, depending on the project deliverable, open sub-issues for the following tasks:
 
 - [ ] [Implement NixOS program module](https://github.com/ngi-nix/ngipkgs/issues/new?template=task-module-program.md)
+  - [ ] Example configuration
+  - [ ] NixOS test
+  - [ ] Shell demo
 - [ ] [Implement NixOS service module](https://github.com/ngi-nix/ngipkgs/issues/new?template=task-module-service.md)
+  - [ ] Example configuration
+  - [ ] NixOS test
+  - [ ] VM demo
+
+**Note:** Each example needs to be tested.

--- a/.github/ISSUE_TEMPLATE/task-metadata.md
+++ b/.github/ISSUE_TEMPLATE/task-metadata.md
@@ -1,6 +1,6 @@
 ---
 name: "Task: Implement project metadata"
-about: "Task for adding in-code metadata for an NGI project"
+about: "Implement in-code metadata for an NGI project"
 title: "Implement project metadata for PROJECT_NAME"
 projects: Nix@NGI
 type: task
@@ -15,6 +15,6 @@ If one doesn't exist, create it by following the instructions in the [contributo
 
 Use metadata about the application from its tracking issue:
 
-- PROJECT_ISSUE_NUMBER
+- #PROJECT_ISSUE_NUMBER
 
 and follow the instructions in the [contributor documentation](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#exposing-an-ngi-project).

--- a/.github/ISSUE_TEMPLATE/task-module-program.md
+++ b/.github/ISSUE_TEMPLATE/task-module-program.md
@@ -1,7 +1,7 @@
 ---
 name: "Task: NixOS program module"
-about: "Implement NixOS program module for an NGI project"
-title: "Implement NixOS program module for <PROJECT_NAME>"
+about: "Implement a NixOS program module for an NGI project"
+title: "Implement NixOS module for PROJECT_NAME program"
 projects: Nix@NGI
 type: task
 labels: ''
@@ -10,19 +10,11 @@ assignees: ''
 
 ### Instructions
 
-<!-- Replace <PROJECT_NAME> in the title and the body of this issue with the project's name. -->
-
-<!-- Replace `<PROJECT_ISSUE_NUMBER>` with the issue number that contains the project's triaged information.
+<!-- Replace `PROJECT_ISSUE_NUMBER` with the issue number that contains the project's triaged information.
 If one doesn't exist, create it by following the instructions in the [contributor documentation](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#triaging-an-ngi-project). -->
 
-Given #<PROJECT_ISSUE_NUMBER> for metadata about the application, implement a NixOS program module for <PROJECT_NAME>.
+Use metadata about the application from its tracking issue:
 
-### Tasks
+- #PROJECT_ISSUE_NUMBER
 
-After or during the implementation of this module, create issues for the following deliverables using the appropriate GitHub template:
-
-- [ ] Example configuration
-- [ ] NixOS test
-- [ ] Shell demo
-
-**Note:** Each example needs to be tested.
+and implement a NixOS module for the program.

--- a/.github/ISSUE_TEMPLATE/task-module-service.md
+++ b/.github/ISSUE_TEMPLATE/task-module-service.md
@@ -1,7 +1,7 @@
 ---
 name: "Task: NixOS service module"
-about: "Task for implementing NixOS service module for an NGI applicaton"
-title: "Implement NixOS service module for <PROJECT_NAME>"
+about: "Implement a NixOS service module for an NGI applicaton"
+title: "Implement NixOS module for PROJECT_NAME service"
 projects: Nix@NGI
 type: task
 labels: ''
@@ -10,18 +10,11 @@ assignees: ''
 
 ### Instructions
 
-<!-- Replace <PROJECT_NAME> in the title and the body of this issue with the project's name. -->
-
-<!-- Replace `<TRIAGE_ISSUE_NUMBER>` with the issue number that contains the project's triaged information.
+<!-- Replace `PROJECT_ISSUE_NUMBER` with the issue number that contains the project's triaged information.
 If one doesn't exist, create it by following the instructions in the [contributor documentation](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#triaging-an-ngi-project). -->
 
-Given #<TRIAGE_ISSUE_NUMBER> for metadata about the application, implement a NixOS service module for <PROJECT_NAME>.
+Use metadata about the application from its tracking issue:
 
-### Tasks
+- #PROJECT_ISSUE_NUMBER
 
-After or during the implementation of this module, create issues for the following deliverables using the appropriate GitHub template:
-
-- [ ] Example configuration
-- [ ] NixOS test
-
-**Note:** Each example needs to be tested.
+and implement a NixOS module for the service.

--- a/.github/ISSUE_TEMPLATE/task-nixos-test.md
+++ b/.github/ISSUE_TEMPLATE/task-nixos-test.md
@@ -1,7 +1,7 @@
 ---
 name: "Task: NixOS test for module"
-about: "Implement NixOS VM test for an NGI project module"
-title: "<PROJECT_NAME>: add NixOS test for <DELIVERABLE_NAME>"
+about: "Implement a NixOS VM test for an NGI project example"
+title: "Implement NixOS VM test for PROJECT_NAME example"
 projects: Nix@NGI
 type: task
 labels: ''
@@ -10,15 +10,11 @@ assignees: ''
 
 ### Instructions
 
-<!-- Replace <PROJECT_NAME> in the title and the body of this issue with the project's name and <DELIVERABLE_NAME> with the appropriate deliverable.
-
-Example:
-
-For a project called `FooBar`,
-if a service is called `foobar-d`,
-the title would be `FooBar: add NixOS test for foobar-d` -->
-
-<!-- Replace `<PROJECT_ISSUE_NUMBER>` with the issue number that contains the project's triaged information.
+<!-- Replace `PROJECT_ISSUE_NUMBER` with the issue number that contains the project's triaged information.
 If one doesn't exist, create it by following the instructions in the [contributor documentation](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#triaging-an-ngi-project). -->
 
-Given #<PROJECT_ISSUE_NUMBER> for metadata about the application, implement a NixOS VM test for <DELIVERABLE_NAME>.
+Use metadata about the application from its tracking issue:
+
+- #PROJECT_ISSUE_NUMBER
+
+and implement a NixOS VM test for the example.


### PR DESCRIPTION
### Changes

- Similar to what was done in https://github.com/ngi-nix/ngipkgs/pull/1143
- List deliverables (example, test, demo) as sub-tasks under the tracking issue

The issue templates can be tested in https://github.com/eljamm/ngipkgs/issues/new/choose