### PR TITLE
merge ngipkgs attr with nixpkgs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -205,7 +205,8 @@ rec {
     name: value: pkgs.writeText "${name}-eval-check" (lib.strings.toJSON value)
   ) eval-projects;
 
-  ngipkgs = import ./pkgs/by-name { inherit pkgs lib dream2nix; };
+  ngipkgs = import ./pkgs/by-name { inherit pkgs lib dream2nix; } // pkgs;
+  ngipkgs-no-nixpkgs = import ./pkgs/by-name { inherit pkgs lib dream2nix; };
 
   raw-projects = import ./projects {
     inherit lib system;

--- a/flake.nix
+++ b/flake.nix
@@ -63,10 +63,15 @@
             inherit system;
           };
 
-          inherit (classic) pkgs ngipkgs optionsDoc;
+          inherit (classic)
+            pkgs
+            ngipkgs
+            ngipkgs-no-nixpkgs
+            optionsDoc
+            ;
         in
         rec {
-          packages = ngipkgs // {
+          packages = ngipkgs-no-nixpkgs // {
             inherit (classic) overview;
 
             options =
@@ -87,7 +92,7 @@
           checks =
             let
               # everything must evaluate for checks to run
-              nonBrokenPackages = filterAttrs (_: v: !v.meta.broken or false) ngipkgs;
+              nonBrokenPackages = filterAttrs (_: v: !v.meta.broken or false) ngipkgs-no-nixpkgs;
 
               checksForAllProjects =
                 let


### PR DESCRIPTION
This allows us to access nixpkgs from the ngipkgs attr. For example:
nix-build -A ngipkgs.neovim now works. It did not before.

Helps with https://github.com/ngi-nix/ngipkgs/issues/1401