### PR TITLE
treewide: fix link to triaging instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/project.md
+++ b/.github/ISSUE_TEMPLATE/project.md
@@ -7,7 +7,7 @@ projects: Nix@NGI
 assignees: ''
 ---
 
-<!-- Follow the instructions in the [contributing guide](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#triaging-an-ngi-project) and put the project metadata here -->
+<!-- Follow the instructions in the [contributing guide](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#triaging-an-ngi-application) and put the project metadata here -->
 
 ### Tasks
 

--- a/.github/ISSUE_TEMPLATE/task-demo.md
+++ b/.github/ISSUE_TEMPLATE/task-demo.md
@@ -11,7 +11,7 @@ assignees: ''
 ### Instructions
 
 <!-- Replace `PROJECT_ISSUE_NUMBER` with the issue number that contains the project's triaged information.
-If one doesn't exist, create it by following the instructions in the [contributor documentation](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#triaging-an-ngi-project). -->
+If one doesn't exist, create it by following the instructions in the [contributor documentation](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#triaging-an-ngi-application). -->
 
 Use metadata about the application from its tracking issue:
 

--- a/.github/ISSUE_TEMPLATE/task-example.md
+++ b/.github/ISSUE_TEMPLATE/task-example.md
@@ -11,7 +11,7 @@ assignees: ''
 ### Instructions
 
 <!-- Replace `PROJECT_ISSUE_NUMBER` with the issue number that contains the project's triaged information.
-If one doesn't exist, create it by following the instructions in the [contributor documentation](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#triaging-an-ngi-project). -->
+If one doesn't exist, create it by following the instructions in the [contributor documentation](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#triaging-an-ngi-application). -->
 
 Use metadata about the application from its tracking issue:
 

--- a/.github/ISSUE_TEMPLATE/task-metadata.md
+++ b/.github/ISSUE_TEMPLATE/task-metadata.md
@@ -11,7 +11,7 @@ assignees: ''
 ### Instructions
 
 <!-- Replace `PROJECT_ISSUE_NUMBER` with the issue number that contains the project's triaged information.
-If one doesn't exist, create it by following the instructions in the [contributor documentation](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#triaging-an-ngi-project). -->
+If one doesn't exist, create it by following the instructions in the [contributor documentation](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#triaging-an-ngi-application). -->
 
 Use metadata about the application from its tracking issue:
 

--- a/.github/ISSUE_TEMPLATE/task-module-program.md
+++ b/.github/ISSUE_TEMPLATE/task-module-program.md
@@ -11,7 +11,7 @@ assignees: ''
 ### Instructions
 
 <!-- Replace `PROJECT_ISSUE_NUMBER` with the issue number that contains the project's triaged information.
-If one doesn't exist, create it by following the instructions in the [contributor documentation](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#triaging-an-ngi-project). -->
+If one doesn't exist, create it by following the instructions in the [contributor documentation](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#triaging-an-ngi-application). -->
 
 Use metadata about the application from its tracking issue:
 

--- a/.github/ISSUE_TEMPLATE/task-module-service.md
+++ b/.github/ISSUE_TEMPLATE/task-module-service.md
@@ -11,7 +11,7 @@ assignees: ''
 ### Instructions
 
 <!-- Replace `PROJECT_ISSUE_NUMBER` with the issue number that contains the project's triaged information.
-If one doesn't exist, create it by following the instructions in the [contributor documentation](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#triaging-an-ngi-project). -->
+If one doesn't exist, create it by following the instructions in the [contributor documentation](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#triaging-an-ngi-application). -->
 
 Use metadata about the application from its tracking issue:
 

--- a/.github/ISSUE_TEMPLATE/task-nixos-test.md
+++ b/.github/ISSUE_TEMPLATE/task-nixos-test.md
@@ -11,7 +11,7 @@ assignees: ''
 ### Instructions
 
 <!-- Replace `PROJECT_ISSUE_NUMBER` with the issue number that contains the project's triaged information.
-If one doesn't exist, create it by following the instructions in the [contributor documentation](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#triaging-an-ngi-project). -->
+If one doesn't exist, create it by following the instructions in the [contributor documentation](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#triaging-an-ngi-application). -->
 
 Use metadata about the application from its tracking issue:
 

--- a/.github/ISSUE_TEMPLATE/task-triage.yaml
+++ b/.github/ISSUE_TEMPLATE/task-triage.yaml
@@ -9,7 +9,7 @@ body:
     attributes:
       label: Instructions
       value: |
-        Collect relevant information about this project by following the instructions in the [contributing guide](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#triaging-an-ngi-project) and put the metadata in the parent issue: `NGI PROJECT: <PROJECT_NAME>`.
+        Collect relevant information about this project by following the instructions in the [contributing guide](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#triaging-an-ngi-application) and put the metadata in the parent issue: `NGI PROJECT: <PROJECT_NAME>`.
     validations:
       required: true
   - type: markdown

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Instead, write one sentence per line, as this makes it easier to review changes.
    $EDITOR projects/some-project/default.nix
    ```
 
-   Note that for new projects, it's ideal that you follow the [triaging template](#triaging-an-ngi-project) workflow and create a new issue, detailing some information about this project.
+   Note that for new projects, it's ideal that you follow the [triaging template](#triaging-an-ngi-application) workflow and create a new issue, detailing some information about this project.
    This will allow you to get more familiar with the project and fill out the template more easily.
 
 1. To add a NixOS service module, start by editing the `default.nix` file in the directory `projects/some-project`.


### PR DESCRIPTION
https://github.com/ngi-nix/ngipkgs/pull/1095 has updated the section title but not the references.