### PR TITLE
maintainers/templates/projects/programs: add cfg.package as default

### DIFF
--- a/maintainers/templates/project/programs/_programName_/module.nix
+++ b/maintainers/templates/project/programs/_programName_/module.nix
@@ -10,10 +10,12 @@ in
 {
   options.programs._programName_ = {
     enable = lib.mkEnableOption "_programName_";
+    package = lib.mkPackageOption pkgs "_programName_" { };
   };
 
   config = lib.mkIf cfg.enable {
     environment.systemPackages = with pkgs; [
+      cfg.package
       # put the `packages` here
     ];
   };


### PR DESCRIPTION
Having the package being configurable by default is probably a good idea.