### PR TITLE
overview: show project list letter by letter

### DIFF
--- a/overview/content-types/project-list.nix
+++ b/overview/content-types/project-list.nix
@@ -65,7 +65,9 @@ in
             </li>
           </ul>
 
-        ${concatMapStringsSep "\n" toString (self.projects)}
+        ${concatMapStringsSep "\n" toString (
+          with lib; sortOn (project: toLower project.name) self.projects
+        )}
 
         </section>
 


### PR DESCRIPTION
Previously, the overview listed projects in ASCII (all projects starting with an uppercase letter, followed by lowercase projects).
- Now, it lists all projects alphabetically regardless of case, but upper case takes precedence in case of matching letters.

Closes #1203 