### PR TITLE
pkgs/_0wm-server: init at 0-unstable-2025-09-23

### DIFF
--- a/pkgs/by-name/_0wm-server/0wm-server.nix
+++ b/pkgs/by-name/_0wm-server/0wm-server.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  fetchFromGitHub,
+  makeWrapper,
+  writableTmpDirAsHomeHook,
+
+  # dependencies
+  ocamlPackages,
+  gendarme,
+  gendarme-yojson,
+  ppx_marshal,
+
+  # passthru
+  deps,
+  nix-update-script,
+}:
+ocamlPackages.buildDunePackage (finalAttrs: {
+  pname = "0wm-server";
+  version = "0-unstable-2025-09-23";
+
+  duneVersion = "3";
+
+  src = fetchFromGitHub {
+    owner = "lab0-cc";
+    repo = "0WM-Server";
+    rev = "a16be8b5dca2359bf1dde666492ccb62b24d77d7";
+    hash = "sha256-oLZvdj59oc7muYKTcSae0WvpBlph4U6eEB/ziOu4xE8=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    writableTmpDirAsHomeHook
+  ];
+
+  buildInputs = with ocamlPackages; [
+    base64
+    camlimages
+    domainslib
+    dream
+    gendarme
+    gendarme-yojson
+    lwt_ppx
+    ppx_marshal
+    uuidm
+  ];
+
+  postBuild = ''
+    dune build src/zwm.exe
+  '';
+
+  postInstall = ''
+    mkdir -p $out/{bin,share/examples}
+
+    cp -r _build/default/src/zwm.exe $out/bin/0wm-server
+    cp config.json $out/share/examples
+
+    # The server only reads the config file from its work directory and there
+    # is no flag to override this.
+    #
+    # As a workaround, we set the default work dir as the example config, so
+    # this package works standalone. Then, in the module, we set "WORKDIR" as
+    # the systemd state directory (where the config is copied to).
+    wrapProgram $out/bin/0wm-server \
+      --set-default "WORKDIR" "$out/share/examples" \
+      --run 'cd "$WORKDIR"'
+  '';
+
+  passthru = {
+    inherit deps;
+    updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+  };
+
+  meta = {
+    description = "0WM Server";
+    homepage = "https://github.com/lab0-cc/0WM-Server";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    teams = with lib.teams; [ ngi ];
+    mainProgram = "0wm-server";
+  };
+})

