### PR TITLE
overview: add source code declaration link to options

### DIFF
--- a/overview/content-types/option-list.nix
+++ b/overview/content-types/option-list.nix
@@ -1,8 +1,7 @@
 {
   lib,
-  name,
-  config,
   pkgs,
+  flake,
   ...
 }:
 let
@@ -28,6 +27,7 @@ in
         listOf (submodule {
           imports = [ ./option.nix ];
           _module.args.pkgs = pkgs;
+          _module.args.flake = flake;
         });
       default = [ ];
     };

--- a/overview/default.nix
+++ b/overview/default.nix
@@ -84,6 +84,7 @@ let
       eval {
         imports = [ ./content-types/option-list.nix ];
         _module.args.pkgs = pkgs;
+        _module.args.flake = self;
 
         inherit prefix;
         module = lib.attrByPath (prefix ++ [ "module" ]) null project.nixos.modules;
@@ -95,6 +96,7 @@ let
             ;
           attrpath = option.loc;
           default = option.default or { };
+          declarations = option.declarations;
         }) (pick.options prefix);
       };
 


### PR DESCRIPTION
Related to https://github.com/ngi-nix/ngipkgs/issues/1022

<img width="494" height="371" alt="image" src="https://github.com/user-attachments/assets/1d782811-d83a-4e8f-a61e-217f187eb57a" />

Links to [Nixpkgs](https://github.com/nixos/nixpkgs/blob/e9f00bd893984bc8ce46c895c3bf7cac95331127/nixos/modules/services/web-apps/galene.nix).

---

<img width="494" height="371" alt="image" src="https://github.com/user-attachments/assets/9b0e9d95-5c9e-4eeb-90ce-34c29d4b759a" />

Links to [NGIpkgs (main)](https://github.com/ngi-nix/ngipkgs/blob/main/projects/Aerogramme/services/module.nix) if the flake is dirty, else to [NGIpkgs (rev)](https://github.com/ngi-nix/ngipkgs/blob/4e61909ede8888d0f005615fc47fdc315b578790/projects/Aerogramme/services/module.nix).