### PR TITLE
flake.lock: Bump all inputs to latest versions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1749646346,
-        "narHash": "sha256-6WOQ5B1uv/TVgJHlgovYhMjqIhghKyJmoOlWHwpkGo4=",
+        "lastModified": 1750803345,
+        "narHash": "sha256-rml3DgfE8AeNAlt+dj9E2ndi48Dy2K6EojId6yPMWzA=",
         "owner": "nix-community",
         "repo": "buildbot-nix",
-        "rev": "7c4745da661c5d3ba28762d1e10080a107046b17",
+        "rev": "6a18f921f8e580d0e5918abae0cfda7829c90728",
         "type": "github"
       },
       "original": {
@@ -32,11 +32,11 @@
         "pyproject-nix": "pyproject-nix"
       },
       "locked": {
-        "lastModified": 1750041384,
-        "narHash": "sha256-eJH3Vz79sKjpCOwmiYi3GCyJptsW8vV08nKqWvFZe4w=",
+        "lastModified": 1750272463,
+        "narHash": "sha256-udleaLnEHK3A5RZVCEQnE6Zeww6yq03NUcqJ/TcUQVc=",
         "owner": "nix-community",
         "repo": "dream2nix",
-        "rev": "ffabb1d849ff0161669376a2c06c63abfb3ace90",
+        "rev": "bd83ed026b859acb34c52c3fdc15631c8766af8e",
         "type": "github"
       },
       "original": {
@@ -166,11 +166,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749903597,
-        "narHash": "sha256-jp0D4vzBcRKwNZwfY4BcWHemLGUs4JrS3X9w5k/JYDA=",
+        "lastModified": 1750811787,
+        "narHash": "sha256-rD/978c35JXz6JLAzciTIOCMenPumF6zrQOj4rVZeHE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "41da1e3ea8e23e094e5e3eeb1e6b830468a7399e",
+        "rev": "992f916556fcfaa94451ebc7fc6e396134bbf5b1",
         "type": "github"
       },
       "original": {
@@ -189,11 +189,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749636823,
-        "narHash": "sha256-WUaIlOlPLyPgz9be7fqWJA5iG6rHcGRtLERSCfUDne4=",
+        "lastModified": 1750779888,
+        "narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "623c56286de5a3193aa38891a6991b28f9bab056",
+        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
         "type": "github"
       },
       "original": {
@@ -282,11 +282,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749592509,
-        "narHash": "sha256-VunQzfZFA+Y6x3wYi2UE4DEQ8qKoAZZCnZPUlSoqC+A=",
+        "lastModified": 1750119275,
+        "narHash": "sha256-Rr7Pooz9zQbhdVxux16h7URa6mA80Pb/G07T4lHvh0M=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "50754dfaa0e24e313c626900d44ef431f3210138",
+        "rev": "77c423a03b9b2b79709ea2cb63336312e78b72e2",
         "type": "github"
       },
       "original": {

--- a/pkgs/by-name/heads/package.nix
+++ b/pkgs/by-name/heads/package.nix
@@ -432,7 +432,10 @@ lib.makeScope newScope (
     # only allow a fixed list of boards and slowly increase it
     # (see: https://github.com/NixOS/nixpkgs/pull/286228#issuecomment-2779598354)
     allowedBoards = [
-      "qemu-coreboot-fbwhiptail-tpm1-hotp"
+      # FIX: it seems this file is no longer accessible:
+      # https://acpica.org/sites/acpica/files/acpica-unix2-20220331.tar.gz
+      # https://buildbot.ngi.nixos.org/#/builders/558/builds/881
+      # "qemu-coreboot-fbwhiptail-tpm1-hotp"
     ];
   in
   {

--- a/pkgs/by-name/libervia-backend/package.nix
+++ b/pkgs/by-name/libervia-backend/package.nix
@@ -19,6 +19,13 @@
   wokkel,
   wrapGAppsHook3,
 }:
+let
+  # FIX: remove after this is solved:
+  # https://github.com/NixOS/nixpkgs/issues/418689
+  lxml-html-clean = python3Packages.lxml-html-clean.overridePythonAttrs {
+    doCheck = false;
+  };
+in
 python3Packages.buildPythonApplication rec {
   pname = "libervia-backend";
   version = "0.8.0-unstable-2024-10-26";

--- a/pkgs/by-name/libervia-desktop-kivy/package.nix
+++ b/pkgs/by-name/libervia-desktop-kivy/package.nix
@@ -96,5 +96,7 @@ python3Packages.buildPythonApplication rec {
     changelog = "https://repos.goffi.org/libervia-desktop-kivy/file/${src.rev}/CHANGELOG";
     license = lib.licenses.agpl3Plus;
     maintainers = [ ];
+    # FIX: https://buildbot.ngi.nixos.org/#/builders/387/builds/1770
+    broken = true;
   };
 }

--- a/pkgs/by-name/libresoc-nmigen/soc.nix
+++ b/pkgs/by-name/libresoc-nmigen/soc.nix
@@ -75,5 +75,7 @@ python3Packages.buildPythonPackage rec {
     description = "A nmigen-based OpenPOWER multi-issue Hybrid 3D CPU-VPU-GPU";
     homepage = "https://git.libre-soc.org/?p=soc.git;a=summary";
     license = lib.licenses.lgpl3Plus;
+    # FIX: https://github.com/NixOS/nixpkgs/issues/389149
+    broken = true;
   };
 }

--- a/pkgs/by-name/libresoc-verilog/verilog.nix
+++ b/pkgs/by-name/libresoc-verilog/verilog.nix
@@ -11,6 +11,9 @@ runCommand "libresoc.v"
       libresoc-nmigen
       pinmux
     ];
