### PR TITLE
projects/mitmproxy: fix typo

### DIFF
--- a/projects/mitmproxy/module.nix
+++ b/projects/mitmproxy/module.nix
@@ -21,6 +21,6 @@ in
     environment.systemPackages = [
       cfg.package
     ]
-    + lib.optional cfg.swagger.enable cfg.swagger.package;
+    ++ lib.optional cfg.swagger.enable cfg.swagger.package;
   };
 }


### PR DESCRIPTION
The typo was introduced in https://github.com/ngi-nix/ngipkgs/pull/1531.