### PR TITLE
chore: trim stray newline from demos

### DIFF
--- a/overview/content-types/demo.nix
+++ b/overview/content-types/demo.nix
@@ -36,7 +36,7 @@ in
       ngipkgs ? import (fetchTarball "https://github.com/ngi-nix/ngipkgs/tarball/main") { },
     }:
     ngipkgs.demo-${config.type} (
-      ${toString (lib.indent "  " (builtins.readFile config.module))}
+      ${toString (lib.trim (lib.indent "  " (builtins.readFile config.module)))}
     )
   '';
 }


### PR DESCRIPTION
eg for blink `/project/Blink/#demo`

```nix
ngipkgs.demo-shell (
  { ... }:
  {
    programs.blink.enable = true;
  }
)
```

vs 

```nix
ngipkgs.demo-shell (
  { ... }:
  {
    programs.blink.enable = true;
  }

)
```