### PR TITLE
ci: enable flakes and nix-command in makemake workflow

### DIFF
--- a/.github/workflows/makemake.yaml
+++ b/.github/workflows/makemake.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: cachix/install-nix-action@v31
         name: 'Install Nix'
-        with: { extra_nix_config: 'experimental-features = no-url-literals' }
+        with: { extra_nix_config: 'experimental-features = flakes nix-command no-url-literals' }
 
       - name: Prepare SSH
         run: |


### PR DESCRIPTION
Since they're disabled by overriding `extra_nix_config` (see [cachix/install-nix-action](https://github.com/cachix/install-nix-action?tab=readme-ov-file#differences-from-the-default-nix-installer))