+
+    # FIX: https://github.com/NixOS/nixpkgs/issues/389149
+    meta.broken = true;
   }
   ''
     mkdir pinmux

--- a/pkgs/by-name/openxc7/package.nix
+++ b/pkgs/by-name/openxc7/package.nix
@@ -128,7 +128,7 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "openxc7";
-  version = "0.8.2-unstable-2025-03-14";
+  version = "0.8.2-unstable-2025-04-03";
 
   # We can't use upstream's files via fetched src without introducing IFD
   # or pushing the building onto the user - which makes internet-less VM testing
@@ -137,8 +137,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "openXC7";
     repo = "toolchain-nix";
-    rev = "f358781e5c21a59ab9c8c10f03beb81d8f8e468a";
-    hash = "sha256-KwFHIGKzY5SdXPbhXj9LcHRlj2MPHVrmam8QECzWysY=";
+    rev = "b2ca2c45c8a4919fffe04a8716654dc9bba6c7c1";
+    hash = "sha256-M4nlDnuFiOVDQvd360NsRPU7jsepIvehEHvIyL/uCSc=";
   };
 
   dontUnpack = true;

--- a/pkgs/by-name/openxc7/package.nix
+++ b/pkgs/by-name/openxc7/package.nix
@@ -176,6 +176,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     platforms = lib.platforms.linux;
     # ghdl -> gnat -> gnat-bootstrap only available for very specific platforms
     # Mark broken if bootstrapping gnat is unavailable, to keep CI green
-    broken = !lib.meta.availableOn stdenvNoCC.hostPlatform gnat-bootstrap;
+    # FIX: re-enable after this is solved
+    # https://github.com/NixOS/nixpkgs/issues/419942
+    # broken = !lib.meta.availableOn stdenvNoCC.hostPlatform gnat-bootstrap;
+    broken = true;
   };
 })

--- a/projects/Canaille/default.nix
+++ b/projects/Canaille/default.nix
@@ -20,7 +20,9 @@
       examples.basic = {
         module = ./services/Canaille/examples/basic.nix;
         description = "";
-        tests.canaille = "${sources.inputs.nixpkgs}/nixos/tests/canaille.nix";
+        # FIX: https://github.com/pallets-eco/flask-alembic/issues/47
+        # tests.canaille = "${sources.inputs.nixpkgs}/nixos/tests/canaille.nix";
+        tests.canaille = null;
       };
       links = {
         build = {

--- a/projects/Heads/default.nix
+++ b/projects/Heads/default.nix
@@ -25,7 +25,11 @@
           Builds heads for the example qemu-coreboot-fbwhiptail-tpm1-hotp board, and makes the ROM image available
           at a fixed location, for testing it in a VM.
         '';
-        tests.basic = import ./test.nix args;
+        # FIX: it seems this file is no longer accessible:
+        # https://acpica.org/sites/acpica/files/acpica-unix2-20220331.tar.gz
+        # https://buildbot.ngi.nixos.org/#/builders/558/builds/881
+        # tests.basic = import ./test.nix args;
+        tests.basic = null;
       };
       links = {
         setup = {

--- a/projects/Libervia/default.nix
+++ b/projects/Libervia/default.nix
@@ -46,7 +46,9 @@
         desktop = {
           description = "Enables the use of the Kivy desktop client for Libervia.";
           module = ./examples/desktop.nix;
-          tests.desktop = import ./tests/desktop.nix args;
+          # FIX: https://buildbot.ngi.nixos.org/#/builders/473/builds/1182
+          # tests.desktop = import ./tests/desktop.nix args;
+          tests.desktop = null;
         };
       };
     };

--- a/projects/LibreSOC/default.nix
+++ b/projects/LibreSOC/default.nix
@@ -31,7 +31,8 @@
     };
   };
 
-  binary = {
-    "libresoc.v".data = pkgs.libresoc-verilog;
-  };
+  # FIX: https://github.com/NixOS/nixpkgs/issues/389149
+  # binary = {
+  #   "libresoc.v".data = pkgs.libresoc-verilog;
+  # };
 }

--- a/projects/OpenWebCalendar/default.nix
+++ b/projects/OpenWebCalendar/default.nix
@@ -13,7 +13,10 @@
       examples.basic = {
         module = ./example.nix;
         description = "";
-        tests.basic = "${sources.inputs.nixpkgs}/nixos/tests/web-apps/open-web-calendar.nix";
+        # FIX: re-enable after this is solved:
+        # https://github.com/NixOS/nixpkgs/issues/418689
+        # tests.basic = "${sources.inputs.nixpkgs}/nixos/tests/web-apps/open-web-calendar.nix";
+        tests.basic = null;
       };
       links = {
         development = {
@@ -45,7 +48,10 @@
     demo.vm = {
       module = ./example.nix;
       description = "Deployment for demo purposes";
-      tests.basic = "${sources.inputs.nixpkgs}/nixos/tests/web-apps/open-web-calendar.nix";
+      # FIX: re-enable after this is solved:
+      # https://github.com/NixOS/nixpkgs/issues/418689
+      # tests.basic = "${sources.inputs.nixpkgs}/nixos/tests/web-apps/open-web-calendar.nix";
+      tests.basic = null;
     };
   };
 }

--- a/projects/nyxt/programs/nyxt/tests/basic.nix
+++ b/projects/nyxt/programs/nyxt/tests/basic.nix
@@ -15,6 +15,9 @@
           sources.modules.programs.nyxt
           sources.examples.nyxt.basic
         ];
+
+        # not enough memory for the allocation
+        virtualisation.memorySize = 4096;
       };
   };
 


### PR DESCRIPTION
This bumps flake inputs to latest versions to get the [Nix security updates](https://nixpk.gs/pr-tracker.html?pr=419575). It has already been applied to makemake manually.