### PR TITLE
docs: add subgrant details for packaging report

### DIFF
--- a/maintainers/templates/report/packaging.nix
+++ b/maintainers/templates/report/packaging.nix
@@ -24,8 +24,16 @@ let
     name:
     let
       hasDemo = metrics.project-metrics.${name}.nixos.demos != 0;
+      subgrant-count =
+        project:
+        toString (
+          lib.mapAttrsToList (
+            subgrant: count: "\n    - ${subgrant}: ${toString count}"
+          ) metrics.project-metrics.${project}.metadata.subgrants
+        );
     in
     "  - [${name}](https://ngi.nixos.org/project/${name}/${lib.optionalString hasDemo "#demo"})"
+    + subgrant-count name
   ) project-names;
 
   # metrics


### PR DESCRIPTION
Instead of trying to group projects under specific funds (which sometimes intersect), it might be better to detail what funds the projects are composed of:

```shellSession
cat $(nix-build -A report.packaging) | head
- Worked on supporting 88 NGI-funded projects (2024-12-16: 45)
  - [0WM](https://ngi.nixos.org/project/0WM/#demo)
    - Core: 1
  - [Arcan](https://ngi.nixos.org/project/Arcan/)
    - Core: 2
    - Entrust: 1
  - [Blink](https://ngi.nixos.org/project/Blink/#demo)
    - Entrust: 1
    - Review: 2
  - [Briar](https://ngi.nixos.org/project/Briar/)
```