### PR TITLE
makemake: Show full traces on failed builds

### DIFF
--- a/infra/makemake/buildbot.nix
+++ b/infra/makemake/buildbot.nix
@@ -39,6 +39,7 @@ in
         name = "ngi";
         auth.authToken.file = config.sops.secrets."cachix".path;
       };
+      showTrace = true;
     };
 
     buildbot-nix.worker = {


### PR DESCRIPTION
This fully closes #1042, as the setting is off by default we need to turn it on.