### PR TITLE
heads: Add Librem targets

### DIFF
--- a/pkgs/by-name/heads/package.nix
+++ b/pkgs/by-name/heads/package.nix
@@ -39,6 +39,8 @@
   nix,
   nixfmt-rfc-style,
   nix-prefetch-scripts,
+  nss,
+  openssl,
   perl,
   pkg-config,
   python3,
@@ -336,6 +338,8 @@ let
 
       buildInputs = [
         elfutils
+        nss
+        openssl
         zlib
       ];
 
@@ -473,6 +477,15 @@ lib.makeScope newScope (
     # install: cannot change permissions of '/build/source/install/x86/sbin/dmsetup.static': No such file or directory
     # https://github.com/ngi-nix/ngipkgs/pull/1433#issuecomment-3097099430
     allowedBoards = [
+      "librem_11"
+      "librem_13v2"
+      "librem_13v4"
+      "librem_14"
+      "librem_15v3"
+      "librem_15v4"
+      "librem_l1um_v2"
+      "librem_mini"
+      "librem_mini_v2"
       "qemu-coreboot-fbwhiptail-tmp1"
       "qemu-coreboot-fbwhiptail-tpm1-hotp"
       "qemu-coreboot-fbwhiptail-tpm1-hotp-prod"


### PR DESCRIPTION
Except `librem_l1um`, since that one still needs a Coreboot version we refuse to offer.

---

First builds for actual hardware platforms, and they don't need any externally-supplied blobs! Some of [these products](https://puri.sm/products/) even ship with Heads pre-installed apparently (11 & Mini mention it in their marketing blurbs).

<sup><sub>(#NotAnAd)</sub></sup>

I don't own any of these products, so the resulting ROMs are all untested. I successfully built two of them on my end (`librem_14` and `librem_l1um_v2`), I'll let CI tell me if any of the other ones have unique issues.