### PR TITLE
overview: add button to link examples' docs

### DIFF
--- a/overview/default.nix
+++ b/overview/default.nix
@@ -193,7 +193,7 @@ let
       many = examples: ''
         ${heading 2 "examples" "Examples"}
         ${concatLines (map one examples)}
-        <button class="button example"><a class = "heading" href="https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md">Add example</a></button>
+        <button class="button example"><a class = "heading" href="https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#how-to-add-an-example">Add an example</a></button>
       '';
     };
 

--- a/overview/default.nix
+++ b/overview/default.nix
@@ -190,12 +190,11 @@ let
 
         </details>
       '';
-      many =
-        examples:
-        optionalString (!empty examples) ''
-          ${heading 2 "examples" "Examples"}
-          ${concatLines (map one examples)}
-        '';
+      many = examples: ''
+        ${heading 2 "examples" "Examples"}
+        ${concatLines (map one examples)}
+        <button class="button example"><a class = "heading" href="https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md">Add example</a></button>
+      '';
     };
 
     subgrants = rec {

--- a/overview/style.css
+++ b/overview/style.css
@@ -336,6 +336,16 @@ div.code > pre /* for pygments output */
   background-color: darkgreen;
 }
 
+.button.example {
+  margin-bottom: 15px;
+  border-radius: 5px;
+  padding: 5px
+}
+
+.button.example:hover {
+  background-color: darkgreen;
+}
+
 details > summary > h2, details > summary > h3 {
     display: inline;
 }


### PR DESCRIPTION
Closes #1200

Adds a button to link instructions on how to add examples.
Nit: Currently, it does not link to the specific section but rather the entire doc. Will be updated once the doc from #1199 is merged.

![image](https://github.com/user-attachments/assets/5fd4795d-9687-4cee-a3fb-0b3797943b5e)
![image](https://github.com/user-attachments/assets/5654a7bc-4852-4092-b94a-ff239a8d6c55)
