### PR TITLE
inventaire*: Apply patches to offer OpenStreetMap as tile provider

### DIFF
--- a/pkgs/by-name/inventaire-client/1001-Support-multiple-map-tile-providers.patch
+++ b/pkgs/by-name/inventaire-client/1001-Support-multiple-map-tile-providers.patch
@@ -1,0 +1,63 @@
+From 2774c9c3d7283d3167b4a4878ebb3fd404dd2f34 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Tue, 15 Jul 2025 15:27:34 +0200
+Subject: [PATCH] Support multiple map tile providers
+
+---
+ app/modules/map/lib/config.ts | 30 +++++++++++++++++++++++-------
+ 1 file changed, 23 insertions(+), 7 deletions(-)
+
+diff --git a/app/modules/map/lib/config.ts b/app/modules/map/lib/config.ts
+index 3a5699a7c..2b5a6ab52 100644
+--- a/app/modules/map/lib/config.ts
++++ b/app/modules/map/lib/config.ts
+@@ -4,6 +4,26 @@ import type { LatLngTuple } from 'leaflet'
+ // Add some margin to maxBounds to prevent bouncing when displaying a map overlapping the antimeridian
+ const antimeridianMargin = 50
+ 
++// Provider details
++const providerMap = {
++  // MapBox
++  'mapbox': {
++    // Different styles are available https://docs.mapbox.com/api/maps/#styles
++    url: 'https://api.mapbox.com/styles/v1/mapbox/streets-v8/tiles/{z}/{x}/{y}?access_token={accessToken}',
++    attribution: `Map data &copy; <a href='http://openstreetmap.org'>OpenStreetMap</a> contributors,
++<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>,
++Imagery © <a href="http://mapbox.com">Mapbox</a>`,
++  },
++
++  // OpenStreetMap
++  'openstreetmap': {
++    url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
++    attribution: `Map data &copy; <a href='http://openstreetmap.org'>OpenStreetMap</a> contributors,
++<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>`,
++  },
++}
++
++
+ export default {
+   // Init once Leaflet was fetched
+   init () {
+@@ -21,16 +41,12 @@ export default {
+       [ 90, 180 + antimeridianMargin ] as LatLngTuple,
+     ],
+   },
+-  tileUrl: 'https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}',
++  tileUrl: providerMap[config.mapTiles.provider].url,
+   tileLayerOptions: {
+-    attribution: `Map data &copy; <a href='http://openstreetmap.org'>OpenStreetMap</a> contributors,
+-<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>,
+-Imagery © <a href="http://mapbox.com">Mapbox</a>`,
++    attribution: providerMap[config.mapTiles.provider].attribution,
+     minZoom: 2,
+     maxZoom: 18,
+-    // Different styles are available https://docs.mapbox.com/api/maps/#styles
+-    id: 'mapbox/streets-v8',
+-    accessToken: config.mapTilesAccessToken,
++    accessToken: config.mapTiles.accessToken,
+     // Increase the font size, see https://gis.stackexchange.com/a/346383
+     tileSize: 512,
+     zoomOffset: -1,
+-- 
+2.49.0
+

--- a/pkgs/by-name/inventaire-client/package.nix
+++ b/pkgs/by-name/inventaire-client/package.nix
@@ -62,6 +62,10 @@ buildNpmPackage rec {
   };
 
   patches = [
+    # Allow user to use a map tile provider that doesn't require an access token
+    # Remove when https://codeberg.org/inventaire/inventaire-client/pulls/554 merged & in release
+    ./1001-Support-multiple-map-tile-providers.patch
+
     (replaceVars ./9901-Use-saved-query-results.patch {
       sparqlQueries = sparql-queries;
     })
@@ -105,9 +109,7 @@ buildNpmPackage rec {
       --replace-fail './scripts/build_i18n' '${lib.getExe copyI18nDataScript}' \
       --replace-fail 'webpack --config ./bundle/webpack.config.prod.cjs --progress' 'webpack --config ./bundle/webpack.config.prod.cjs' \
       --replace-fail 'date -Ins' 'date -d "@$SOURCE_DATE_EPOCH" -Ins' \
-      --replace-fail '$(git rev-parse --short HEAD)' '"${
-        if src.tag != null then src.tag else src.rev
-      }"' \
+      --replace-fail '$(git rev-parse --short HEAD)' '"${if src.tag != null then src.tag else src.rev}"'
   '';
 
   # "Your cache folder contains root-owned files" error from NPM

--- a/pkgs/by-name/inventaire-unwrapped/1001-Add-config-option-to-pick-tile-provider-for-map.patch
+++ b/pkgs/by-name/inventaire-unwrapped/1001-Add-config-option-to-pick-tile-provider-for-map.patch
@@ -1,0 +1,90 @@
+From 3f5c35ee181245a5b75ce985ef4907476f0d5381 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Tue, 15 Jul 2025 15:13:06 +0200
+Subject: [PATCH] Add config option to pick tile provider for map
+
+---
+ config/default.cjs              | 10 +++++++---
+ docs/configuration/map_tiles.md |  5 ++++-
+ server/controllers/config.ts    |  4 ++--
+ server/types/config.ts          |  5 ++++-
+ 4 files changed, 17 insertions(+), 7 deletions(-)
+
+diff --git a/config/default.cjs b/config/default.cjs
+index 0c3508ca6..f2eb96504 100644
+--- a/config/default.cjs
++++ b/config/default.cjs
+@@ -257,9 +257,13 @@ const config = {
+     rec: 1,
+   },
+ 
+-  // Required to use MapBox tiles within leaflet maps
+-  // See https://console.mapbox.com/account/access-tokens/
+-  mapTilesAccessToken: 'youraccesstoken',
++  // Tile provider settings for the map
++  mapTiles: {
++    provider: 'mapbox',
++    // Required to use MapBox tiles within leaflet maps
++    // See https://console.mapbox.com/account/access-tokens/
++    accessToken: 'youraccesstoken',
++  },
+ 
+   // ~~~~~~~
+   // Media storage
+diff --git a/docs/configuration/map_tiles.md b/docs/configuration/map_tiles.md
+index 298c4ef79..a6d472514 100644
+--- a/docs/configuration/map_tiles.md
++++ b/docs/configuration/map_tiles.md
+@@ -19,7 +19,10 @@ Add your Mapbox public access token in your local configuration file (`config/lo
+ ```js
+ module.exports = {
+   ...
+-  mapTilesAccessToken: "yourToken"
++  mapTiles: {
++    provider: "mapbox",
++    accessToken: "yourToken",
++  },
+   ...
+ }
+ ```
+diff --git a/server/controllers/config.ts b/server/controllers/config.ts
+index f477ee152..4d290c871 100644
+--- a/server/controllers/config.ts
++++ b/server/controllers/config.ts
+@@ -2,7 +2,7 @@ import { gitHeadRev, softwareName, version } from '#lib/package'
+ import { sendStaticJson } from '#lib/responses'
+ import config, { publicHost } from '#server/config'
+ 
+-const { env, instanceName, orgName, orgUrl, mapTilesAccessToken, defaultLandingPageMapPosition } = config
++const { env, instanceName, orgName, orgUrl, mapTiles, defaultLandingPageMapPosition } = config
+ const { remoteEntitiesOrigin } = config.federation
+ 
+ const clientConfig = {
+@@ -14,7 +14,7 @@ const clientConfig = {
+   orgName,
+   orgUrl,
+   remoteEntitiesOrigin,
+-  mapTilesAccessToken,
++  mapTiles,
+   publicHost,
+   defaultLandingPageMapPosition,
+ } as const
+diff --git a/server/types/config.ts b/server/types/config.ts
+index 1b5c4d139..81226a099 100644
+--- a/server/types/config.ts
++++ b/server/types/config.ts
+@@ -245,7 +245,10 @@ export type Config = ReadonlyDeep<{
+     suspectKeywords: string[]
+   }
+ 
+-  mapTilesAccessToken: string
++  mapTiles: {
++    provider: 'mapbox' | 'openstreetmap'
++    accessToken: string
++  }
+ 
+   tasks: {
+     minimumScoreToAutogenerate: number
+-- 
+2.49.0
+

--- a/pkgs/by-name/inventaire-unwrapped/package.nix
+++ b/pkgs/by-name/inventaire-unwrapped/package.nix
@@ -27,6 +27,12 @@ buildNpmPackage rec {
     hash = "sha256-y3zX6tfjIX81Fvp01yllIU0C7VudyS3l5l2h4UzRbtQ=";
   };
 
+  patches = [
+    # Allow user to use a map tile provider that doesn't require an access token
+    # Remove when https://codeberg.org/inventaire/inventaire/pulls/862 merged & in release
+    ./1001-Add-config-option-to-pick-tile-provider-for-map.patch
+  ];
+
   postPatch = ''
     cp -v ${npmDeps.src}/package{,-lock}.json ./
 

--- a/projects/Inventaire/examples/basic.nix
+++ b/projects/Inventaire/examples/basic.nix
@@ -123,6 +123,11 @@ in
         origin = "http://localhost:${toString elasticPort}";
       };
 
+      # OpenStreetMap, so no access token is necessary
+      mapTiles = {
+        provider = "openstreetmap";
+      };
+
       # Storage of downloaded files
       mediaStorage = {
         local = {


### PR DESCRIPTION
…and use it in the example/demo.

<img width="958" height="948" alt="image" src="https://github.com/user-attachments/assets/7dfc7ea9-640c-4f1e-b32d-334359c66650" />

https://codeberg.org/inventaire/inventaire/pulls/862
https://codeberg.org/inventaire/inventaire-client/pulls/554