### PR TITLE
Replace fricklerhandwerk/flake-inputs with builtins.getFlake

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,5 @@
 {
-  flake-inputs ? import (fetchTarball {
-    url = "https://github.com/fricklerhandwerk/flake-inputs/tarball/4.1.0";
-    sha256 = "1j57avx2mqjnhrsgq3xl7ih8v7bdhz1kj3min6364f486ys048bm";
-  }),
-  flake ? flake-inputs.import-flake { src = ./.; },
+  flake ? builtins.getFlake (toString ./.),
   sources ? flake.inputs,
   system ? builtins.currentSystem,
   pkgs ? import sources.nixpkgs {


### PR DESCRIPTION
We only use flake-inputs.import-flake, which can be replaced by builtins.getFlake.  Since 25.11, the minimum version of Nix required to evaluate Nixpkgs has been raised from 2.3 to 2.18[1], which has[2] builtins.getFlake.  So we can drop fricklerhandwerk/flake-inputs now.

Dropping flake-inputs has many benefits and one of them is to avoid wrong usage of other flake-inputs funtions, such as this one[3].

[1]: https://github.com/NixOS/nixpkgs/blob/860a8446fce35924d49809a0a61b61afaf13f325/doc/release-notes/rl-2511.section.md?plain=1#L285C7-L285C91
[2]: https://nix.dev/manual/nix/2.18/language/builtins.html?highlight=getFlake#builtins-getFlake
[3]: https://github.com/ngi-nix/ngipkgs/issues/1909#issuecomment-3654325435