--- a/pkgs/by-name/_0wm-server/gendarme-ezjsonm.nix
+++ b/pkgs/by-name/_0wm-server/gendarme-ezjsonm.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  writableTmpDirAsHomeHook,
+  ocamlPackages,
+  gendarme,
+  ppx_marshal_ext,
+}:
+
+ocamlPackages.buildDunePackage (finalAttrs: {
+  pname = "gendarme-ezjsonm";
+  inherit (gendarme) version src;
+
+  minimalOCamlVersion = "4.13";
+
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  buildInputs = with ocamlPackages; [
+    ezjsonm
+    ppx_marshal_ext
+  ];
+
+  meta = {
+    description = "Marshal OCaml data structures to JSON using Ezjsonm";
+    homepage = "https://github.com/bensmrs/gendarme";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/by-name/_0wm-server/gendarme-json.nix
+++ b/pkgs/by-name/_0wm-server/gendarme-json.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  writableTmpDirAsHomeHook,
+  ocamlPackages,
+  gendarme,
+}:
+
+ocamlPackages.buildDunePackage (finalAttrs: {
+  pname = "gendarme-json";
+  inherit (gendarme) version src;
+
+  minimalOCamlVersion = "4.13";
+
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  meta = {
+    description = "Metapackage for JSON marshalling using Gendarme";
+    homepage = "https://github.com/bensmrs/gendarme";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/by-name/_0wm-server/gendarme-toml.nix
+++ b/pkgs/by-name/_0wm-server/gendarme-toml.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  writableTmpDirAsHomeHook,
+  ocamlPackages,
+  gendarme,
+  ppx_marshal_ext,
+}:
+
+ocamlPackages.buildDunePackage (finalAttrs: {
+  pname = "gendarme-toml";
+  inherit (gendarme) version src;
+
+  minimalOCamlVersion = "4.13";
+
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  buildInputs = with ocamlPackages; [
+    ppx_marshal_ext
+    toml
+  ];
+
+  meta = {
+    description = "Marshal OCaml data structures to TOML";
+    homepage = "https://github.com/bensmrs/gendarme";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/by-name/_0wm-server/gendarme-yaml.nix
+++ b/pkgs/by-name/_0wm-server/gendarme-yaml.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  writableTmpDirAsHomeHook,
+  ocamlPackages,
+  gendarme,
+  ppx_marshal_ext,
+}:
+
+ocamlPackages.buildDunePackage (finalAttrs: {
+  pname = "gendarme-yaml";
+  inherit (gendarme) version src;
+
+  minimalOCamlVersion = "4.13";
+
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  buildInputs = with ocamlPackages; [
+    ppx_marshal_ext
+    yaml
+  ];
+
+  meta = {
+    description = "Marshal OCaml data structures to YAML";
+    homepage = "https://github.com/bensmrs/gendarme";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/by-name/_0wm-server/gendarme-yojson.nix
+++ b/pkgs/by-name/_0wm-server/gendarme-yojson.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  writableTmpDirAsHomeHook,
+  ocamlPackages,
+  gendarme,
+  ppx_marshal_ext,
+}:
+
+ocamlPackages.buildDunePackage (finalAttrs: {
+  pname = "gendarme-yojson";
+  inherit (gendarme) version src;
+
+  minimalOCamlVersion = "4.13";
+
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  buildInputs = with ocamlPackages; [
+    ppx_marshal_ext
+    yojson
+  ];
+
+  meta = {
+    description = "Marshal OCaml data structures to JSON using Yojson";
+    homepage = "https://github.com/bensmrs/gendarme";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/by-name/_0wm-server/gendarme.nix
+++ b/pkgs/by-name/_0wm-server/gendarme.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchFromGitHub,
+  writableTmpDirAsHomeHook,
+  ocamlPackages,
+}:
+
+ocamlPackages.buildDunePackage (finalAttrs: {
+  pname = "gendarme";
+  version = "0.3-unstable-2025-09-23";
+
+  minimalOCamlVersion = "4.13";
+
+  src = fetchFromGitHub {
+    owner = "bensmrs";
+    repo = "gendarme";
+    rev = "eccdfd253ff02a854fd4d1f1bcc78cee34bcd491";
+    hash = "sha256-+5CWsQVNc+DT6zJYXhijNf1HGNjFdswkJQ6/dlpIK8Y=";
+  };
+
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  meta = {
+    description = "Marshalling library for OCaml";
+    homepage = "https://github.com/bensmrs/gendarme";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/by-name/_0wm-server/package.nix
+++ b/pkgs/by-name/_0wm-server/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  newScope,
+  ocaml-ng,
+}:
+
+let
+  ocamlPackages = ocaml-ng.ocamlPackages_5_2;
+
+  # A scope automatically makes attributes available as arguments
+  # https://nixos.org/manual/nixpkgs/unstable/#function-library-lib.customisation.makeScope
+  deps = lib.makeScope newScope (
+    self:
+    let
+      callPackage = self.newScope { inherit ocamlPackages; };
+    in
+    {
+      _0wm-server = callPackage ./0wm-server.nix {
+        # pass dependencies to `_0wm-server.passthru.deps`
+        deps = self;
+      };
+
+      gendarme = callPackage ./gendarme.nix { };
+
+      gendarme-ezjsonm = callPackage ./gendarme-ezjsonm.nix { };
+
+      gendarme-json = callPackage ./gendarme-json.nix { };
+
+      gendarme-toml = callPackage ./gendarme-toml.nix { };
+
+      gendarme-yaml = callPackage ./gendarme-yaml.nix { };
+
+      gendarme-yojson = callPackage ./gendarme-yojson.nix { };
+
+      ppx_marshal = callPackage ./ppx_marshal.nix { };
+
+      ppx_marshal_ext = callPackage ./ppx_marshal_ext.nix { };
+    }
+  );
+in
+# We're only interested in the server pacakge, but dependencies are passed to
+# the final output (`_0wm-server.passthru.deps`) in case we need them
+deps._0wm-server

--- a/pkgs/by-name/_0wm-server/ppx_marshal.nix
+++ b/pkgs/by-name/_0wm-server/ppx_marshal.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  writableTmpDirAsHomeHook,
+  ocamlPackages,
+  gendarme,
+  gendarme-ezjsonm,
+  gendarme-json,
+  gendarme-toml,
+  gendarme-yaml,
+  gendarme-yojson,
+  ppx_marshal_ext,
+}:
+
+ocamlPackages.buildDunePackage (finalAttrs: {
+  pname = "ppx_marshal";
+  inherit (gendarme) version src;
+
+  minimalOCamlVersion = "4.13";
+
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  buildInputs = [
+    gendarme-ezjsonm
+    gendarme-json
+    gendarme-toml
+    gendarme-yaml
+    gendarme-yojson
+    ppx_marshal_ext
+  ];
+
+  meta = {
+    description = "Preprocessor extension to automatically define marshallers for OCaml types";
+    homepage = "https://github.com/bensmrs/gendarme";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/by-name/_0wm-server/ppx_marshal_ext.nix
+++ b/pkgs/by-name/_0wm-server/ppx_marshal_ext.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  writableTmpDirAsHomeHook,
+  ocamlPackages,
+  gendarme,
+}:
+
+ocamlPackages.buildDunePackage (finalAttrs: {
+  pname = "ppx_marshal_ext";
+  inherit (gendarme) version src;
+
+  minimalOCamlVersion = "4.13";
+
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  propagatedBuildInputs = with ocamlPackages; [
+    gendarme
+    ppxlib
+  ];
+
+  meta = {
+    description = "Preprocessor extension to simplify writing Gendarme encoders";
+    homepage = "https://github.com/bensmrs/gendarme";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    teams = with lib.teams; [ ngi ];
+  };
+})


### PR DESCRIPTION
Closes https://github.com/ngi-nix/ngipkgs/issues/1686

Test with:

```shellSession
nix run github:eljamm/ngipkgs/init/pkgs/0WM-server#_0wm-server
```

**NOTE:** The package can be used as a development shell for compiling the upstream project:

```shellSession
$ git clone https://github.com/lab0-cc/0WM-Server
$ cd 0WM-Server
$ nix develop github:eljamm/ngipkgs/init/pkgs/0WM-server#_0wm-server
$ dune exec src/zwm.exe
```