### PR TITLE
overview: use evaluated-modules.config.projects

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -35,6 +35,13 @@ let
       in
       f "";
 
+    filter-map =
+      attrs: input:
+      lib.pipe attrs [
+        (lib.concatMapAttrs (_: value: value."${input}" or { }))
+        (lib.filterAttrs (_: v: v != null))
+      ];
+
     # Recursively evaluate attributes for an attribute set.
     # Coupled with an evaluated nixos configuration, this presents an efficient
     # way for checking module types.
@@ -113,8 +120,8 @@ rec {
     inherit
       lib
       system
-      projects
       ;
+    projects = evaluated-modules.config.projects;
     self = flake;
     pkgs = pkgs // ngipkgs;
     options = optionsDoc.optionsNix;
@@ -230,12 +237,6 @@ rec {
         if lib.isDerivation test then test else pkgs.nixosTest args;
 
       empty-if-null = x: if x != null then x else { };
-      filter-map =
-        attrs: input:
-        lib.pipe attrs [
-          (lib.concatMapAttrs (_: value: value."${input}" or { }))
-          (lib.filterAttrs (_: v: v != null))
-        ];
 
       hydrate =
         # we use fields to track state of completion.

--- a/default.nix
+++ b/default.nix
@@ -252,10 +252,11 @@ rec {
             lib.mapAttrs (name: value: value.module or null) project.nixos.modules.programs or { }
           );
           # TODO: access examples for services and programs separately?
-          nixos.examples =
+          nixos.examples = lib.filterAttrs (name: example: example.module != null) (
             (empty-if-null (project.nixos.examples or { }))
             // (filter-map (project.nixos.modules.programs or { }) "examples")
-            // (filter-map (project.nixos.modules.services or { }) "examples");
+            // (filter-map (project.nixos.modules.services or { }) "examples")
+          );
           nixos.tests = mapAttrs (
             _: test:
             if lib.isString test then

--- a/projects/Aerogramme/default.nix
+++ b/projects/Aerogramme/default.nix
@@ -33,7 +33,6 @@
           # meta.broken = true;
         };
     };
-    tests = null;
-    examples = null;
+    examples.basic.module = null;
   };
 }

--- a/projects/Agorakit/default.nix
+++ b/projects/Agorakit/default.nix
@@ -14,7 +14,7 @@
   nixos = {
     modules.services.agorakit = {
       module = lib.moduleLocFromOptionString "services.agorakit";
-      examples.basic = null;
+      examples.basic.module = null;
     };
     tests.basic = import "${sources.inputs.nixpkgs}/nixos/tests/web-apps/agorakit.nix" args;
   };

--- a/projects/Forgejo/default.nix
+++ b/projects/Forgejo/default.nix
@@ -34,7 +34,7 @@
   nixos.modules.services = {
     forgejo = {
       module = lib.moduleLocFromOptionString "services.forgejo";
-      examples.basic = null;
+      examples.basic.module = null;
     };
   };
 

--- a/projects/Kaidan/default.nix
+++ b/projects/Kaidan/default.nix
@@ -40,5 +40,5 @@
       };
     };
   };
-  nixos.modules.services.kaidan = null;
+  nixos.modules.services.kaidan.module = null;
 }

