### PR TITLE
Projects/Wax

### DIFF
--- a/pkgs/by-name/wax-client/package.nix
+++ b/pkgs/by-name/wax-client/package.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/bin
 
     cat > $out/bin/wax-client << EOF
-      ${stdenv.shell}
+      #!${stdenv.shell}
       cd "$out/lib/wax-client"
       exec sh ./env.sh serve -p 8080 --single ./_build "\$@"
     EOF

--- a/projects/Wax/default.nix
+++ b/projects/Wax/default.nix
@@ -27,7 +27,6 @@
     };
   };
 
-  nixos.modules.services.wax.module = null;
   nixos.modules.programs = {
     wax-client = {
       name = "wax-client";
@@ -36,6 +35,17 @@
       examples."Enable Wax web client" = {
         module = ./programs/wax-client/examples/basic.nix;
         tests.basic.module = null;
+      };
+    };
+  };
+  nixos.modules.services = {
+    wax-server = {
+      name = "wax-server";
+      # if a project has `packages`, add them inside the `module.nix` file
+      module = ./services/wax-server/module.nix;
+      examples."Enable Wax web server" = {
+        module = ./services/wax-server/examples/basic.nix;
+        tests.basic.module = import ./services/wax-server/tests/basic.nix args;
       };
     };
   };

--- a/projects/Wax/default.nix
+++ b/projects/Wax/default.nix
@@ -27,6 +27,16 @@
     };
   };
 
-  nixos.modules.programs.wax.module = null;
   nixos.modules.services.wax.module = null;
+  nixos.modules.programs = {
+    wax-client = {
+      name = "wax-client";
+      # if a project has `packages`, add them inside the `module.nix` file
+      module = ./programs/wax-client/module.nix;
+      examples."Enable Wax web client" = {
+        module = ./programs/wax-client/examples/basic.nix;
+        tests.basic.module = null;
+      };
+    };
+  };
 }

--- a/projects/Wax/programs/wax-client/examples/basic.nix
+++ b/projects/Wax/programs/wax-client/examples/basic.nix
@@ -1,0 +1,4 @@
+{ ... }:
+{
+  programs.wax-client.enable = true;
+}

--- a/projects/Wax/programs/wax-client/module.nix
+++ b/projects/Wax/programs/wax-client/module.nix
@@ -1,0 +1,31 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.wax-client;
+in
+{
+  options.programs.wax-client = {
+    enable = lib.mkEnableOption "enable wax-client";
+    package = lib.mkPackageOption pkgs "wax-client" { };
+    serverUrl = lib.mkOption {
+      description = ''
+        Wax server access url
+      '';
+      type = lib.types.nullOr lib.types.str;
+      default = "http://localhost:3000";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = with pkgs; [
+      cfg.package
+    ];
+    environment.variables = {
+      SERVER_URL = cfg.serverUrl;
+    };
+  };
+}

--- a/projects/Wax/services/wax-server/examples/basic.nix
+++ b/projects/Wax/services/wax-server/examples/basic.nix
@@ -1,0 +1,4 @@
+{ ... }:
+{
+  services.wax-server.enable = true;
+}

--- a/projects/Wax/services/wax-server/module.nix
+++ b/projects/Wax/services/wax-server/module.nix
@@ -1,0 +1,33 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    types
+    ;
+  cfg = config.services.wax-server;
+in
+{
+  options.services.wax-server.enable = mkEnableOption "wax-server";
+  options.services.wax-server.package = mkPackageOption pkgs "wax-server" { };
+
+  options.services.wax-server.POSTGRES_DB = mkOption {
+    type = types.str;
+    description = "Postgres db";
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      cfg.package
+    ];
+    environment.variables = {
+      POSTGRES_DB = cfg.POSTGRES_DB;
+    };
+  };
+}

--- a/projects/Wax/services/wax-server/tests/basic.nix
+++ b/projects/Wax/services/wax-server/tests/basic.nix
@@ -1,0 +1,66 @@
+{
+  sources,
+  pkgs,
+  ...
+}:
+{
+  name = "wax";
+
+  nodes = {
+    machine =
+      { ... }:
+      {
+        imports = [
+          sources.modules.ngipkgs
+          sources.modules.services.wax-server
+          sources.modules.programs.wax-client
+          "${sources.inputs.nixpkgs}/nixos/tests/common/x11.nix"
+        ];
+
+        environment.systemPackages = with pkgs; [
+          firefox
+          wax-client
+          wax-server
+        ];
+        environment.variables = {
+          POSTGRES_DB = "wax";
+          POSTGRES_USER = "wax";
+          POSTGRES_HOST = "localhost";
+          S3_ACCESS_KEY_ID = "12345";
+          S3_SECRET_ACCESS_KEY = "12345678";
+          S3_URL = "http://127.0.0.1:9001";
+        };
+
+        services.postgresql = {
+          enable = true;
+          settings = {
+            port = 5432;
+          };
+          ensureDatabases = [ "wax" ];
+          ensureUsers = [
+            {
+              name = "wax";
+              ensureDBOwnership = true;
+            }
+          ];
+          authentication = ''
+            host  wax wax 127.0.0.1/32 trust
+          '';
+        };
+
+        services.minio = {
+          enable = true;
+          accessKey = "12345";
+          listenAddress = ":9000";
+          consoleAddress = ":9001";
+          secretKey = "12345678";
+        };
+      };
+  };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      start_all()
+    '';
+}


### PR DESCRIPTION
Still WIP.

The test needs some more work.
- The wax-server fails to start due to an issue with graphql
- ~~The wax-client currently breaks as it drops into a different shell, maybe because of `{stdenv.shell}`. I will investigate~~ (fixed https://github.com/ngi-nix/ngipkgs/pull/1620/commits/29b01c8d092ad1af1c1ebdc0ab7a333e6ffd9dd2)
- Uses minio for file/object storage over S3 buckets. Seems to be working but will be confirmed once other bugs are fixed.
- Needs the wax-server package (#1544) merged