### PR TITLE
heads: Make Linux build more verbose

### DIFF
--- a/pkgs/by-name/heads/package.nix
+++ b/pkgs/by-name/heads/package.nix
@@ -227,6 +227,10 @@ let
         # Look them up in named subdirs, so archives don't conflict
         substituteInPlace modules/coreboot \
           --replace-fail '"$(COREBOOT_TOOLCHAIN_DIR)" "$(1)" "$(packages)"' '"$(COREBOOT_TOOLCHAIN_DIR)" "$(1)" "$(packages)"/"$(coreboot_module)"'
+
+        # Make Linux build more verbose, so builds on slower hardware don't time out due to lack of output
+        substituteInPlace modules/linux \
+          --replace-fail 'ARCH=' 'V=1 ARCH='
       '';
 
       preConfigure =


### PR DESCRIPTION
From

```
1970-01-01 00:00:00+00:00 MAKE linux
1970-01-01 00:00:00+00:00 DONE linux
```

… to

```
1970-01-01 00:00:00+00:00 MAKE linux
[...]
make -f ../scripts/Makefile.build obj=init \
need-builtin=1 \
need-modorder=1 \

make -f ../scripts/Makefile.build obj=usr \
need-builtin=1 \
need-modorder=1 \

make -f ../scripts/Makefile.build obj=arch/x86 \
need-builtin=1 \
need-modorder=1 \

make -f ../scripts/Makefile.build obj=kernel \
need-builtin=1 \
need-modorder=1 \

make -f ../scripts/Makefile.build obj=certs \
need-builtin=1 \
need-modorder=1 \
[...]
1970-01-01 00:00:00+00:00 DONE linux
```