--- a/projects/Mastodon/default.nix
+++ b/projects/Mastodon/default.nix
@@ -17,7 +17,7 @@
   nixos = {
     modules.services.mastodon = {
       module = lib.moduleLocFromOptionString "services.mastodon";
-      examples.basic = null;
+      examples.basic.module = null;
     };
     tests = {
       standard = "${sources.inputs.nixpkgs}/nixos/tests/web-apps/mastodon/standard.nix";

--- a/projects/Namecoin/default.nix
+++ b/projects/Namecoin/default.nix
@@ -8,9 +8,9 @@
   nixos = {
     modules.services.namecoind.module = lib.moduleLocFromOptionString "services.namecoind";
     modules.services.ncdns.module = lib.moduleLocFromOptionString "services.ncdns";
-    modules.programs.electrum-nmc = null;
+    modules.programs.electrum-nmc.module = null;
     # the namecoind service module does not add namecoin commands to the environment
-    modules.programs.namecoin = null;
+    modules.programs.namecoin.module = null;
 
     examples.tor-browser-temporary = {
       description = ''

--- a/projects/Seppo/default.nix
+++ b/projects/Seppo/default.nix
@@ -23,6 +23,6 @@
     };
   };
 
-  nixos.modules.programs.seppo = null;
-  nixos.modules.services.seppo = null;
+  nixos.modules.programs.seppo.module = null;
+  nixos.modules.services.seppo.module = null;
 }

--- a/projects/Wireguard/default.nix
+++ b/projects/Wireguard/default.nix
@@ -33,7 +33,7 @@
   nixos.modules.services = {
     wireguard = {
       module = lib.moduleLocFromOptionString "networking.wireguard";
-      examples.basic = null;
+      examples.basic.module = null;
     };
   };
 

--- a/projects/mCaptcha/default.nix
+++ b/projects/mCaptcha/default.nix
@@ -27,7 +27,7 @@
     mcaptcha = {
       name = "mcaptcha";
       module = ./services/mcaptcha/module.nix;
-      examples.basic = null;
+      examples.basic.module = null;
       links = {
         setup = {
           text = "Development setup";

--- a/projects/ntpd-rs/default.nix
+++ b/projects/ntpd-rs/default.nix
@@ -27,7 +27,7 @@
     ntpd-rs = {
       name = "ntpd-rs";
       module = lib.moduleLocFromOptionString "services.ntpd-rs";
-      examples.basic = null;
+      examples.basic.module = null;
       # See https://github.com/NixOS/nixpkgs/blob/nixos-unstable/nixos/tests/ntpd-rs.nix for examples
     };
   };

--- a/projects/types.nix
+++ b/projects/types.nix
@@ -177,7 +177,7 @@ let
         options = {
           module = mkOption {
             description = "the example must be a NixOS module in a file";
-            type = deferredModule;
+            type = nullOr path;
           };
           description = mkOption {
             description = "description of the example, ideally with further instructions on how to use it";

--- a/projects/types.nix
+++ b/projects/types.nix
@@ -107,7 +107,7 @@ let
               type = nullOr deferredModule;
             };
             examples = mkOption {
-              type = attrsOf (nullOr types'.example);
+              type = attrsOf types'.example;
               default = { };
             };
             extensions = mkOption {
@@ -137,8 +137,8 @@ let
               type = nullOr deferredModule;
             };
             examples = mkOption {
-              type = nullOr (attrsOf (nullOr types'.example));
-              default = null;
+              type = attrsOf types'.example;
+              default = { };
             };
             extensions = mkOption {
               type = nullOr (attrsOf (nullOr types'.plugin));
@@ -159,18 +159,6 @@ let
     # TODO: implement this, now that we're using the module system
     plugin = with types; anything;
 
-    nonEmtpyAttrs =
-      elemType:
-      with types;
-      (
-        (attrsOf elemType)
-        // {
-          name = "nonEmtpyAttrs";
-          description = "non-empty attribute set";
-          check = x: lib.isAttrs x && x != { };
-        }
-      );
-
     example =
       with types;
       submodule {
@@ -186,7 +174,8 @@ let
           };
           tests = mkOption {
             description = "at least one test for the example";
-            type = types'.nonEmtpyAttrs (nullOr types'.test);
+            type = attrsOf (nullOr types'.test);
+            default = { };
           };
           links = mkOption {
             description = "links to related resources";
@@ -253,13 +242,15 @@ let
                     with types;
                     submodule {
                       options = {
-                        modules.programs = mkOption {
-                          type = nullOr (attrsOf (nullOr types'.program));
-                          default = null;
-                        };
-                        modules.services = mkOption {
-                          type = nullOr (attrsOf (nullOr types'.service));
-                          default = null;
+                        modules = {
+                          programs = mkOption {
+                            type = attrsOf types'.program;
+                            default = { };
+                          };
+                          services = mkOption {
+                            type = attrsOf types'.service;
+                            default = { };
+                          };
                         };
                         demo = mkOption {
                           type = nullOr (attrTag {
@@ -274,16 +265,16 @@ let
                         # If this tends to be too cumbersome for package authors and we find a way obtain coverage information programmatically,
                         # we can still reduce granularity and move all examples to the application level.
                         examples = mkOption {
-                          type = nullOr (attrsOf types'.example);
-                          default = null;
+                          type = attrsOf types'.example;
+                          default = { };
                         };
                         # TODO: Tests should really only be per example, in order to clarify that we care about tested examples more than merely tests.
                         #       But reality is such that most NixOS tests aren't based on self-contained, minimal examples, or if they are they can't be extracted easily.
                         #       Without this field, many applications will appear entirely untested although there's actually *some* assurance that *something* works.
                         #       Eventually we want to move to documentable tests exclusively, and then remove this field, but this may take a very long time.
                         tests = mkOption {
-                          type = nullOr (attrsOf types'.test);
-                          default = null;
+                          type = attrsOf (nullOr types'.test);
+                          default = { };
                         };
                       };
                     };

--- a/projects/xrsh/default.nix
+++ b/projects/xrsh/default.nix
@@ -29,7 +29,7 @@
     };
   };
 
-  nixos.modules.services.xrsh = null;
+  nixos.modules.services.xrsh.module = null;
 
   nixos.demo.shell = {
     module = ./programs/xrsh/examples/basic.nix;


### PR DESCRIPTION
The overview previously used `projects` from default.nix that had been processed through `make-projects`. This changed the projects structure in unexpected ways and removed necessary information for changes such as showing missing deliverables.

This PR switches to using `evaluated-modules`. To make this easier, the usage of null in the module system was made stricter. Now, to mark something as not implemented but needed, `.module` should be set to null.

There are a couple other improvements in this PR. Most notably that options for separate programs/services now render in separate blocks. This fixes the bug where until expanded, there appeared to only be options for the first program/service. It also at least partially addresses #1006.