### PR TITLE
Overview: modularize examples

### DIFF
--- a/overview/content-types/example-list.nix
+++ b/overview/content-types/example-list.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  name,
+  config,
+  ...
+}:
+let
+  inherit (lib) types mkOption;
+in
+{
+  options = {
+    examples = mkOption { type = with types; listOf (submodule ./example.nix); };
+    __toString = mkOption {
+      type = with types; functionTo str;
+      default =
+        self:
+        let
+          heading = ''
+            <a class="heading" href="#examples">
+              <h2 id="examples">
+                Examples
+                <span class="anchor"/>
+              </h2>
+            </a>
+          '';
+          button-add-example = ''
+            <button class="button example">
+            <a class = "heading" href="https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#how-to-add-an-example" target ="_blank">Add an example</a>
+            </button>
+          '';
+        in
+        ''
+          ${heading}
+          ${lib.concatLines (map toString self.examples)}
+          ${button-add-example}
+        '';
+    };
+  };
+}

--- a/overview/content-types/example.nix
+++ b/overview/content-types/example.nix
@@ -1,0 +1,40 @@
+{ lib, config, ... }:
+let
+  inherit (lib)
+    mkOption
+    types
+    optionalString
+    any
+    attrValues
+    ;
+
+  types' = import ../../projects/types.nix { inherit lib; };
+in
+{
+  options = {
+    inherit (types'.example.getSubOptions { }) description module tests;
+    example-snippet = mkOption {
+      type = types.submodule ./code-snippet.nix;
+      default.filepath = config.module;
+    };
+    __toString = mkOption {
+      type = with types; functionTo str;
+      readOnly = true;
+      default =
+        self:
+        let
+          button-missing-test = optionalString (any (test: test.module == null) (attrValues config.tests)) ''
+            <button class="button missing">
+            <a class = "heading" href="https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md" target = "_blank">Add missing test</a>
+            </button>
+          '';
+        in
+        ''
+          <details><summary>${self.description}</summary>
+          ${self.example-snippet}
+          ${button-missing-test}
+          </details>
+        '';
+    };
+  };
+}

--- a/overview/default.nix
+++ b/overview/default.nix
@@ -97,24 +97,6 @@ let
         }) projectOptions;
       };
 
-    examples = rec {
-      one = example: ''
-        <details><summary>${example.description}</summary>
-
-        ${eval {
-          imports = [ ./content-types/code-snippet.nix ];
-          filepath = example.module;
-        }}
-
-        </details>
-      '';
-      many = examples: ''
-        ${heading 2 "examples" "Examples"}
-        ${concatLines (map one examples)}
-        <button class="button example"><a class = "heading" href="https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md#how-to-add-an-example">Add an example</a></button>
-      '';
-    };
-
     subgrants = rec {
       one = subgrant: ''
         <li>
@@ -151,6 +133,11 @@ let
     projects.one =
       name: project:
       let
+        examples = eval {
+          imports = [ ./content-types/example-list.nix ];
+          examples = map (value: { inherit (value) description module tests; }) (pick.examples project);
+        };
+
         optionsRender =
           lib.concatMapStringsSep "\n"
             (
@@ -186,7 +173,7 @@ let
           )}
           ${optionalString (lib.trim optionsRender != "") "${heading 2 "service" "Options"}"}
           ${optionsRender}
-          ${render.examples.many (pick.examples project)}
+          ${examples}
         </article>
       '';
 

--- a/overview/style.css
+++ b/overview/style.css
@@ -339,11 +339,15 @@ div.code > pre /* for pygments output */
 .button.example {
   margin-bottom: 15px;
   border-radius: 5px;
+  background-color: darkgreen;
   padding: 5px
 }
 
-.button.example:hover {
-  background-color: darkgreen;
+.button.missing {
+  background-color: red;
+  margin-bottom: 15px;
+  border-radius: 5px;
+  padding: 5px
 }
 
 details > summary > h2, details > summary > h3 {


### PR DESCRIPTION
closes #1193
paired with @eljamm 

Shows a button to add tests for examples without:

![image](https://github.com/user-attachments/assets/8afe9118-2816-4baa-b71b-a707b6a3b87c)
