### PR TITLE
demo: fix trusted-public-keys, case sensitive

### DIFF
--- a/overview/content-types/demo-instructions.nix
+++ b/overview/content-types/demo-instructions.nix
@@ -59,8 +59,8 @@ in
           "https://ngi.cachix.org/"
         ];
         trusted-public-keys = [
-          "cache.nixos.org-1:6nchdd59x431o0gwypbmraurkbj16zpmqfgspcdshjy="
-          "ngi.cachix.org-1:n+cal72roc3qqulxihpv+tw5t42whxmmhpragkrsrow="
+          "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+          "ngi.cachix.org-1:n+CAL72ROC3qQuLxIHpV+Tw5t42WhXmMhprAGkRSrOw="
         ];
       };
     };


### PR DESCRIPTION
We have had wrong instructions for a while. Noticed that these should be case sensitive, copied them from https://app.cachix.org/cache/ngi and https://github.com/NixOS/nixpkgs/blob/233f4672b905e51077ecd1dccf6dde02e5f3c3c6/nixos/modules/config/nix.nix#L371 respectively.

I had a call with @ppom0 to try to debug https://github.com/ngi-nix/ngipkgs/issues/1921 and we noticed this when trying to run the demo. We faced several issues (#1923) this being one of them.