### PR TITLE
bigbluebutton.bbb-freeswitch-core: Fix patch situation

### DIFF
--- a/pkgs/by-name/bigbluebutton/bbb-freeswitch-core/libwebsockets-0001-v3.2.3-CVE-2025-11677.patch
+++ b/pkgs/by-name/bigbluebutton/bbb-freeswitch-core/libwebsockets-0001-v3.2.3-CVE-2025-11677.patch
@@ -1,0 +1,96 @@
+From 1d9d977bfed5b38099fe488827b52346999bd028 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Thu, 13 Nov 2025 16:49:37 +0100
+Subject: [PATCH] v3.2.3 CVE-2025-11677
+
+---
+ lib/roles/http/server/server.c | 60 +++++++++++++++++-----------------
+ 1 file changed, 30 insertions(+), 30 deletions(-)
+
+diff --git a/lib/roles/http/server/server.c b/lib/roles/http/server/server.c
+index 6bec745c..6c734ec6 100644
+--- a/lib/roles/http/server/server.c
++++ b/lib/roles/http/server/server.c
+@@ -1985,49 +1985,49 @@ raw_transition:
+ 						HTTP_STATUS_FORBIDDEN, NULL) ||
+ 				    lws_http_transaction_completed(wsi))
+ 					goto bail_nuke_ah;
+-			}
+-
+-			n = user_callback_handle_rxflow(wsi->protocol->callback,
+-					wsi, LWS_CALLBACK_HTTP_CONFIRM_UPGRADE,
+-					wsi->user_space, (char *)up, 0);
++			} else {
++				n = user_callback_handle_rxflow(wsi->protocol->callback,
++						wsi, LWS_CALLBACK_HTTP_CONFIRM_UPGRADE,
++						wsi->user_space, (char *)up, 0);
+ 
+-			/* just hang up? */
++				/* just hang up? */
+ 
+-			if (n < 0)
+-				goto bail_nuke_ah;
++				if (n < 0)
++					goto bail_nuke_ah;
+ 
+-			/* callback returned headers already, do t_c? */
++				/* callback returned headers already, do t_c? */
+ 
+-			if (n > 0) {
+-				if (lws_http_transaction_completed(wsi))
+-					goto bail_nuke_ah;
++				if (n > 0) {
++					if (lws_http_transaction_completed(wsi))
++						goto bail_nuke_ah;
+ 
+-				/* continue on */
++					/* continue on */
+ 
+-				return 0;
+-			}
++					return 0;
++				}
+ 
+-			/* callback said 0, it was allowed */
++				/* callback said 0, it was allowed */
+ 
+-			if (wsi->vhost->options &
+-			    LWS_SERVER_OPTION_VHOST_UPG_STRICT_HOST_CHECK &&
+-			    lws_confirm_host_header(wsi))
+-				goto bail_nuke_ah;
++				if (wsi->vhost->options &
++				    LWS_SERVER_OPTION_VHOST_UPG_STRICT_HOST_CHECK &&
++				    lws_confirm_host_header(wsi))
++					goto bail_nuke_ah;
+ 
+-			if (!strcasecmp(up, "websocket")) {
++				if (!strcasecmp(up, "websocket")) {
+ #if defined(LWS_ROLE_WS)
+-				wsi->vhost->conn_stats.ws_upg++;
+-				lwsl_info("Upgrade to ws\n");
+-				goto upgrade_ws;
++					wsi->vhost->conn_stats.ws_upg++;
++					lwsl_info("Upgrade to ws\n");
++					goto upgrade_ws;
+ #endif
+-			}
++				}
+ #if defined(LWS_WITH_HTTP2)
+-			if (!strcasecmp(up, "h2c")) {
+-				wsi->vhost->conn_stats.h2_upg++;
+-				lwsl_info("Upgrade to h2c\n");
+-				goto upgrade_h2c;
+-			}
++				if (!strcasecmp(up, "h2c")) {
++					wsi->vhost->conn_stats.h2_upg++;
++					lwsl_info("Upgrade to h2c\n");
++					goto upgrade_h2c;
++				}
+ #endif
++			}
+ 		}
+ 
+ 		/* no upgrade ack... he remained as HTTP */
+-- 
+2.51.0
+


### PR DESCRIPTION
##### `libks`
One patch was dropped from Nixpkgs upstream (due to bump) which is still relevant for us (fixing random segfaults in test suite). Another was dropped from our end by mistake.

##### `libwebsockets`
Overriding `patches` fixed the build, but meant that we missed out on CVE patches. Not ideal…

I *may* have overengineered a mechanism to provide replacements to patches in a way that makes patch dropping explicit. Interested in thought about it. Although we maybe don't do enough `overrideAttrs`ing of packages from Nixpkgs for smth like this to be used outside of BBB?

Either way though, dropping CVE fixes is bad.