### PR TITLE
Split tests into separate file; use runTest

### DIFF
--- a/projects/default.nix
+++ b/projects/default.nix
@@ -34,6 +34,7 @@ let
       allowedFiles = [
         "README.md"
         "default.nix"
+        "tests.nix"
         "types.nix"
       ];
     in

--- a/projects/tests.nix
+++ b/projects/tests.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  pkgs,
+  project,
+  examples,
+  ...
+}:
+let
+  nixosTest =
+    test:
+    let
+      # Amenities for interactive tests
+      tools =
+        { pkgs, ... }:
+        {
+          environment.systemPackages = with pkgs; [
+            vim
+            tmux
+            jq
+          ];
+          # Use kmscon <https://www.freedesktop.org/wiki/Software/kmscon/>
+          # to provide a slightly nicer console.
+          # kmscon allows zooming with [Ctrl] + [+] and [Ctrl] + [-]
+          services.kmscon = {
+            enable = true;
+            autologinUser = "root";
+          };
+        };
+      debugging.interactive.nodes = lib.mapAttrs (_: _: tools) test.nodes;
+      args = lib.mergeAttrsList [
+        debugging
+        test
+        {
+          # we need to extend pkgs with ngipkgs, so it can't be read-only
+          node.pkgsReadOnly = false;
+        }
+      ];
+    in
+    if lib.isDerivation test then test else pkgs.testers.runNixOSTest args;
+
+  # TODO: refactor
+  tests = lib.mergeAttrsList [
+    (project.nixos.tests or { })
+    (project.nixos.demo.vm.tests or { })
+    (project.nixos.demo.shell.tests or { })
+    (lib.filter-map examples "tests")
+  ];
+
+  filtered-tests = lib.filterAttrs (
+    _: test: (!test ? problem.broken) && (test ? module && test.module != null)
+  ) tests;
+in
+lib.mapAttrs (
+  _: test:
+  if lib.isString test.module then
+    nixosTest (
+      import test.module {
+        inherit pkgs lib;
+        inherit (pkgs) system;
+      }
+    )
+  else
+    nixosTest test.module
+) filtered-tests


### PR DESCRIPTION
NixOS is migrating to `runTest`, which has a bunch of advantages, according to the [tracking issue](https://github.com/NixOS/nixpkgs/issues/386873):

- Define values for any test option
- Use imports to compose tests
- Access the module arguments like hostPkgs and config.node.pkgs
- Portable to other VM hosts, specifically Darwin
- Faster evaluation, using a single pkgs instance
- [Documented](https://nixos.org/manual/nixos/unstable/#sec-calling-nixos-tests) for external use too

Which may be useful in certain scenarios (https://github.com/ngi-nix/ngipkgs/issues/1434, perhaps?).
Not only this, but test migrating to NixOS would probably be more seamless.