### PR TITLE
heads: Fix build (for now)

### DIFF
--- a/pkgs/by-name/heads/deps.nix
+++ b/pkgs/by-name/heads/deps.nix
@@ -666,11 +666,13 @@
         url = "https://ftp.gnu.org/gnu/binutils/binutils-2.37.tar.xz";
         hash = "sha256-gg2XJPAgo+acszeJOgtjwtsWHa3LDgb8Edwp6x6Eoyw=";
       }
-      {
-        name = "coreboot-crossgcc-acpica-unix2-20220331.tar.gz";
-        url = "https://acpica.org/sites/acpica/files/acpica-unix2-20220331.tar.gz";
-        hash = "sha256-CG1rZYX1Zndob+2K9rC1upOuwYC0HSKFobdM0CtY8ko=";
-      }
+      # URL seems long-term broken, needs #1256 to get fixed
+      # Short-term, commenting this package out makes boards that don't need this particular coreboot version build again
+      #{
+      #  name = "coreboot-crossgcc-acpica-unix2-20220331.tar.gz";
+      #  url = "https://acpica.org/sites/acpica/files/acpica-unix2-20220331.tar.gz";
+      #  hash = "sha256-CG1rZYX1Zndob+2K9rC1upOuwYC0HSKFobdM0CtY8ko=";
+      #}
       {
         name = "coreboot-crossgcc-llvm-14.0.6.src.tar.xz";
         url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/llvm-14.0.6.src.tar.xz";

--- a/pkgs/by-name/heads/package.nix
+++ b/pkgs/by-name/heads/package.nix
@@ -432,10 +432,7 @@ lib.makeScope newScope (
     # only allow a fixed list of boards and slowly increase it
     # (see: https://github.com/NixOS/nixpkgs/pull/286228#issuecomment-2779598354)
     allowedBoards = [
-      # FIX: it seems this file is no longer accessible:
-      # https://acpica.org/sites/acpica/files/acpica-unix2-20220331.tar.gz
-      # https://buildbot.ngi.nixos.org/#/builders/558/builds/881
-      # "qemu-coreboot-fbwhiptail-tpm1-hotp"
+      "qemu-coreboot-fbwhiptail-tpm1-hotp"
     ];
   in
   {

--- a/projects/Heads/default.nix
+++ b/projects/Heads/default.nix
@@ -25,11 +25,7 @@
           Builds heads for the example qemu-coreboot-fbwhiptail-tpm1-hotp board, and makes the ROM image available
           at a fixed location, for testing it in a VM.
         '';
-        # FIX: it seems this file is no longer accessible:
-        # https://acpica.org/sites/acpica/files/acpica-unix2-20220331.tar.gz
-        # https://buildbot.ngi.nixos.org/#/builders/558/builds/881
-        # tests.basic = import ./test.nix args;
-        tests.basic = null;
+        tests.basic = import ./test.nix args;
       };
       links = {
         setup = {
@@ -47,9 +43,6 @@
       };
     };
   };
-  # TODO: Referencing `pkgs` here is currently causing eval issues all over ngipkgs.
-  # https://github.com/ngi-nix/ngipkgs/pull/773
-  # Resolve this first before enabling this.
   binary = lib.attrsets.mapAttrs' (
     board: pkg: lib.attrsets.nameValuePair "${board}.rom" { data = "${pkg}/${pkg.passthru.romName}"; }
   ) (lib.attrsets.filterAttrs (_: lib.attrsets.isDerivation) pkgs.heads);


### PR DESCRIPTION
Long term this needs #1256, but this should work until the next time we try to bump Heads.