### PR TITLE
vula: fix build

### DIFF
--- a/pkgs/by-name/vula/package.nix
+++ b/pkgs/by-name/vula/package.nix
@@ -17,6 +17,7 @@ in
 python3.pkgs.buildPythonApplication {
   pname = "vula";
   version = "0.2-unstable-2024-05-17";
+  format = "setuptools";
 
   src = fetchgit {
     url = "https://codeberg.org/vula/vula";


### PR DESCRIPTION
Upstream nixpkgs recently caused python applications using implicityly defined `format = "..."` to fail building. This explicitly sets the format, fixing the build. I noticed this failure while testing Owi and had updated my nixpkgs to the master branch. This is a prophylactic fix to avoid a failing `nix flake update` on Monday.

Link: https://github.com/NixOS/nixpkgs/pull/421660