### PR TITLE
maintainers/templates/projects: fix extra args

### DIFF
--- a/maintainers/templates/project/default.nix
+++ b/maintainers/templates/project/default.nix
@@ -2,6 +2,7 @@
   lib,
   pkgs,
   sources,
+  ...
 }@args:
 
 {


### PR DESCRIPTION
In accordance with e4d0440977a0807e3c015522cd6f2771f8e16691