### PR TITLE
Inventaire: open firewall; print ready message in demo 

### DIFF
--- a/overview/demo/default.nix
+++ b/overview/demo/default.nix
@@ -16,6 +16,14 @@ let
         (sources.nixpkgs + "/nixos/modules/virtualisation/qemu-vm.nix")
         ./shell.nix
         ./vm
+        {
+          options.demo = lib.mkOption {
+            type = lib.types.bool;
+            description = "Whether the configuration should run as a demo.";
+            default = false;
+          };
+          config.demo = true;
+        }
       ] ++ extendedNixosModules;
       specialArgs = { inherit sources; };
     };

--- a/projects/Inventaire/examples/basic.nix
+++ b/projects/Inventaire/examples/basic.nix
@@ -12,6 +12,7 @@ let
   couchdbPassword = "ThisIsNotSecurelyManagedAndImFullyAwareOfThis";
   couchdbPort = 5984;
   elasticPort = 9200;
+  inventairePort = 3006;
 
   inventaireServiceDeps = [
     "couchdb.service"
@@ -100,10 +101,11 @@ in
   services.inventaire = {
     enable = true;
     inProductionMode = false; # production mode expects to be running behind nginx, breaks some asset serving
+    openFirewall = true;
 
     settings = {
       hostname = "0.0.0.0";
-      port = 3006;
+      port = inventairePort;
 
       # CouchDB
       db = {

--- a/projects/Inventaire/module.nix
+++ b/projects/Inventaire/module.nix
@@ -173,5 +173,11 @@ in
         );
       };
     };
+
+    programs.bash.interactiveShellInit = lib.mkIf (config ? demo && config.demo) ''
+      echo "Inventaire is starting. Please wait ..."
+      until systemctl show inventaire.service | grep -q ActiveState=active; do sleep 1; done
+      echo "Inventaire is ready at http://localhost:${toString cfg.settings.port}"
+    '';
   };
 }


### PR DESCRIPTION
## Changes

- Inventaire
  - open port in firewall so the demo service becomes accessible on host machines
  - print ready message when service starts, courtesy of @Prince213 (see https://github.com/ngi-nix/ngipkgs/pull/1295)
- Demo
  - add option to separate demo code from production

![inventaire](https://github.com/user-attachments/assets/21e91f26-9df4-418c-ae67-c9ea32665962)
