### PR TITLE
xrsh/demo-shell: remove hardcoded env variable

### DIFF
--- a/projects/xrsh/programs/xrsh/module.nix
+++ b/projects/xrsh/programs/xrsh/module.nix
@@ -31,7 +31,7 @@ in
       programs = {
         xrsh = cfg.package;
       };
-      env.XRSH_PORT = "8090";
+      env.XRSH_PORT = toString cfg.port;
     };
   };
 }


### PR DESCRIPTION
Closes #1226 
Previously, it was not possible to edit the port on which the Xrsh web server runs in the demo shell. This was due to a hardcoded environment variable. It is now removed and changing the port in the demo-shell config, also changes the env.