### PR TITLE
flake: Use the refactoring branch of buildbot-nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,15 +10,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1758013444,
-        "narHash": "sha256-fYRTQqFNbFn6tGSkC+GIUfl/ejh4Oen7Gqq5ah1C3PE=",
+        "lastModified": 1758036668,
+        "narHash": "sha256-zqKYqUcgeRWiLPVVK9kSpvK9NmJN251PFVFY8l0JC6w=",
         "owner": "nix-community",
         "repo": "buildbot-nix",
-        "rev": "201ae35c51726ef1a0903207fdb11c1f5579eef2",
+        "rev": "1a210ea4c099cf24a1a499eef953ca1b0904677e",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
+        "ref": "refactoring",
         "repo": "buildbot-nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
   inputs.sops-nix.inputs.nixpkgs.follows = "nixpkgs";
   inputs.sops-nix.url = "github:Mic92/sops-nix";
   inputs.buildbot-nix.inputs.nixpkgs.follows = "nixpkgs";
-  inputs.buildbot-nix.url = "github:nix-community/buildbot-nix";
+  inputs.buildbot-nix.url = "github:nix-community/buildbot-nix?ref=refactoring";
 
   # See <https://github.com/ngi-nix/ngipkgs/issues/24> for plans to support Darwin.
   inputs.systems.url = "github:nix-systems/default-linux";


### PR DESCRIPTION
The rafactoring branch is currently used in https://github.com/nix-community/buildbot-nix/pull/492 which will help with performance. Let's try it out and report back to upstream if it works better for us or if we run into issues.