### PR TITLE
demo/vm: make getty auto user optional

### DIFF
--- a/overview/demo/vm/users.nix
+++ b/overview/demo/vm/users.nix
@@ -1,4 +1,8 @@
 {
+  lib,
+  ...
+}:
+{
   users.users.nixos = {
     isNormalUser = true;
     extraGroups = [ "wheel" ];
@@ -6,5 +10,5 @@
   };
 
   security.sudo.wheelNeedsPassword = false;
-  services.getty.autologinUser = "nixos";
+  services.getty.autologinUser = lib.mkDefault "nixos";
 }


### PR DESCRIPTION
Some vm tests need a priveledged user to work correctly. i.e holo