### PR TITLE
reuse(devLib): expose extended `lib` by default and use an overlay to extend it

### DIFF
--- a/pkgs/lib.nix
+++ b/pkgs/lib.nix
@@ -1,10 +1,9 @@
 {
-  lib,
   sources,
   system,
   ...
 }@args:
-rec {
+lib: previousLib: {
   /*
     Adapted from `lib.customisation.makeScope`:
     https://nixos.org/manual/nixpkgs/stable/#function-library-lib.customisation.makeScope
@@ -19,7 +18,7 @@ rec {
     let
       self = f self // {
         newScope = scope: newScope (self // scope);
-        overrideScope = g: customScope newScope (lib.extends g f);
+        overrideScope = g: lib.customScope newScope (lib.extends g f);
         callPackage = self.newScope { };
 
         # Compute a scope's fixpoint using `callPackage`
@@ -80,7 +79,7 @@ rec {
     let
       lines = lib.splitString "\n" s;
     in
-    join "\n" ([ (head lines) ] ++ (map (x: if x == "" then x else "${prefix}${x}") (tail lines)));
+    lib.join "\n" ([ (head lines) ] ++ (map (x: if x == "" then x else "${prefix}${x}") (tail lines)));
 
   # Recursively evaluate attributes for an attribute set.
   # Coupled with an evaluated nixos configuration, this presents an efficient
@@ -95,7 +94,7 @@ rec {
           # if eval fails
           if !(builtins.tryEval i).success then
             # recursively recurse into attrsets
-            if lib.isAttrs i then forceEvalRecursive i else (builtins.tryEval i).success
+            if lib.isAttrs i then lib.forceEvalRecursive i else (builtins.tryEval i).success
           else
             (builtins.tryEval i).success
         ) v


### PR DESCRIPTION
+reuse: exposing the extended `lib` by default enables to reuse it in modules
evaluated by `pkgs.testers.runNixOSTest` in `projects/tests.nix`,
otherwise `lib` given to modules when testing is Nixpkgs' `pkgs.lib`.

+clarity: being able to factorize code in a `lib`rary
is much easier to check, maintain and develop
than having to manage multiple copies of the same code.

+standardization: having some code in a `lib`rary
nudges more to use it than if it would require to copy,
since it's already an explicitly shared pattern.

+customizability: using an overlay enables to customize `lib`'s
sub attrs (eg. adding types to `lib.types`).

-portability: using a custom `lib` specific to NGIpkgs
means the code is less portable, eg. pushing it into Nixpkgs or NixOS
means pushing the part of `lib` it depends on with it,
or to copy it in the package or module.

-installability: using a custom `lib` specific to NGIpkgs
means the modules must be imported with that `lib` by users,
which may not be obvious.