### PR TITLE
reoxide: init at 0.7.0, reoxide-plugin-simple: init at 0-unstable-2025-09-12

### DIFF
--- a/pkgs/by-name/reoxide-plugin-simple/package.nix
+++ b/pkgs/by-name/reoxide-plugin-simple/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  fetchFromGitea,
+  clangStdenv,
+
+  meson,
+  clang,
+  ninja,
+  reoxide,
+}:
+
+clangStdenv.mkDerivation (finalAttrs: {
+  pname = "reoxide-plugin-simple";
+  version = "0-unstable-2025-09-12";
+
+  # use latest dev branch commit
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "ReOxide";
+    repo = "plugin-template";
+    rev = "ef4856f1a4a146b6b07e5969ad60289f9ce47abd";
+    hash = "sha256-/kROJRarla8uV3jRMgyuNVJ5wxC8OfliwHG5iRl6yiE=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    clang
+    ninja
+    reoxide
+  ];
+
+  env = {
+    CC = "${clangStdenv.cc}/bin/clang";
+    CXX = "${clangStdenv.cc}/bin/clang++";
+  };
+
+  mesonBuildType = "release";
+
+  preConfigure = ''
+
+    mkdir -p .config/reoxide
+    touch .config/reoxide/reoxide.toml
+    export HOME=$PWD
+
+    meson setup --buildtype=release build
+
+  '';
+
+  postInstall = ''
+    mkdir -p $out/lib
+    cp simple/libsimple.so $out/lib/
+  '';
+
+  meta = {
+    description = "Simple plugin template for reoxide";
+    homepage = "https://codeberg.org/ReOxide/reoxide";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      themadbit
+    ];
+    teams = with lib.teams; [ ngi ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/reoxide/package.nix
+++ b/pkgs/by-name/reoxide/package.nix
@@ -85,7 +85,7 @@ python3.pkgs.buildPythonApplication rec {
     popd
     chmod +x $out/opt/ghidra/ghidraRun
     chmod +x $out/opt/ghidra/support/launch.sh
-    ln -s $out/opt/ghidra/ghidraRun $out/bin/reoxided-ghidra
+    ln -s $out/opt/ghidra/ghidraRun $out/bin/reoxide-ghidra
   '';
 
   pythonImportsCheck = [

--- a/pkgs/by-name/reoxide/package.nix
+++ b/pkgs/by-name/reoxide/package.nix
@@ -1,0 +1,106 @@
+{
+  lib,
+  python3,
+  fetchFromGitea,
+  cacert,
+  clang,
+  meson,
+  pkg-config,
+  cppzmq,
+  libclang,
+  libllvm,
+  ghidra,
+}:
+python3.pkgs.buildPythonApplication rec {
+  pname = "reoxide";
+  version = "0.7.0";
+  pyproject = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "ReOxide";
+    repo = "reoxide";
+    tag = "v${version}";
+    hash = "sha256-cHJZhYJvCBXRB+V1SP/g1YBzGdwC9drOStVPCwdi6lo=";
+
+    nativeBuildInputs = [
+      meson
+      cacert
+    ];
+
+    postFetch = ''
+      pushd "$out"
+        for prj in subprojects/*.wrap; do
+          meson subprojects download "$(basename "$prj" .wrap)"
+          rm -rf subprojects/$(basename "$prj" .wrap)/.git
+        done
+      popd
+    '';
+  };
+
+  build-system = [
+    clang
+    pkg-config
+    python3.pkgs.meson
+    python3.pkgs.meson-python
+    python3.pkgs.ninja
+    python3.pkgs.setuptools
+  ];
+
+  dependencies = with python3.pkgs; [
+    cppzmq
+    libclang
+    libllvm
+    platformdirs
+    pyyaml
+    pyzmq
+  ];
+
+  mesonFlags = [
+    (lib.mesonBool "b_ndebug" true)
+    (lib.mesonEnable "extract-actions" true)
+  ];
+
+  postPatch = ''
+    # Replace version.py with a version that returns the package version
+    cat > scripts/version.py << 'EOF'
+    #! ${python3.interpreter}
+
+    import sys
+    if len(sys.argv) > 1 and sys.argv[1] == 'get-vcs':
+        print('${version}'.split('-')[0])
+    else:
+        exit(1)
+    EOF
+
+  '';
+
+  postFixup = ''
+    # Patch ghidra decompiler path to use reoxide decompile binary
+    mkdir -p $out/opt
+    cp -R --no-preserve=mode ${ghidra}/lib/ghidra $out/opt
+    pushd $out/opt/ghidra/Ghidra/Features/Decompiler/os/linux_x86_64
+      mv decompile decompile.orig
+      cp $out/lib/python3.13/site-packages/reoxide/data/bin/decompile .
+    popd
+    chmod +x $out/opt/ghidra/ghidraRun
+    chmod +x $out/opt/ghidra/support/launch.sh
+    ln -s $out/opt/ghidra/ghidraRun $out/bin/reoxided-ghidra
+  '';
+
+  pythonImportsCheck = [
+    "reoxide"
+  ];
+
+  meta = {
+    description = "Plugin System for the Ghidra Decompiler";
+    homepage = "https://codeberg.org/ReOxide/reoxide";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      themadbit
+    ];
+    teams = with lib.teams; [ ngi ];
+    mainProgram = "reoxide";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
closes #1573 

This PR overrides https://github.com/ngi-nix/ngipkgs/pull/1574. It uses `buildPythonApplication` over `clangStdenv` that only builds the shared libraries and not the *frontend executables: `reoxide` and `reoxided`.

Notes: Might need to be shipped together with Ghidra, since reoxide renames the Ghidra decompiler and symlinks the original decompiler with another. This needs the Ghidra path to be writable, which it is not.

Update:
- Includes a Ghidra package, which is patched with the reoxide decompiler to produce a '`reoxide-ghidra`' package. A bit hacky, and I am open to a better way of making reoxide work with Ghidra.
