### PR TITLE
demo: refactor and expose in the toplevel

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -252,26 +252,23 @@ rec {
     inherit lib pkgs metrics;
   };
 
-  project-demos = lib.filterAttrs (name: value: value != null) (
-    lib.mapAttrs (name: value: value.nixos.demo.vm or value.nixos.demo.shell or null) projects
-  );
-
-  demo = import ./overview/demo {
-    inherit
-      lib
-      pkgs
-      sources
-      system
-      ;
-    demo-modules = lib.flatten (
-      lib.mapAttrsToList (name: value: value.module-demo.imports) project-demos
-    );
-    nixos-modules = extendedNixosModules;
-  };
-
-  inherit (demo)
-    demo-vm
+  inherit
+    (import ./overview/demo {
+      inherit
+        lib
+        pkgs
+        sources
+        system
+        projects
+        ;
+      nixos-modules = extendedNixosModules;
+    })
+    # for demo code activation. used in the overview code snippets
     demo-shell
+    demo-vm
+    # - $(nix-build -A demos.PROJECT_NAME)
+    # - nix run .#demos.PROJECT_NAME
+    demos
     ;
 }
 # required for update scripts

--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,7 @@
         in
         rec {
           packages = ngipkgs // {
-            inherit (classic) overview;
+            inherit (classic) overview demos;
 
             options =
               pkgs.runCommand "options.json"

--- a/overview/demo/shell.nix
+++ b/overview/demo/shell.nix
@@ -10,6 +10,7 @@ let
     mkOption
     ;
 
+  isFLake = !builtins ? currentSystem;
   makeManPath = lib.makeSearchPathOutput "man" "share/man";
 
   activate =
@@ -19,8 +20,8 @@ let
       runtimeInputs = lib.attrValues demo-shell.programs;
       runtimeEnv = demo-shell.env;
       passthru.inheritManPath = false;
-      # HACK: start shell from ./result
-      derivationArgs.postCheck = ''
+      # HACK: start shell from ./result, if not using flakes
+      derivationArgs.postCheck = lib.optionalString (!isFLake) ''
         mv $out/bin/$name /tmp/$name
         rm -rf $out && mv /tmp/$name $out
       '';

--- a/projects/types.nix
+++ b/projects/types.nix
@@ -703,7 +703,21 @@ rec {
     > [!TIP]
     > [Example](#libexample) modules can also be used for demos, if they clearly describe how the application should be configured and used.
 
-    After implementing the demo, run the [checks](#checks) to make sure that everything is correct.
+    After implementing the demo, run the following commands to test it:
+
+    - With classic Nix:
+
+      ```shellSession
+      nix-build -A demos.PROJECT_NAME
+      ```
+
+    - With flakes:
+
+      ```shellSession
+      nix run .#demos.PROJECT_NAME
+      ```
+
+    Then, run the [checks](#checks) to make sure that everything is correct.
   */
   demo = types.submodule (
     { name, ... }:
@@ -729,6 +743,13 @@ rec {
               ];
           };
           default = { };
+        };
+        type = mkOption {
+          type = types.enum [
+            "vm"
+            "shell"
+          ];
+          default = name;
         };
         problem = mkOption {
           type = types.nullOr problem;


### PR DESCRIPTION
Demos can now be triggered from the command line:

- `$(nix-build -A demos.PROJECT_NAME)`
- `nix build .#demos.PROJECT_NAME && ./result`

Supersedes https://github.com/ngi-nix/ngipkgs/pull/1528