### PR TITLE
compat(REUSE): init configuration

### DIFF
--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,18 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,10 @@
+version = 1
+SPDX-PackageName = "ngipkgs"
+SPDX-PackageSupplier = "NGIpkgs contributors <ngi@nixos.org>"
+SPDX-PackageDownloadLocation = "https://github.com/ngi-nix/ngipkgs"
+
+[[annotations]]
+path = ["**"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "NGIpkgs contributors <ngi@nixos.org>"
+SPDX-License-Identifier = "MIT"


### PR DESCRIPTION
This PR introduces a minimal [REUSE](https://reuse.software) configuration.

```console
$ reuse lint
# SUMMARY

* Bad licenses: 0
* Deprecated licenses: 0
* Licenses without file extension: 0
* Missing licenses: 0
* Unused licenses: 0
* Used licenses: MIT
* Read errors: 0
* Files with copyright information: 819 / 819
* Files with license information: 819 / 819

Congratulations! Your project is compliant with version 3.3 of the REUSE Specification :-)
```