### PR TITLE
heads: Rework board enablement, add more boards

### DIFF
--- a/pkgs/by-name/heads/patches/coreboot-talos_2/default.nix
+++ b/pkgs/by-name/heads/patches/coreboot-talos_2/default.nix
@@ -11,10 +11,15 @@
     name = "0001-coreboot-Make-build-verbose.patch";
     patch = ./0001-coreboot-Make-build-verbose.patch;
   }
-  {
-    name = "0002-coreboot-Hardcode-build-and-host-configure-flags.patch";
-    patch = replaceVars ./0002-coreboot-Hardcode-build-and-host-configure-flags.patch.in {
-      inherit buildConfig hostConfig;
-    };
-  }
+  # TODO
+  # This patch conflicts with a patch that Heads wants to apply. Haven't checked if their patch might already address
+  # what this one is doing, because the board target currently doesn't build.
+  /*
+    {
+      name = "0002-coreboot-Hardcode-build-and-host-configure-flags.patch";
+      patch = replaceVars ./0002-coreboot-Hardcode-build-and-host-configure-flags.patch.in {
+        inherit buildConfig hostConfig;
+      };
+    }
+  */
 ]


### PR DESCRIPTION
- Don't allow firmware blobs by default. Assume that when they're enabled, they taint the resulting package license.
- Explicitly comment that the allowedBoards list only includes boards for which we are sure that we can redistribute the results for.
- Allow multiple `qemu-coreboot*` boards that have managed to build fine on CI so far.
- Make a list of known-broken boards: Depend on coreboot 4.11, which wants a known-insecure expat version.