### PR TITLE
flake: Follow main again on buildbot-nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,16 +10,15 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1758036668,
-        "narHash": "sha256-zqKYqUcgeRWiLPVVK9kSpvK9NmJN251PFVFY8l0JC6w=",
+        "lastModified": 1758119284,
+        "narHash": "sha256-zNav4JIsc64rPCuHIXiRMnKiBLwN37Qobpncjxy7eqs=",
         "owner": "nix-community",
         "repo": "buildbot-nix",
-        "rev": "1a210ea4c099cf24a1a499eef953ca1b0904677e",
+        "rev": "b1f94c5b3cec4617086506504e4a8ca1b2b81a4f",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "refactoring",
         "repo": "buildbot-nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
   inputs.sops-nix.inputs.nixpkgs.follows = "nixpkgs";
   inputs.sops-nix.url = "github:Mic92/sops-nix";
   inputs.buildbot-nix.inputs.nixpkgs.follows = "nixpkgs";
-  inputs.buildbot-nix.url = "github:nix-community/buildbot-nix?ref=refactoring";
+  inputs.buildbot-nix.url = "github:nix-community/buildbot-nix";
 
   # See <https://github.com/ngi-nix/ngipkgs/issues/24> for plans to support Darwin.
   inputs.systems.url = "github:nix-systems/default-linux";


### PR DESCRIPTION
An update on #1640, the upstream of buildbot-nix already merged the PR and development has moved on, so we should also now go back to tracking `main`.