### PR TITLE
overview: fix download button

### DIFF
--- a/overview/content-types/code-snippet.nix
+++ b/overview/content-types/code-snippet.nix
@@ -36,7 +36,7 @@ in
             {{ include_code("${self.language}", "${self.filepath}" ${optionalString self.relative ", relative_path=True"}) }}
             <div class="code-buttons">
               ${optionalString self.downloadable ''
-                <a class="button download" href="${self.filepath}" download>Download</a>
+                <a class="button download" href="default.nix" download>Download</a>
               ''}
               <template scripted>
                 <button class="button copy" onclick="copyToClipboard(this, '${self.filepath}')">

--- a/overview/content-types/demo.nix
+++ b/overview/content-types/demo.nix
@@ -27,6 +27,7 @@ in
   };
 
   # TODO: highlight strings instead of files?
+  config.downloadable = true;
   config.filepath = pkgs.writeText "default.nix" config.snippet-text;
   config.snippet-text = ''
     # default.nix


### PR DESCRIPTION
Which broke during the modularization of the demo.

Fixed with @erictapen during the office hours.