### PR TITLE
makemake: Set Nix max-silent-time to one hour

### DIFF
--- a/infra/makemake/configuration.nix
+++ b/infra/makemake/configuration.nix
@@ -53,6 +53,7 @@
       sandbox = true;
       trusted-users = [ "remotebuild" ];
     };
+    extraOptions = "max-silent-time = 3600";
   };
 
   time.timeZone = "Europe/Amsterdam";


### PR DESCRIPTION
This will hopefully allow some big project compilations to finish before being killed by Nix. This is because of servo in #1444 