### PR TITLE
pkgs(pmtiles): init at 0-unstable-2025-12-29

### DIFF
--- a/pkgs/by-name/pmtiles-app/package.nix
+++ b/pkgs/by-name/pmtiles-app/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "pmtiles-app";
+  version = "0-unstable-2025-01-06";
+
+  src = fetchFromGitHub {
+    owner = "protomaps";
+    repo = "PMTiles";
+    rev = "754e15bf58fa3cd1491bbfd16d48d72a72602596"; # main branch as of 2025-01-06
+    hash = "sha256-RtDSUZeW3tIQQNftGzMjPF8srx4hw8ZWV5oJNCYeBig=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/app";
+
+  npmDepsHash = "sha256-VLNkcBtwXBe1nqA1qlt9DOj3DiAtUwgyXRpHX16cfHs=";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/pmtiles-app
+    cp -r dist/* $out/share/pmtiles-app/
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Web viewer for PMTiles - a single-file archive format for tiled data";
+    homepage = "https://protomaps.com/docs/pmtiles";
+    changelog = "https://github.com/protomaps/PMTiles/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/pmtiles-app/package.nix
+++ b/pkgs/by-name/pmtiles-app/package.nix
@@ -32,9 +32,8 @@ buildNpmPackage (finalAttrs: {
   };
 
   meta = {
-    description = "Web viewer for PMTiles - a single-file archive format for tiled data";
+    description = "Web viewer for PMTiles";
     homepage = "https://protomaps.com/docs/pmtiles";
-    changelog = "https://github.com/protomaps/PMTiles/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;


### PR DESCRIPTION
Fixes ngi-nix/projects#1335
  The package:
  - Uses `buildNpmPackage` to build the web application from the protomaps/PMTiles repository
  - Extracts and builds only the `/app` directory from the repository
  - Installs static assets to `share/pmtiles-app` for serving
  - Follows the by-name package structure convention
  - Includes nix-update-script for automated updates from the main branch
  - Provides proper metadata (BSD-3 license, homepage)
  
  ## Test Plan
  - [x] Build the package: `nix build .#pmtiles-app`
  - [x] Serve the web app locally: `python3 -m http.server 8000 --directory result/share/pmtiles-app`
  - [x] Verify the web viewer loads correctly at http://localhost:8000