### PR TITLE
projects/owi: migrate to upstream test

### DIFF
--- a/projects/owi/default.nix
+++ b/projects/owi/default.nix
@@ -21,7 +21,7 @@
       examples.basic = {
         module = ./programs/owi/examples/basic.nix;
         description = "Enable the owi program";
-        tests.basic.module = import ./programs/owi/tests/shell.nix args;
+        tests.basic.module = pkgs.nixosTests.owi;
       };
     };
   };
@@ -29,6 +29,6 @@
   nixos.demo.shell = {
     module = ./programs/owi/examples/basic.nix;
     description = "owi usage example";
-    tests.basic.module = import ./programs/owi/tests/shell.nix args;
+    tests.basic.module = pkgs.nixosTests.owi;
   };
 }


### PR DESCRIPTION
As of https://github.com/NixOS/nixpkgs/pull/426120, the owi tests are now upstream.

We will have to wait for it to diffuse to other channels, however.