### PR TITLE
overview: fix update script status for scopes

### DIFF
--- a/overview/content-types/option.nix
+++ b/overview/content-types/option.nix
@@ -84,11 +84,15 @@ in
           alert-update-script =
             let
               isDrv = self.type == "package";
-              optionName = lib.removePrefix "pkgs." self.default.text;
+              attrPath = lib.splitString "." self.default.text ++ [
+                "passthru"
+                "updateScript"
+              ];
+              updateScript = lib.attrByPath attrPath null pkgs;
             in
             # TODO: plug a function that recurses into all dependencies,
             # so we'd know how much of the build graph is kept up to date automatically
-            optionalString (isDrv && !pkgs ? ${optionName}.passthru.updateScript) ''
+            optionalString (isDrv && updateScript == null) ''
               <dt>Notes:</dt>
               <dd><span class="option-alert">Missing update script</span> An update script is required for automatically tracking the latest release.</dd>
             '';


### PR DESCRIPTION
Selecting nested attributes doesn't work with strings (for example: `pkgs."python3Packages.dmt-core"`), which results in update scripts wrongly marked as missing (see #1326).

This change corrects that by checking the derivation's attribute path using `lib.attrByPath`.

Closes #1326

![image](https://github.com/user-attachments/assets/0b7ff1e7-2a53-4320-bfa0-51d954cd6002)