### PR TITLE
projects/PeerTube: add update scripts to and update plugins

### DIFF
--- a/pkgs/by-name/peertube-plugin-akismet/package.nix
+++ b/pkgs/by-name/peertube-plugin-akismet/package.nix
@@ -6,20 +6,20 @@
 }:
 buildNpmPackage (finalAttrs: {
   pname = "peertube-plugin-akismet";
-  version = "0.1.1";
+  version = "0-unstable-2025-05-30";
 
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = "framasoft";
     repo = "peertube/official-plugins";
-    rev = "6d07c51ac627d76de63b093ef0cd9e20da1019cf";
+    rev = "1c6f794d7a5d9c69374cb6fa1daf184258acb63a";
     sparseCheckout = [ "peertube-plugin-akismet" ];
-    hash = "sha256-W9ojtIsKo70gF9Wrpd2y1gt9T2/TDdmJ5yqWJ13+wic=";
+    hash = "sha256-vFWvBxSfKg2YjKzUM0Qds7MEi9O9PFfnweOZu1Sd6KA=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/peertube-plugin-akismet";
 
-  npmDepsHash = "sha256-U+AQeOJI31QPeZrej6STDRtnwYJgSp86ycf4vsqSats=";
+  npmDepsHash = "sha256-cd/vCw2oP8lOEeg9LFj1Zh2Mmj+KKArFhtjd5G7hhTo=";
 
   passthru = {
     updateScript = [

--- a/pkgs/by-name/peertube-plugin-akismet/package.nix
+++ b/pkgs/by-name/peertube-plugin-akismet/package.nix
@@ -2,8 +2,9 @@
   lib,
   buildNpmPackage,
   fetchFromGitLab,
+  unstableGitUpdater,
 }:
-buildNpmPackage rec {
+buildNpmPackage (finalAttrs: {
   pname = "peertube-plugin-akismet";
   version = "0.1.1";
 
@@ -12,14 +13,21 @@ buildNpmPackage rec {
     owner = "framasoft";
     repo = "peertube/official-plugins";
     rev = "6d07c51ac627d76de63b093ef0cd9e20da1019cf";
-    hash = "sha256-vKA9rdfatdJqXlLqMsLL0xrNIj7A+dechwDl3QMquwE=";
+    sparseCheckout = [ "peertube-plugin-akismet" ];
+    hash = "sha256-W9ojtIsKo70gF9Wrpd2y1gt9T2/TDdmJ5yqWJ13+wic=";
   };
 
-  sourceRoot = "${src.name}/peertube-plugin-akismet";
+  sourceRoot = "${finalAttrs.src.name}/peertube-plugin-akismet";
 
   npmDepsHash = "sha256-U+AQeOJI31QPeZrej6STDRtnwYJgSp86ycf4vsqSats=";
 
-  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+  passthru = {
+    updateScript = [
+      ./update.sh
+      (unstableGitUpdater { })
+    ];
+    peertubeOfficialPluginsUpdateScript = finalAttrs.passthru.updateScript;
+  };
 
   meta = {
     description = "Reject local comments, remote comments and registrations based on Akismet service";
@@ -28,4 +36,4 @@ buildNpmPackage rec {
     maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/peertube-plugin-akismet/update.sh
+++ b/pkgs/by-name/peertube-plugin-akismet/update.sh
@@ -1,0 +1,20 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p nix-update
+# Once  https://github.com/Mic92/nix-update/issues/281 is resolved, the usage of
+# this script can be replaced with:
+#
+# ```nix
+# passthru.updateScript = nix-update-script {
+#   extraArgs = [ "--version=branch" ];
+# };
+# ```
+#
+
+set -euo pipefail
+
+# Run `unstableGitUpdater`. the script and arguments for running it
+# should be passed to this script.
+eval $@
+
+# Handle `npmDepsHash`
+nix-update --version=skip $UPDATE_NIX_ATTR_PATH

--- a/pkgs/by-name/peertube-plugin-auth-ldap/package.nix
+++ b/pkgs/by-name/peertube-plugin-auth-ldap/package.nix
@@ -2,8 +2,9 @@
   lib,
   buildNpmPackage,
   fetchFromGitLab,
+  peertube-plugin-akismet,
 }:
-buildNpmPackage rec {
+buildNpmPackage (finalAttrs: {
   pname = "peertube-plugin-auth-ldap";
   version = "0.0.12";
 
@@ -12,16 +13,17 @@ buildNpmPackage rec {
     owner = "framasoft";
     repo = "peertube/official-plugins";
     rev = "fb3226e552a475f70b5ee033803274ed27a86619";
-    hash = "sha256-VzypXOf05nigevG9E8AIISEbR7XI+TExyJMv1MDMfOY=";
+    sparseCheckout = [ "peertube-plugin-auth-ldap" ];
+    hash = "sha256-bvLCCn2uSuO4ERVt5G3eTqpD50oTE4fvbyVcLV/lx20=";
   };
 
-  sourceRoot = "${src.name}/peertube-plugin-auth-ldap";
+  sourceRoot = "${finalAttrs.src.name}/peertube-plugin-auth-ldap";
 
   npmDepsHash = "sha256-1esTdjtbBIf3xY90xPbTZ9YmydhHO8tF430O8sIevjo=";
 
   dontNpmBuild = true;
 
-  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+  passthru.updateScript = peertube-plugin-akismet.peertubeOfficialPluginsUpdateScript;
 
   meta = {
     description = "Add LDAP support to login form in PeerTube";
@@ -30,4 +32,4 @@ buildNpmPackage rec {
     maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/peertube-plugin-auth-ldap/package.nix
+++ b/pkgs/by-name/peertube-plugin-auth-ldap/package.nix
@@ -6,20 +6,20 @@
 }:
 buildNpmPackage (finalAttrs: {
   pname = "peertube-plugin-auth-ldap";
-  version = "0.0.12";
+  version = "0-unstable-2025-05-30";
 
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = "framasoft";
     repo = "peertube/official-plugins";
-    rev = "fb3226e552a475f70b5ee033803274ed27a86619";
+    rev = "1c6f794d7a5d9c69374cb6fa1daf184258acb63a";
     sparseCheckout = [ "peertube-plugin-auth-ldap" ];
-    hash = "sha256-bvLCCn2uSuO4ERVt5G3eTqpD50oTE4fvbyVcLV/lx20=";
+    hash = "sha256-kyQeVRNRgEVh74fjFvwto9dDbliurQhRTlb0+gYYf1Q=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/peertube-plugin-auth-ldap";
 
-  npmDepsHash = "sha256-1esTdjtbBIf3xY90xPbTZ9YmydhHO8tF430O8sIevjo=";
+  npmDepsHash = "sha256-Q3HDMv8Suac3y8yP+obnnMuhKS6gteHfmVZjfzCkUBY=";
 
   dontNpmBuild = true;
 

--- a/pkgs/by-name/peertube-plugin-auth-openid-connect/package.nix
+++ b/pkgs/by-name/peertube-plugin-auth-openid-connect/package.nix
@@ -6,20 +6,20 @@
 }:
 buildNpmPackage (finalAttrs: {
   pname = "peertube-plugin-auth-openid-connect";
-  version = "0.1.1";
+  version = "0-unstable-2025-05-30";
 
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = "framasoft";
     repo = "peertube/official-plugins";
-    rev = "9ed56041e9a9dcb98cc610e938c7853db38cd349";
+    rev = "1c6f794d7a5d9c69374cb6fa1daf184258acb63a";
     sparseCheckout = [ "peertube-plugin-auth-openid-connect" ];
-    hash = "sha256-6XQWdFJGuU8cpOZeIYwHOJJl2hRguNdS1dxS/+7Ux+g=";
+    hash = "sha256-vc1ZOO1hAmTD2NE4P7WELZjDTP7+CwJk7yMCXeuRn0E=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/peertube-plugin-auth-openid-connect";
 
-  npmDepsHash = "sha256-3FD9i4utzkHOjBXVPz574vttOL6VDuqM1kxtgqp8eOA=";
+  npmDepsHash = "sha256-NXCjLPJvFZ05b3gHnhnGF58ULgfL23+r6b0IaMeIw60=";
 
   dontNpmBuild = true;
 

--- a/pkgs/by-name/peertube-plugin-auth-openid-connect/package.nix
+++ b/pkgs/by-name/peertube-plugin-auth-openid-connect/package.nix
@@ -2,8 +2,9 @@
   lib,
   buildNpmPackage,
   fetchFromGitLab,
+  peertube-plugin-akismet,
 }:
-buildNpmPackage rec {
+buildNpmPackage (finalAttrs: {
   pname = "peertube-plugin-auth-openid-connect";
   version = "0.1.1";
 
@@ -12,16 +13,17 @@ buildNpmPackage rec {
     owner = "framasoft";
     repo = "peertube/official-plugins";
     rev = "9ed56041e9a9dcb98cc610e938c7853db38cd349";
-    hash = "sha256-L9yD+amw49s+zhP4anTkXGdemitOoqJgqwzwd9PHWyw=";
+    sparseCheckout = [ "peertube-plugin-auth-openid-connect" ];
+    hash = "sha256-6XQWdFJGuU8cpOZeIYwHOJJl2hRguNdS1dxS/+7Ux+g=";
   };
 
-  sourceRoot = "${src.name}/peertube-plugin-auth-openid-connect";
+  sourceRoot = "${finalAttrs.src.name}/peertube-plugin-auth-openid-connect";
 
   npmDepsHash = "sha256-3FD9i4utzkHOjBXVPz574vttOL6VDuqM1kxtgqp8eOA=";
 
   dontNpmBuild = true;
 
-  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+  passthru.updateScript = peertube-plugin-akismet.peertubeOfficialPluginsUpdateScript;
 
   meta = {
     description = "Add OpenID Connect support to login form in PeerTube";
@@ -30,4 +32,4 @@ buildNpmPackage rec {
     maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/peertube-plugin-auth-saml2/package.nix
+++ b/pkgs/by-name/peertube-plugin-auth-saml2/package.nix
@@ -2,8 +2,9 @@
   lib,
   buildNpmPackage,
   fetchFromGitLab,
+  peertube-plugin-akismet,
 }:
-buildNpmPackage rec {
+buildNpmPackage (finalAttrs: {
   pname = "peertube-plugin-auth-saml2";
   version = "0.0.8";
 
@@ -12,16 +13,17 @@ buildNpmPackage rec {
     owner = "framasoft";
     repo = "peertube/official-plugins";
     rev = "6737d29dce5272d2abeac8a8c501ba874413e422";
-    hash = "sha256-xmyVwfXPMl/8TNtDXzJ6ngrC3Y1G5gdFK+zmIEbL5Uw=";
+    sparseCheckout = [ "peertube-plugin-auth-saml2" ];
+    hash = "sha256-qLTL+FoXHpXwNGwc77v4S04zqp8EcfElkw3+ZW1k2CM=";
   };
 
-  sourceRoot = "${src.name}/peertube-plugin-auth-saml2";
+  sourceRoot = "${finalAttrs.src.name}/peertube-plugin-auth-saml2";
 
   npmDepsHash = "sha256-Mkku+nu9WewKXzUcyaaekB3MgZ7mLeAOwGXLU5evdp8=";
 
   dontNpmBuild = true;
 
-  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+  passthru.updateScript = peertube-plugin-akismet.peertubeOfficialPluginsUpdateScript;
 
   meta = {
     description = "Add SAML2 support to login form in PeerTube";
@@ -30,4 +32,4 @@ buildNpmPackage rec {
     maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/peertube-plugin-auto-block-videos/package.nix
+++ b/pkgs/by-name/peertube-plugin-auto-block-videos/package.nix
@@ -2,8 +2,9 @@
   lib,
   buildNpmPackage,
   fetchFromGitLab,
+  peertube-plugin-akismet,
 }:
-buildNpmPackage rec {
+buildNpmPackage (finalAttrs: {
   pname = "peertube-plugin-auto-block-videos";
   version = "0.0.2";
 
@@ -12,16 +13,17 @@ buildNpmPackage rec {
     owner = "framasoft";
     repo = "peertube/official-plugins";
     rev = "bf3602a782fb4605cc674aa21e1fe7dcb2693cf3";
-    hash = "sha256-R+jbfubeph68aVP1Kg7QozRwrgwhXvK5QuGSZHU5iJk=";
+    sparseCheckout = [ "peertube-plugin-auto-block-videos" ];
+    hash = "sha256-whEVTnv2p44VWc+gzGpMwh0RRhyMNcCx1fY8QpEOCXo=";
   };
 
-  sourceRoot = "${src.name}/peertube-plugin-auto-block-videos";
+  sourceRoot = "${finalAttrs.src.name}/peertube-plugin-auto-block-videos";
 
   npmDepsHash = "sha256-inmRylbPXSJjglozVM1Xxja9eZaM+h5bv6CffiX61cA=";
 
   dontNpmBuild = true;
 
-  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+  passthru.updateScript = peertube-plugin-akismet.peertubeOfficialPluginsUpdateScript;
 
   meta = {
     description = "Auto block videos based on public blocklists";
@@ -30,4 +32,4 @@ buildNpmPackage rec {
     maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/peertube-plugin-auto-mute/package.nix
+++ b/pkgs/by-name/peertube-plugin-auto-mute/package.nix
@@ -2,8 +2,9 @@
   lib,
   buildNpmPackage,
   fetchFromGitLab,
+  peertube-plugin-akismet,
 }:
-buildNpmPackage rec {
+buildNpmPackage (finalAttrs: {
   pname = "peertube-plugin-auto-mute";
   version = "0.0.6";
 
@@ -12,16 +13,17 @@ buildNpmPackage rec {
     owner = "framasoft";
     repo = "peertube/official-plugins";
     rev = "932c51d45ce3160ab9ba097bbede51a44d890a61";
-    hash = "sha256-UGqoevqoyvWfAmumuOsdDdMIDPfaOhnjwoFXynWCgHQ=";
+    sparseCheckout = [ "peertube-plugin-auto-mute" ];
+    hash = "sha256-OOIUXs09Gx5WkXE8W8BpIwwpSxqDp0ifJh5PsA4Eoko=";
   };
 
-  sourceRoot = "${src.name}/peertube-plugin-auto-mute";
+  sourceRoot = "${finalAttrs.src.name}/peertube-plugin-auto-mute";
 
   npmDepsHash = "sha256-YbFEefvSLk9jf6g6FMmCahxqA+X+FD4MCc+c6luRZq4=";
 
   dontNpmBuild = true;
 
-  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+  passthru.updateScript = peertube-plugin-akismet.peertubeOfficialPluginsUpdateScript;
 
   meta = {
     description = "Auto mute accounts or instances based on public blocklists";
@@ -30,4 +32,4 @@ buildNpmPackage rec {
     maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/peertube-plugin-hello-world/package.nix
+++ b/pkgs/by-name/peertube-plugin-hello-world/package.nix
@@ -6,20 +6,20 @@
 }:
 buildNpmPackage (finalAttrs: {
   pname = "peertube-plugin-hello-world";
-  version = "0.0.22";
+  version = "0-unstable-2025-05-30";
 
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = "framasoft";
     repo = "peertube/official-plugins";
-    rev = "fa9005ab1bab93e41e10bb1be3dc4837bd6bbc47";
+    rev = "1c6f794d7a5d9c69374cb6fa1daf184258acb63a";
     sparseCheckout = [ "peertube-plugin-hello-world" ];
-    hash = "sha256-gNeOJpKYqIRVLMbgfSVXnzCD9QGOJfGcJB3IkZweTEI=";
+    hash = "sha256-U5VjoIxk/UvP+jyn8D7c75Sb2+pPxAEfJIgSPPGjlZc=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/peertube-plugin-hello-world";
 
-  npmDepsHash = "sha256-Y6bq2w5ykqLMY9eDTNKL3DMkoOx+imV7OCw2Hy961Tk=";
+  npmDepsHash = "sha256-dNoVdDImF+KaOiMlW0tva4bOk2hMykHkzOZSSZWVEyw=";
 
   dontNpmBuild = true;
 

--- a/pkgs/by-name/peertube-plugin-hello-world/package.nix
+++ b/pkgs/by-name/peertube-plugin-hello-world/package.nix
@@ -2,8 +2,9 @@
   lib,
   buildNpmPackage,
   fetchFromGitLab,
+  peertube-plugin-akismet,
 }:
-buildNpmPackage rec {
+buildNpmPackage (finalAttrs: {
   pname = "peertube-plugin-hello-world";
   version = "0.0.22";
 
@@ -12,16 +13,17 @@ buildNpmPackage rec {
     owner = "framasoft";
     repo = "peertube/official-plugins";
     rev = "fa9005ab1bab93e41e10bb1be3dc4837bd6bbc47";
-    hash = "sha256-d1DGrmRCavc1a6r3UvT7AzcLkFMJktwDKpEjgx7RJAI=";
+    sparseCheckout = [ "peertube-plugin-hello-world" ];
+    hash = "sha256-gNeOJpKYqIRVLMbgfSVXnzCD9QGOJfGcJB3IkZweTEI=";
   };
 
-  sourceRoot = "${src.name}/peertube-plugin-hello-world";
+  sourceRoot = "${finalAttrs.src.name}/peertube-plugin-hello-world";
 
   npmDepsHash = "sha256-Y6bq2w5ykqLMY9eDTNKL3DMkoOx+imV7OCw2Hy961Tk=";
 
   dontNpmBuild = true;
 
-  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+  passthru.updateScript = peertube-plugin-akismet.peertubeOfficialPluginsUpdateScript;
 
   meta = {
     description = "Hello world PeerTube plugin example";
@@ -30,4 +32,4 @@ buildNpmPackage rec {
     maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/peertube-plugin-livechat/9000-Default-to-using-system-installed-prosody.patch
+++ b/pkgs/by-name/peertube-plugin-livechat/9000-Default-to-using-system-installed-prosody.patch
@@ -11,15 +11,6 @@ diff --git a/server/lib/settings.ts b/server/lib/settings.ts
 index eda78e1df..098ae3b14 100644
 --- a/server/lib/settings.ts
 +++ b/server/lib/settings.ts
-@@ -120,7 +120,7 @@ function initImportantNotesSettings ({ registerSetting }: RegisterServerOptions)
-       // Note: the following text as a variable in it.
-       //   Not translating it: it should be very rare.
-       descriptionHTML: `<span class="peertube-plugin-livechat-warning">
--It seems that your are using a ${process.arch} CPU, 
-+It seems that your are using a ${process.arch} CPU,
- which is not compatible with the plugin.
- Please read
- <a
 @@ -535,7 +535,7 @@ function initChatServerAdvancedSettings ({ registerSetting }: RegisterServerOpti
      label: loc('system_prosody_label'),
      descriptionHTML: loc('system_prosody_description'),

--- a/pkgs/by-name/peertube-plugin-livechat/package.nix
+++ b/pkgs/by-name/peertube-plugin-livechat/package.nix
@@ -10,17 +10,17 @@ let
   details = {
     livechat = rec {
       pname = "peertube-plugin-livechat";
-      version = "13.0.0";
+      version = "14.0.0";
       src = fetchFromGitHub {
         owner = "JohnXLivingston";
         repo = "peertube-plugin-livechat";
         rev = "refs/tags/v${version}";
-        hash = "sha256-zoG5KkGATi4zIZ2HkhVHZEIRkfl3rP1sE+5UROdmCiY=";
+        hash = "sha256-5cq4Z0WQ/xbqoYlIia9KzglFtyExlK9cDyT6dyfZVr4=";
       };
       npmDeps = fetchNpmDeps {
         name = "${pname}-${version}-deps";
         inherit src;
-        hash = "sha256-M4FxLJEJ1IntNnr1U7be2kNaK87pN8qHEsHnx+a4ZEo=";
+        hash = "sha256-B2VZnJ4G5uycEvB0jHdtvBVZet4oQSlY6E6lrwnWx9g=";
       };
     };
 

--- a/pkgs/by-name/peertube-plugin-livechat/package.nix
+++ b/pkgs/by-name/peertube-plugin-livechat/package.nix
@@ -175,7 +175,9 @@ let
     installPhase = ''
       runHook preInstall
 
-      cp -r dist/client/conversejs $out
+      mkdir -p $out/client
+      cp -r dist/client/conversejs $out/client/
+      cp dist/converse-emoji.json $out/
 
       runHook postInstall
     '';
@@ -185,7 +187,7 @@ let
     installCheckPhase = ''
       runHook preInstallCheck
 
-      if [ ! -f $out/converse.min.js -o ! -f $out/converse.min.css ]; then
+      if [ ! -f $out/client/conversejs/converse.min.js -o ! -f $out/client/conversejs/converse.min.css ]; then
         echo "converse.min.js or converse.min.css failed to be generated, please check the build log!"
         exit 1
       fi
@@ -214,7 +216,7 @@ buildNpmPackage {
   postPatch = ''
     mkdir -p dist/client
     cp -r --no-preserve=mode,ownership ${translations} dist/languages
-    cp -r --no-preserve=mode,ownership ${conversejs} dist/client/conversejs
+    cp -r --no-preserve=mode,ownership ${conversejs}/* dist/
 
     # Don't try to delete & rebuild everything when installing (either in this derivation or as a plugin in peertube)
     # clean:light would get rid of the built conversejs

--- a/pkgs/by-name/peertube-plugin-livechat/package.nix
+++ b/pkgs/by-name/peertube-plugin-livechat/package.nix
@@ -202,6 +202,15 @@ let
       inherit (commonMeta) maintainers platforms;
     };
   };
+
+  livechatProsody = prosody.override {
+    withExtraLuaPackages = (
+      p: [
+        # Needed by one of peertube-livechat's prosody modules
+        p.lrexlib-oniguruma
+      ]
+    );
+  };
 in
 buildNpmPackage {
   inherit (details.livechat) pname version npmDeps;
@@ -229,8 +238,8 @@ buildNpmPackage {
 
     # Wants to run its own prosody instance
     substituteInPlace server/lib/prosody/config.ts \
-      --replace-fail "exec = 'prosody'" "exec = '${lib.getExe' prosody "prosody"}'" \
-      --replace-fail "execCtl = 'prosodyctl'" "execCtl = '${lib.getExe' prosody "prosodyctl"}'" \
+      --replace-fail "exec = 'prosody'" "exec = '${lib.getExe' livechatProsody "prosody"}'" \
+      --replace-fail "execCtl = 'prosodyctl'" "execCtl = '${lib.getExe' livechatProsody "prosodyctl"}'" \
   '';
 
   meta = {

--- a/pkgs/by-name/peertube-plugin-logo-framasoft/package.nix
+++ b/pkgs/by-name/peertube-plugin-logo-framasoft/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitLab,
+  peertube-plugin-akismet,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "peertube-plugin-logo-framasoft";
@@ -12,7 +13,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "framasoft";
     repo = "peertube/official-plugins";
     rev = "b4ff861a3458bd502a6b95c9005c90d786f2a74e";
-    hash = "sha256-BPV1DrqCvKsV5SA4o2+oUsE/kNY9sL6svJmshjDTG+Y=";
+    sparseCheckout = [ "peertube-plugin-logo-famasof" ];
+    hash = "sha256-BwoM47xMcLHBoat0hgbO7vjzplwlDQhiMoSiRM5/Szk=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/peertube-plugin-logo-framasoft";
@@ -28,7 +30,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+  passthru.updateScript = peertube-plugin-akismet.peertubeOfficialPluginsUpdateScript;
 
   meta = {
     description = "Framasoft logo on PeerTube";

--- a/pkgs/by-name/peertube-plugin-logo-framasoft/package.nix
+++ b/pkgs/by-name/peertube-plugin-logo-framasoft/package.nix
@@ -6,15 +6,15 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "peertube-plugin-logo-framasoft";
-  version = "0.0.1";
+  version = "0-unstable-2025-05-30";
 
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = "framasoft";
     repo = "peertube/official-plugins";
-    rev = "b4ff861a3458bd502a6b95c9005c90d786f2a74e";
+    rev = "1c6f794d7a5d9c69374cb6fa1daf184258acb63a";
     sparseCheckout = [ "peertube-plugin-logo-famasof" ];
-    hash = "sha256-BwoM47xMcLHBoat0hgbO7vjzplwlDQhiMoSiRM5/Szk=";
+    hash = "sha256-jn4jWFREfcXXwxLMdwZ7Jfjl5ZM//nE18YuI2EAx/0c=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/peertube-plugin-logo-framasoft";

--- a/pkgs/by-name/peertube-plugin-logo-framasoft/package.nix
+++ b/pkgs/by-name/peertube-plugin-logo-framasoft/package.nix
@@ -13,8 +13,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "framasoft";
     repo = "peertube/official-plugins";
     rev = "1c6f794d7a5d9c69374cb6fa1daf184258acb63a";
-    sparseCheckout = [ "peertube-plugin-logo-famasof" ];
-    hash = "sha256-jn4jWFREfcXXwxLMdwZ7Jfjl5ZM//nE18YuI2EAx/0c=";
+    sparseCheckout = [ "peertube-plugin-logo-framasoft" ];
+    hash = "sha256-svLsqvUYSFUvAD13xtt6C8JtvQi7lQ36w51Iy7U+0L0=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/peertube-plugin-logo-framasoft";

--- a/pkgs/by-name/peertube-plugin-matomo/package.nix
+++ b/pkgs/by-name/peertube-plugin-matomo/package.nix
@@ -2,8 +2,9 @@
   lib,
   buildNpmPackage,
   fetchFromGitLab,
+  peertube-plugin-akismet,
 }:
-buildNpmPackage rec {
+buildNpmPackage (finalAttrs: {
   pname = "peertube-plugin-matomo";
   version = "1.0.2";
 
@@ -12,14 +13,15 @@ buildNpmPackage rec {
     owner = "framasoft";
     repo = "peertube/official-plugins";
     rev = "9bd2db9033c11c650cdf1035f7eed6f4ba61cf54";
-    hash = "sha256-EUocSJLi2s9VXddRIffG1Aj8/1AlegwP+76IbowhoOo=";
+    sparseCheckout = [ "peertube-plugin-matomo" ];
+    hash = "sha256-c7Wnli7L382XbfEOApPlqALkjK8Le9A9xvUOdMRq4Io=";
   };
 
-  sourceRoot = "${src.name}/peertube-plugin-matomo";
+  sourceRoot = "${finalAttrs.src.name}/peertube-plugin-matomo";
 
   npmDepsHash = "sha256-s2vrUKMRF+VhBPAbv/RQ66UBNOBYEvi/axxJB132R9s=";
 
-  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+  passthru.updateScript = peertube-plugin-akismet.peertubeOfficialPluginsUpdateScript;
 
   meta = {
     description = "Matomo plugin that tracks page views on a PeerTube instance";
@@ -28,4 +30,4 @@ buildNpmPackage rec {
     maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/peertube-plugin-privacy-remover/package.nix
+++ b/pkgs/by-name/peertube-plugin-privacy-remover/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitLab,
+  peertube-plugin-akismet,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "peertube-plugin-privacy-remover";
@@ -12,7 +13,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "framasoft";
     repo = "peertube/official-plugins";
     rev = "2df3a5909536f17f143b2c391bb483e339f36c3e";
-    hash = "sha256-2kcugu4uEPd/WgOe3vV6xaA1d2OcSBJy2ZkZ8gNv760=";
+    sparseCheckout = [ "peertube-plugin-privacy-remover" ];
+    hash = "sha256-CptC4fBeJ5q9i/EmgShdl1tdtz6ymnGR/T5kj60EBPI=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/peertube-plugin-privacy-remover";
@@ -28,7 +30,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+  passthru.updateScript = peertube-plugin-akismet.peertubeOfficialPluginsUpdateScript;
 
   meta = {
     description = "Remove video privacy settings of your choice";

--- a/pkgs/by-name/peertube-plugin-privacy-remover/package.nix
+++ b/pkgs/by-name/peertube-plugin-privacy-remover/package.nix
@@ -6,15 +6,15 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "peertube-plugin-privacy-remover";
-  version = "0.0.1";
+  version = "0-unstable-2025-05-30";
 
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = "framasoft";
     repo = "peertube/official-plugins";
-    rev = "2df3a5909536f17f143b2c391bb483e339f36c3e";
+    rev = "1c6f794d7a5d9c69374cb6fa1daf184258acb63a";
     sparseCheckout = [ "peertube-plugin-privacy-remover" ];
-    hash = "sha256-CptC4fBeJ5q9i/EmgShdl1tdtz6ymnGR/T5kj60EBPI=";
+    hash = "sha256-cK1ojyhjYfOUoYfLZA7pzUtp1P1o3PXrezR+mOhS0SE=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/peertube-plugin-privacy-remover";

--- a/pkgs/by-name/peertube-plugin-transcoding-custom-quality/package.nix
+++ b/pkgs/by-name/peertube-plugin-transcoding-custom-quality/package.nix
@@ -6,15 +6,15 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "peertube-plugin-transcoding-custom-quality";
-  version = "0.1.0";
+  version = "0-unstable-2025-05-30";
 
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = "framasoft";
     repo = "peertube/official-plugins";
-    rev = "9731357f9fb68c48df9cdc3f51fe3dafbecf3bf6";
+    rev = "1c6f794d7a5d9c69374cb6fa1daf184258acb63a";
     sparseCheckout = [ "peertube-plugin-transcoding-custom-quality" ];
-    hash = "sha256-e7twKvYxb1NjGu/LnsDnv3XOqdMN9VuofhVpdGMriOs=";
+    hash = "sha256-DEYyrQtogtKCSZM8nIBZiKIcbbG22RmXsenGPd9hTGE=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/peertube-plugin-transcoding-custom-quality";

--- a/pkgs/by-name/peertube-plugin-transcoding-custom-quality/package.nix
+++ b/pkgs/by-name/peertube-plugin-transcoding-custom-quality/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitLab,
+  peertube-plugin-akismet,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "peertube-plugin-transcoding-custom-quality";
@@ -12,7 +13,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "framasoft";
     repo = "peertube/official-plugins";
     rev = "9731357f9fb68c48df9cdc3f51fe3dafbecf3bf6";
-    hash = "sha256-diklMd0S6wUsQKunQYLGzrIJqIfAfDzBTZy6aUiu584=";
+    sparseCheckout = [ "peertube-plugin-transcoding-custom-quality" ];
+    hash = "sha256-e7twKvYxb1NjGu/LnsDnv3XOqdMN9VuofhVpdGMriOs=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/peertube-plugin-transcoding-custom-quality";
@@ -28,7 +30,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+  passthru.updateScript = peertube-plugin-akismet.peertubeOfficialPluginsUpdateScript;
 
   meta = {
     description = "Set a custom quality for transcoding";

--- a/pkgs/by-name/peertube-plugin-transcoding-profile-debug/package.nix
+++ b/pkgs/by-name/peertube-plugin-transcoding-profile-debug/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitLab,
+  peertube-plugin-akismet,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "peertube-plugin-transcoding-profile-debug";
@@ -12,7 +13,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "framasoft";
     repo = "peertube/official-plugins";
     rev = "077c983e32743462372c503b636814543f65845e";
-    hash = "sha256-fL+JhHHtSIb1X87z6VqX8I0C31yewjj2C9tx1aVzJPA=";
+    sparseCheckout = [ "peertube-plugin-transcoding-profile-debug" ];
+    hash = "sha256-oa3oAKPbsg9Io1R20yhAmdNjbCIHTXN5dhmkCEpDeOY=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/peertube-plugin-transcoding-profile-debug";
@@ -28,7 +30,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+  passthru.updateScript = peertube-plugin-akismet.peertubeOfficialPluginsUpdateScript;
 
   meta = {
     description = "Allow admins to create custom transcoding profiles using the plugin settings";

--- a/pkgs/by-name/peertube-plugin-video-annotation/package.nix
+++ b/pkgs/by-name/peertube-plugin-video-annotation/package.nix
@@ -6,15 +6,15 @@
 }:
 buildNpmPackage (finalAttrs: {
   pname = "peertube-plugin-video-annotation";
-  version = "0.0.8";
+  version = "0-unstable-2025-05-30";
 
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = "framasoft";
     repo = "peertube/official-plugins";
-    rev = "fee5b7eb1d8d1a51c56ea9a6b4b7d109f91b20c3";
+    rev = "1c6f794d7a5d9c69374cb6fa1daf184258acb63a";
     sparseCheckout = [ "peertube-plugin-video-annotation" ];
-    hash = "sha256-jiGbwSaHwYfQCxe/LEywV+zEITkdWznTCo/HQyEfqvc=";
+    hash = "sha256-YLEhMJuOFiX9SE+XjhOPZ2kHvAM+arFYmuHXWZDa6+0=";
   };
 
   # prepare script breaks installation at peertube plugin time
@@ -25,7 +25,7 @@ buildNpmPackage (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/peertube-plugin-video-annotation";
 
-  npmDepsHash = "sha256-gqEa1DwNlNR5JED0Lhhi9XFKCoJ+NhNHKioNR1A8puU=";
+  npmDepsHash = "sha256-1/9RQZHiUtZFFycIBewGUSImGKUJdv4flZv5EaIJ02E=";
 
   passthru.updateScript = peertube-plugin-akismet.peertubeOfficialPluginsUpdateScript;
 

--- a/pkgs/by-name/peertube-plugin-video-annotation/package.nix
+++ b/pkgs/by-name/peertube-plugin-video-annotation/package.nix
@@ -2,8 +2,9 @@
   lib,
   buildNpmPackage,
   fetchFromGitLab,
+  peertube-plugin-akismet,
 }:
-buildNpmPackage rec {
+buildNpmPackage (finalAttrs: {
   pname = "peertube-plugin-video-annotation";
   version = "0.0.8";
 
@@ -12,7 +13,8 @@ buildNpmPackage rec {
     owner = "framasoft";
     repo = "peertube/official-plugins";
     rev = "fee5b7eb1d8d1a51c56ea9a6b4b7d109f91b20c3";
-    hash = "sha256-MWcHMAXPLAxlp+EEFs60nIAR99PBNw15bWj1/NA3ZWs=";
+    sparseCheckout = [ "peertube-plugin-video-annotation" ];
+    hash = "sha256-jiGbwSaHwYfQCxe/LEywV+zEITkdWznTCo/HQyEfqvc=";
   };
 
   # prepare script breaks installation at peertube plugin time
@@ -21,11 +23,11 @@ buildNpmPackage rec {
       --replace-fail '"prepare": "npm run build",' ""
   '';
 
-  sourceRoot = "${src.name}/peertube-plugin-video-annotation";
+  sourceRoot = "${finalAttrs.src.name}/peertube-plugin-video-annotation";
 
   npmDepsHash = "sha256-gqEa1DwNlNR5JED0Lhhi9XFKCoJ+NhNHKioNR1A8puU=";
 
-  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+  passthru.updateScript = peertube-plugin-akismet.peertubeOfficialPluginsUpdateScript;
 
   meta = {
     description = "Add a field in the video form so users can set annotation to their video";
@@ -34,4 +36,4 @@ buildNpmPackage rec {
     maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/peertube-theme-background-red/package.nix
+++ b/pkgs/by-name/peertube-theme-background-red/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitLab,
+  peertube-plugin-akismet,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "peertube-theme-background-red";
@@ -12,7 +13,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "framasoft";
     repo = "peertube/official-plugins";
     rev = "e763baddf3ad0efb215bcc8c0d3eb286d0471f21";
-    hash = "sha256-50H4JU4BW/2+6xQzXkoK6Ug30FzFDRpt42mTXh1SH9o=";
+    sparseCheckout = [ "peertube-theme-background-red" ];
+    hash = "sha256-euc/7gEkxNmJT/W4nHZYohNQyzRsRm+JauHeNs8GD/8=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/peertube-theme-background-red";
@@ -28,7 +30,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+  passthru.updateScript = peertube-plugin-akismet.peertubeOfficialPluginsUpdateScript;
 
   meta = {
     description = "Ugly and painful example theme";

--- a/pkgs/by-name/peertube-theme-dark/package.nix
+++ b/pkgs/by-name/peertube-theme-dark/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitLab,
+  peertube-plugin-akismet,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "peertube-theme-dark";
@@ -12,7 +13,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "framasoft";
     repo = "peertube/official-plugins";
     rev = "631f784774dc5f9686bf06033d6ceb0d596ef987";
-    hash = "sha256-VvtqF9et2uLxj8kGIjdaHQjxQbeNIAwz+NTPME/6Wpk=";
+    sparseCheckout = [ "peertube-theme-dark" ];
+    hash = "sha256-e4S5NpwE9tDoQfyYsZVAtaiqUmNv6Zhk0qcoPqT6N7U=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/peertube-theme-dark";
@@ -28,7 +30,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+  passthru.updateScript = peertube-plugin-akismet.peertubeOfficialPluginsUpdateScript;
 
   meta = {
     description = "PeerTube dark theme";

--- a/pkgs/by-name/peertube-theme-dark/package.nix
+++ b/pkgs/by-name/peertube-theme-dark/package.nix
@@ -6,15 +6,15 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "peertube-theme-dark";
-  version = "2.5.0";
+  version = "0-unstable-2025-05-30";
 
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = "framasoft";
     repo = "peertube/official-plugins";
-    rev = "631f784774dc5f9686bf06033d6ceb0d596ef987";
+    rev = "1c6f794d7a5d9c69374cb6fa1daf184258acb63a";
     sparseCheckout = [ "peertube-theme-dark" ];
-    hash = "sha256-e4S5NpwE9tDoQfyYsZVAtaiqUmNv6Zhk0qcoPqT6N7U=";
+    hash = "sha256-qICONcpP05r1BYF+GaPsp9+7CoKZcF024otOHspU2Tk=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/peertube-theme-dark";

--- a/pkgs/by-name/peertube-theme-framasoft/package.nix
+++ b/pkgs/by-name/peertube-theme-framasoft/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitLab,
+  peertube-plugin-akismet,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "peertube-theme-framasoft";
@@ -12,7 +13,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "framasoft";
     repo = "peertube/official-plugins";
     rev = "e85121a9d68c9337a60198ed67e68ef520d6b50b";
-    hash = "sha256-uLw4XK1I1YM/hI5gbYKJ3flyZ1GOVLarvUNa57W5bBs=";
+    sparseCheckout = [ "peertube-theme-framasoft" ];
+    hash = "sha256-3HfAT1kXtKRy+iFfPQXPrsdwIzbx8eAPTkThU48xbfE=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/peertube-theme-framasoft";
@@ -28,7 +30,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  # TODO: passthru.updateScript? there are no tags, versions come as commits with changes to subdir's package.json
+  passthru.updateScript = peertube-plugin-akismet.peertubeOfficialPluginsUpdateScript;
 
   meta = {
     description = "PeerTube Framasoft theme";

--- a/pkgs/by-name/peertube-theme-framasoft/package.nix
+++ b/pkgs/by-name/peertube-theme-framasoft/package.nix
@@ -6,15 +6,15 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "peertube-theme-framasoft";
-  version = "0.0.1";
+  version = "0-unstable-2025-05-30";
 
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = "framasoft";
     repo = "peertube/official-plugins";
-    rev = "e85121a9d68c9337a60198ed67e68ef520d6b50b";
+    rev = "1c6f794d7a5d9c69374cb6fa1daf184258acb63a";
     sparseCheckout = [ "peertube-theme-framasoft" ];
-    hash = "sha256-3HfAT1kXtKRy+iFfPQXPrsdwIzbx8eAPTkThU48xbfE=";
+    hash = "sha256-Tx68ZpzMhIn/CzWfYdao3GK8k2tMK0GVgvaRPfarnPg=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/peertube-theme-framasoft";

--- a/projects/PeerTube/default.nix
+++ b/projects/PeerTube/default.nix
@@ -55,6 +55,7 @@
           module = ./services/peertube/examples/basic.nix;
           description = "Basic configuration mainly used for testing purposes";
           tests.peertube-plugins = import ./services/peertube/tests/peertube-plugins.nix args;
+          tests.peertube-plugin-livechat = import ./services/peertube/tests/peertube-plugin-livechat.nix args;
         };
       };
     };

--- a/projects/PeerTube/services/peertube/tests/peertube-plugin-livechat.nix
+++ b/projects/PeerTube/services/peertube/tests/peertube-plugin-livechat.nix
@@ -1,0 +1,41 @@
+{
+  sources,
+  pkgs,
+  lib,
+  ...
+}:
+{
+  name = "peertube-plugin-livechat";
+
+  nodes = {
+    server =
+      { config, ... }:
+      {
+        imports = [
+          sources.modules.ngipkgs
+          sources.modules.services.peertube
+          sources.examples.PeerTube.basic
+        ];
+
+        services.peertube.plugins.plugins = lib.mkForce [
+          pkgs.peertube-plugin-livechat
+        ];
+
+        boot.kernelPackages = pkgs.linuxPackages_latest;
+      };
+  };
+
+  testScript =
+    { nodes, ... }:
+    let
+      url = "http://${nodes.server.services.peertube.localDomain}:${toString nodes.server.services.peertube.listenWeb}";
+    in
+    ''
+      start_all()
+
+      # Wait until we can get through to the instance and trigger some initial loading
+      server.wait_until_succeeds("curl -Ls ${url}")
+
+      server.wait_for_console_text("loading peertube admins and moderators")
+    '';
+}

--- a/projects/PeerTube/services/peertube/tests/peertube-plugins.nix
+++ b/projects/PeerTube/services/peertube/tests/peertube-plugins.nix
@@ -56,10 +56,10 @@
       # And the plugins should now be loaded
       # The order of the checks here is based on when different plugins emit their log messages
 
-      with subtest("peertube plugin ${pkgs.peertube-plugin-livechat.pname} works"):
-          server.wait_for_console_text("loading peertube admins and moderators")
-
       with subtest("peertube plugin ${pkgs.peertube-plugin-hello-world.pname} works"):
           server.wait_for_console_text("hello world PeerTube admin")
+
+      with subtest("peertube plugin ${pkgs.peertube-plugin-livechat.pname} works"):
+          server.wait_for_console_text("loading peertube admins and moderators")
     '';
 }

--- a/projects/PeerTube/services/peertube/tests/peertube-plugins.nix
+++ b/projects/PeerTube/services/peertube/tests/peertube-plugins.nix
@@ -58,8 +58,5 @@
 
       with subtest("peertube plugin ${pkgs.peertube-plugin-hello-world.pname} works"):
           server.wait_for_console_text("hello world PeerTube admin")
-
-      with subtest("peertube plugin ${pkgs.peertube-plugin-livechat.pname} works"):
-          server.wait_for_console_text("loading peertube admins and moderators")
     '';
 }


### PR DESCRIPTION
This PR adds updates all PeerTube plugins/themes. It also adds update scripts to all of them except livechat. I'm leaving livechat for now, since I think its build process will get simpler in the future.

All the official PeerTube plugins live in the same repository with no tags. Each commit could update any one of the plugins. Due to the use of sparseCheckout, each plugin will only get updated when its files have changed. Otherwise, the update script will give an error.
Once https://github.com/Mic92/nix-update/issues/281 is resolved, the plugins will be able to use nix-update instead of the custom script.

Finally, the update script is referenced with `peertube-plugin-akismet.peertubeOfficialPluginsUpdateScript`, because there was no better place currently to put the update script than one of the plugin package directories.
