### PR TITLE
overview: fix demo description access

### DIFF
--- a/overview/default.nix
+++ b/overview/default.nix
@@ -199,10 +199,11 @@ let
         demo = {
           inherit type;
           inherit (demo)
-            tests
             module
+            tests
+            problem
+            description
             ;
-          problem = demo.problem or null;
           _module.args.pkgs = pkgs;
         };
       };


### PR DESCRIPTION
The descriptions aren't shown in the overview yet, but the not implemented warning now works correctly.