### PR TITLE
Add script to update all packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -70,9 +70,6 @@
           inherit (classic) pkgs ngipkgs optionsDoc;
         in
         rec {
-          # nix run github:Mic92/nix-update -- --flake -u update.x86_64-linux.PACKAGE_NAME
-          update = ngipkgs;
-
           packages = ngipkgs // {
             inherit (classic) overview;
 


### PR DESCRIPTION
Closes https://github.com/ngi-nix/ngipkgs/issues/1045

To test, run:

```shellSession
nix-shell --run 'update-all'
```

You can also pass [nix-update](https://github.com/Mic92/nix-update) arguments. For example, to make a commit for each package update:

```shellSession
nix-shell --run 'update-all --commit'
```

> [!NOTE]
> Package updates' commit messages are prefixed with `update.${system}`, which isn't ideal. We should either figure out how to customize this, or make the packages accessible through the top-level `default.nix`.

The names of packages that fail to update are printed at the end, so we can investigate them further. These are the ones that are currently failing:

```
anastasis-gtk
atomic-browser
atomic-cli
bigbluebutton
corestore
firefox-meta-press
heads
hkdf
inventaire
inventaire-client
kazarma
kbin
kbin-frontend
liberaforms
libervia-backend
libervia-desktop-kivy
libervia-media
libervia-templates
libresoc-nmigen
libresoc-verilog
peertube-plugin-auto-block-videos
peertube-plugin-auto-mute
peertube-plugin-livechat
pretalxFull
proximity-matcher
reoxide-plugin-simple
sat-tmp
taler-mdb
urwid-satext
wax-client
wax-server
wireguard-rs
```