### PR TITLE
overview: indicate problems on deliverable tags

### DIFF
--- a/overview/content-types/project-list-item.nix
+++ b/overview/content-types/project-list-item.nix
@@ -19,25 +19,25 @@ in
     deliverables = mkOption {
       type =
         with types;
-        # XXX(@fricklerhandwerk): this is very simple-minded. we'll need to think
-        # about how to deal with cases where there are multiple services etc.
-        submodule {
+        listOf (submodule {
           options = {
-            service = mkOption {
-              type = types.bool;
-              default = false;
+            name = mkOption {
+              type = str;
             };
-            program = mkOption {
-              type = types.bool;
-              default = false;
+            type = mkOption {
+              type = enum [
+                "program"
+                "service"
+                "demo"
+              ];
             };
-            demo = mkOption {
-              type = types.bool;
-              default = false;
+            hasProblem = mkOption {
+              type = nullOr bool;
+              default = null;
             };
           };
-        };
-      default = { };
+        });
+      default = [ ];
     };
     __toString = mkOption {
       type = with types; functionTo str;
@@ -50,10 +50,15 @@ in
                 <a href="/project/${self.name}">${self.name}</a>
               </h2>
               ${concatStringsSep "\n" (
-                mapAttrsToList (
-                  deliverable: exists:
-                  optionalString exists ''<a class="deliverable-tag" href="/project/${self.name}#${deliverable}">${deliverable}</a>''
-                ) self.deliverables
+                map (deliverable: ''
+                  <a
+                    class="deliverable-tag ${optionalString (deliverable.hasProblem) "deliverable-has-problem"}"
+                    title="${deliverable.name} ${deliverable.type}${optionalString (deliverable.hasProblem) " has a problem"}"
+                    href="/project/${self.name}#${deliverable.type}"
+                  >
+                    ${deliverable.type}
+                  </a>
+                '') self.deliverables
               )}
             </div>
             ${optionalString (!isNull self.description) ''

--- a/overview/style.css
+++ b/overview/style.css
@@ -412,6 +412,10 @@ article.project .deliverable-tag {
   font-weight: 500;
 }
 
+article.project .deliverable-tag.deliverable-has-problem {
+  background-color: lightpink;
+}
+
 .option-name {
   font-weight: 600;
   font-family: "IBM Plex Mono";


### PR DESCRIPTION
Indicate deliverables that are missing or have a problem on the projects list page. Also, handle multiple of each type of deliverable and add tooltips.

Fixes #1031.

![image](https://github.com/user-attachments/assets/7dc55055-251a-4f60-98c8-a6bb1b3b3181)
