### PR TITLE
makemake: Limit max-jobs and cores per nix build

### DIFF
--- a/infra/makemake/configuration.nix
+++ b/infra/makemake/configuration.nix
@@ -42,9 +42,9 @@
           GiB = 1024 * 1024 * 1024;
         in
         4 * GiB;
-      max-jobs = lib.mkDefault 16;
+      max-jobs = lib.mkDefault 4;
       allowed-uris = "https://github.com/ https://git.savannah.gnu.org/ github: gitlab: git+https:";
-      cores = 0;
+      cores = 4;
       experimental-features = [
         "nix-command"
         "flakes"


### PR DESCRIPTION
Related to ngi-nix/ngipkgs#782.

Makemake has 16 logical cores, so 4 jobs times 4 cores will max it out. I tested this with ngi-nix/ngipkgs#1292, the [build took ~7 hours](https://buildbot.ngi.nixos.org/#/builders/5/builds/2629) and ultimately failed, but the host was responsive throughout the build. [Grafana dashboard with timestamp](https://grafana.nixos.org/d/rYdddlPWk/node-exporter-full?orgId=1&from=2025-07-02T21:43:16.804Z&to=2025-07-03T05:30:11.949Z&timezone=browser&var-datasource=default&var-job=node&var-node=makemake.ngi.nixos.org:9100&var-diskdevices=%5Ba-z%5D%2B%7Cnvme%5B0-9%5D%2Bn%5B0-9%5D%2B%7Cmmcblk%5B0-9%5D%2B) while makemake was trying to build heads.