### PR TITLE
projects/DNSvizor: init

### DIFF
--- a/projects/DNSvizor/default.nix
+++ b/projects/DNSvizor/default.nix
@@ -1,0 +1,315 @@
+{
+  lib,
+  pkgs,
+  sources,
+  ...
+}@args:
+
+let
+  problem =
+    if lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.syslinux then
+      null
+    else
+      {
+        broken.reason = ''
+          dependency pkgs.syslinux is not available on this platform
+        '';
+      };
+  webInterfaceManual = {
+    text = "Web interface manual";
+    url = "https://robur-coop.github.io/dnsvizor-handbook/dnsvizor_web_interface.html";
+  };
+in
+{
+  metadata = {
+    summary = "Privacy-enhanced, secure and robust DNS resolver and DHCP server with a small resource footprint as a MirageOS unikernel";
+    subgrants = {
+      Entrust = [ "DNSvizor" ];
+    };
+    links = {
+      homepage = null;
+      repo = {
+        text = "Source repository";
+        url = "https://github.com/robur-coop/dnsvizor";
+      };
+      docs = {
+        text = "Handbook";
+        url = "https://robur-coop.github.io/dnsvizor-handbook/";
+      };
+      blog = {
+        text = "Blog";
+        url = "https://blog.robur.coop/tags.html#tag-DNSvizor";
+      };
+      upstreamBuilds = {
+        text = "Reproducible unikernel binaries built by upstream";
+        url = "https://builds.robur.coop/job/dnsvizor";
+      };
+      mirageOS = {
+        text = "MirageOS";
+        url = "https://mirage.io/";
+      };
+    };
+  };
+
+  nixos.modules.services.dnsvizor = {
+    name = "DNSvizor";
+    module = ./services/dnsvizor/module.nix;
+    examples =
+      let
+        mkExample =
+          {
+            exampleName,
+            exampleModule,
+            exampleDescription,
+            testName,
+            testModule,
+            testCfg,
+          }:
+          lib.nameValuePair exampleName {
+            module = exampleModule;
+            description = exampleDescription;
+            tests =
+              let
+                testArgToString =
+                  testArgName: testArgValue: seperator:
+                  if testArgValue == true then
+                    seperator + testArgName
+                  else if testArgValue == false then
+                    ""
+                  else if lib.isString testArgValue then
+                    seperator + testArgValue
+                  else
+                    throw "testArgToString: not implemented for ${testArgName}=${toString testArgValue}";
+                testArgsToString =
+                  testArgs:
+                  lib.pipe testArgs [
+                    (lib.mapAttrs (testArgName: testArgValue: "${testArgToString testArgName testArgValue "-"}"))
+                    lib.attrValues
+                    lib.concatStrings
+                  ];
+                mkTest =
+                  testArgs:
+                  lib.nameValuePair ("${testName}${testArgsToString testArgs}") {
+                    module = import testModule (args // testArgs // { inherit exampleName; });
+                    inherit problem;
+                  };
+              in
+              lib.listToAttrs (map mkTest (lib.cartesianProduct testCfg));
+            links = { inherit webInterfaceManual; };
+          };
+        dnsResolverExampleDescription = ''
+          Usage instructions
+
+          1. Query DNS with UDP/TCP, DNS-over-TLS(DoT) and DNS-over-HTTPS(DoH)
+          2. Open the web interface for management
+        '';
+      in
+      lib.listToAttrs (
+        map mkExample [
+          {
+            exampleName = "Enable DNSvizor as a IPv4-only stub DNS resolver";
+            exampleModule = ./services/dnsvizor/examples/stub-dns-resolver.nix;
+            exampleDescription = dnsResolverExampleDescription;
+            testName = "dns-ipv4";
+            testModule = ./services/dnsvizor/tests/dns.nix;
+            testCfg = {
+              resolverKind = [ "stub" ];
+              useNetworkd = [
+                true
+                false
+              ];
+              useNftables = [
+                true
+                false
+              ];
+            };
+          }
+          {
+            exampleName = "Enable DNSvizor as a dual-stack recursive DNS resolver";
+            exampleModule = ./services/dnsvizor/examples/recursive-dns-resolver.nix;
+            exampleDescription = dnsResolverExampleDescription;
+            testName = "dns-dualstack";
+            testModule = ./services/dnsvizor/tests/dns.nix;
+            testCfg = {
+              resolverKind = [ "recursive" ];
+              useNetworkd = [
+                true
+                false
+              ];
+              useNftables = [
+                true
+                false
+              ];
+            };
+          }
+        ]
+      );
+  };
+
+  nixos.demo.vm = {
+    module = ./services/dnsvizor/examples/recursive-dns-resolver.nix;
+    module-demo = ./demo/module-demo.nix;
+    usage-instructions = [
+      {
+        instruction = ''
+          Visit <https://127.0.0.1:4443> in your browser.  This is a web interface of DNSvizor.
+
+          You'll see a warning of potential security risk.
+          Rest assured.
+          This is because DNSvizor uses a self-signed certification.
+
+          Accept the risk and continue.
+        '';
+      }
+      {
+        instruction = ''
+          In the demo VM terminal, run this to send DNS queries to DNSvizor (`10.0.0.2`):
+
+          ```shellSession
+          $ q --verbose www.example.com A @10.0.0.2
+          ```
+
+          If the query timeouts, re-run the command to query again.
+        '';
+      }
+      {
+        instruction = ''
+          You can also use an IPv6 address for DNSvizor (`fdc9:281f:4d7:9ee9::2`):
+
+          ```shellSession
+          $ q --verbose www.example.com A @fdc9:281f:4d7:9ee9::2
+          ```
+        '';
+      }
+      {
+        instruction = ''
+          You can also use a domain name for DNSvizor (`dnsvizor.mydomain.example`):
+
+          ```shellSession
+          $ q --verbose www.example.com A @dnsvizor.mydomain.example
+          ```
+        '';
+      }
+      {
+        instruction = ''
+          Send encrypted DNS queries using `DNS-over-TLS`:
+
+          ```shellSession
+          $ q --verbose www.example.com A @tls://dnsvizor.mydomain.example
+          ```
+
+          You'll see an error telling you that certification verification failed.
+          This is because DNSvizor uses a self-signed certification, which is not trusted by default.
+          You can ignore that error by adding `--tls-insecure-skip-verify`:
+
+          ```shellSession
+          $ q --verbose --tls-insecure-skip-verify www.example.com A @tls://dnsvizor.mydomain.example
+          ```
+        '';
+      }
+      {
+        instruction = ''
+          Let's show you how to trust that self-signed certification of DNSvizor.
+
+          First, we extract that certification using `curl`.
+
+          ```shellSession
+          $ curl --write-out %{certs} https://dnsvizor.mydomain.example > /tmp/self-signed-cert.pem
+          ```
+
+          Then we setting environment variable `SSL_CERT_FILE` before running `q`.
+
+          ```shellSession
+          $ SSL_CERT_FILE=/tmp/self-signed-cert.pem q --verbose www.example.com A @tls://dnsvizor.mydomain.example
+          ```
+        '';
+      }
+      {
+        instruction = ''
+          Send encrypted DNS queries using `DNS-over-HTTPS`:
+
+          ```shellSession
+          $ SSL_CERT_FILE=/tmp/self-signed-cert.pem q --verbose www.example.com A @https://dnsvizor.mydomain.example
+          ```
+        '';
+      }
+      {
+        instruction = ''
+          Go back to the [Dashboard](https://127.0.0.1:4443/dashboard) page, you should see those numbers, such as `Total queries`, have changed.
+        '';
+      }
+      {
+        instruction = ''
+          Go to the [Query log](https://127.0.0.1:4443/querylog) page, you should see domains you just queried.
+        '';
+      }
+      {
+        instruction = ''
+          DNSvizor supports blocking DNS resolution for some domains.
+          You can specify them as boot parameters.
+
+          Go to the [Blocklist](https://127.0.0.1:4443/blocklist) page.
+          Enter the password `password`.
+          User can be anything you like.
+          You can see some blocked domains we already specified.
+
+          Query one of them:
+
+          ```shellSession
+          $ q --verbose --format raw block1.cli.example.com A @dnsvizor.mydomain.example
+          ```
+
+          You should see `status: NXDOMAIN` and `ANSWER: 0` in the output.
+          This means there is no answer to your DNS query.
+          You should also see `appears in blocklist boot-parameter` in the output.
+        '';
+      }
+      {
+        instruction = ''
+          Blocked domains can also be specified using URLs.
+          DNSvizor will fetch them using those URLs.
+
+          Go to the [Blocklist](https://127.0.0.1:4443/blocklist) page, you can see some blocked domain lists we already specified.
+
+          Query one of them:
+
+          ```shellSession
+          $ q --verbose --format raw block1.url.example.com A @dnsvizor.mydomain.example
+          ```
+
+          You should see `status: NXDOMAIN` and `ANSWER: 0` in the output.
+          You should also see `appears in blocklist http://10.0.0.1/block-list-4` in the output.
+        '';
+      }
+      {
+        instruction = ''
+          In the [Blocklist](https://127.0.0.1:4443/blocklist) page, you can also add or delete blocked domains.
+
+          Add one, query it and check the result.
+
+          You should see a similar output as before.  But this time, it shows `appears in blocklist web-ui`.
+
+          Delete the domain you just added, query it and check the result.
+
+          You should see the normal result again.
+        '';
+      }
+      {
+        instruction = ''
+          Now go back to the [Dashboard](https://127.0.0.1:4443/dashboard) page, you should see the number of "Queries blocked" has changed.
+        '';
+      }
+    ];
+    tests.dns-dualstack-recursive.module = import ./services/dnsvizor/tests/dns.nix (
+      args
+      // {
+        exampleName = "Enable DNSvizor as a dual-stack recursive DNS resolver";
+        resolverKind = "recursive";
+        useNetworkd = false;
+        useNftables = false;
+      }
+    );
+    inherit problem;
+    links = { inherit webInterfaceManual; };
+  };
+}

--- a/projects/DNSvizor/demo/module-demo.nix
+++ b/projects/DNSvizor/demo/module-demo.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.dnsvizor;
+  quoteIpv6 = ipv6: "[${ipv6}]";
+in
+{
+  config = lib.mkIf cfg.enable {
+    services.dnsvizor = {
+      mainInterface = lib.mkForce "eth0"; # mkForce because already set in the example module
+      openFirewall = true;
+    };
+
+    networking.hosts = lib.optionalAttrs (cfg.settings.hostname != null) (
+      {
+        ${cfg.ipv4Prefix} = [ cfg.settings.hostname ];
+      }
+      // lib.optionalAttrs cfg.ipv6Enabled {
+        ${cfg.ipv6Prefix} = [ cfg.settings.hostname ];
+      }
+    );
+
+    environment.systemPackages = [
+      pkgs.q # DNS query tool
+    ];
+
+    virtualisation.forwardPorts = lib.optionals (!cfg.settings.no-tls) ([
+      {
+        from = "host";
+        host.port = 4443; # non-privileged port
+        guest.port = cfg.settings.https-port;
+        proto = "tcp";
+      }
+    ]);
+
+    services.caddy = {
+      enable = true;
+      virtualHosts.dnsBlockLists = {
+        hostName = "http://";
+        extraConfig =
+          let
+            dnsBlockList4 = pkgs.writeTextDir "block-list-4" ''
+              block1.url.example.com
+              block2.url.example.com
+            '';
+            dnsBlockList6 = pkgs.writeTextDir "block-list-6" ''
+              block3.url.example.com
+              block4.url.example.com
+            '';
+            dnsBlockListDir = pkgs.symlinkJoin {
+              name = "dns-block-lists";
+              paths = [
+                dnsBlockList4
+                dnsBlockList6
+              ];
+            };
+          in
+          ''
+            root ${dnsBlockListDir}
+            file_server
+          '';
+        logFormat = ""; # let systemd also handle access log
+      };
+      logFormat = "level INFO";
+    };
+    systemd.services.dnsvizor = {
+      wants = [ "caddy.service" ];
+      after = [ "caddy.service" ];
+    };
+  };
+}

--- a/projects/DNSvizor/services/dnsvizor/examples/recursive-dns-resolver.nix
+++ b/projects/DNSvizor/services/dnsvizor/examples/recursive-dns-resolver.nix
@@ -1,0 +1,30 @@
+{ ... }:
+
+{
+  services.dnsvizor = {
+    enable = true;
+    memory = 128;
+    mainInterface = "enp1s0";
+    settings = {
+      hostname = "dnsvizor.mydomain.example";
+      ipv4 = "10.0.0.2/24";
+      ipv4-gateway = "10.0.0.1";
+      ipv6 = "fdc9:281f:4d7:9ee9::2/64";
+      ipv6-gateway = "fdc9:281f:4d7:9ee9::1";
+      ca-seed = "Te9ffyY3Clcaz/4P7eFLyZQfLWIz/fSSK4NDb8THMDc=";
+      password = "password";
+      dns-block = [
+        "block1.cli.example.com"
+        "block2.cli.example.com"
+      ];
+      dns-blocklist-url = [
+        "http://10.0.0.1/block-list-4"
+        "http://[fdc9:281f:4d7:9ee9::1]:80/block-list-6"
+        "https://example.com/non-existent-block-list"
+      ];
+      qname-minimisation = true;
+      opportunistic-tls-authoritative = true;
+    };
+    openFirewall = true;
+  };
+}

--- a/projects/DNSvizor/services/dnsvizor/examples/stub-dns-resolver.nix
+++ b/projects/DNSvizor/services/dnsvizor/examples/stub-dns-resolver.nix
@@ -1,0 +1,25 @@
+{ ... }:
+
+{
+  services.dnsvizor = {
+    enable = true;
+    memory = 128;
+    mainInterface = "enp1s0";
+    settings = {
+      ipv4 = "10.0.0.2/24";
+      ipv4-gateway = "10.0.0.1";
+      ipv4-only = "true";
+      ca-seed = "Te9ffyY3Clcaz/4P7eFLyZQfLWIz/fSSK4NDb8THMDc=";
+      password = "password";
+      dns-block = [
+        "block1.cli.example.com"
+        "block2.cli.example.com"
+      ];
+      dns-blocklist-url = [
+        "http://10.0.0.1/block-list"
+        "https://example.com/non-existent-block-list"
+      ];
+      dns-upstream = "tls:1.1.1.1";
+    };
+  };
+}

--- a/projects/DNSvizor/services/dnsvizor/module.nix
+++ b/projects/DNSvizor/services/dnsvizor/module.nix
@@ -1,0 +1,457 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+
+# TODO(linj) implement and test DHCP
+#   - run dnsvizor as a DHCP server
+#   - update DNS record in the authoritative DNS server when DHCP ip changes
+#   - update config for tlstunnel mirageos unikernel when DHCP ip changes
+#     - need to add module (and package) for tlstunnel unikernel first, which itself is a complex project
+# TODO(linj) implement and test --ipv6-only: currently we assume ipv4 is always there and have implemented/tested --ipv4-only and dual stack configs
+#   - dnsvizor always has a default value for --ipv4 (but not ipv4-gateway?), seems conflict with --ipv6-only.  is --ipv6-only even supported by dnsvizor?
+# TODO(linj) test DNSSEC (is that even possible?)
+
+let
+  cfg = config.services.dnsvizor;
+  moreDoc = ''
+    See [upstream online documentation](https://robur-coop.github.io/dnsvizor-handbook/dnsvizor_options.html) for more information.
+    Setting {option}`services.dnsvizor.settings.help` shows the help message locally at runtime.
+  '';
+  secretWarning = ''
+    ::: {.warning}
+    This secret will be copied into the nix store in clear text.
+    :::
+  '';
+  allowedUDPPorts = [ 53 ];
+  allowedTCPPorts = [
+    53
+  ]
+  ++ lib.optionals (!cfg.settings.no-tls) [
+    cfg.settings.https-port
+    853
+  ];
+  onlyOneIsNull = x: y: x == null && y != null || x != null && y == null;
+  unikernelInterfaceSystemdUnit = "sys-subsystem-net-devices-${utils.escapeSystemdPath cfg.unikernelInterface}.device";
+  quote = x: ''"${x}"'';
+in
+{
+  options.services.dnsvizor = {
+    enable = lib.mkEnableOption "dnsvizor";
+
+    package = lib.mkPackageOption pkgs "dnsvizor (hvt target)" {
+      default = [
+        "dnsvizor"
+        "hvt"
+      ];
+      extraDescription = "We assume dnsvizor.hvt exists at the root dir of the package.";
+    };
+
+    memory = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 512;
+      description = "Memory limit of the unikernel in MB.";
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = lib.types.attrsOf (
+          lib.types.nullOr (
+            lib.types.oneOf [
+              lib.types.bool
+              lib.types.str
+              (lib.types.listOf lib.types.str)
+            ]
+          )
+        );
+        options = {
+          ipv4 = lib.mkOption {
+            type = lib.types.str;
+            default = "10.0.0.2/24";
+            description = ''
+              IPv4 network address and prefix length for the unikernel.  ${moreDoc}
+            '';
+          };
+          ipv4-gateway = lib.mkOption {
+            type = lib.types.str;
+            default = "10.0.0.1";
+            description = "IPv4 gateway of the unikernel.  ${moreDoc}";
+          };
+          ipv4-only = lib.mkOption {
+            type = lib.types.nullOr (
+              lib.types.enum [
+                "true"
+                "false"
+              ]
+            );
+            default = null;
+            example = "true";
+            description = "Only use IPv4 for the unikernel.  ${moreDoc}";
+          };
+          ipv6 = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            description = ''
+              IPv6 network address and prefix length for the unikernel.  ${moreDoc}
+            '';
+          };
+          ipv6-gateway = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            description = "IPv6 gateway of the unikernel.  ${moreDoc}";
+          };
+          ipv6-only = lib.mkOption {
+            type = lib.types.nullOr (
+              lib.types.enum [
+                "true"
+                "false"
+              ]
+            );
+            default = null;
+            example = "true";
+            description = "Only use IPv6 for the unikernel.  ${moreDoc}";
+          };
+          # TODO handle secrets better: https://github.com/robur-coop/dnsvizor/issues/117
+          ca-seed = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            example = "Te9ffyY3Clcaz/4P7eFLyZQfLWIz/fSSK4NDb8THMDc=";
+            description = ''
+              The seed (base64 encoded) used to generate the private key for the certificate.
+              ${moreDoc}
+
+              ${secretWarning}
+            '';
+          };
+          # TODO handle secrets better: https://github.com/robur-coop/dnsvizor/issues/117
+          password = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            example = "passwordWithOne\\ space";
+            description = ''
+              Password used for authentication.  ${moreDoc}
+
+              ::: {.tip}
+              The space character needs to be escaped with `\\`.
+              :::
+
+              ${secretWarning}
+            '';
+          };
+          dns-upstream = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            example = "tls:1.1.1.1";
+            description = ''
+              Upstream DNS resolver.
+              By default, it runs as a recursive DNS resolver.
+              If this is specified, it runs as a stub DNS resolver instead.
+              ${moreDoc}
+            '';
+          };
+          hostname = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            example = "dnsvizor.mydomain.example";
+            description = ''
+              The hostname (SNI for the certificate, entry in DNS) of the unikernel.
+              ${moreDoc}
+            '';
+          };
+          dns-block = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            default = [ ];
+            example = [
+              "block1.cli.example.com"
+              "block2.cli.example.com"
+            ];
+            description = "Domains to block.  ${moreDoc}";
+          };
+          dns-blocklist-url = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            default = [ ];
+            example = [
+              "http://10.0.0.1/block-list-4"
+              "http://[fdc9:281f:4d7:9ee9::1]:80/block-list-6"
+              "https://example.com/non-existent-block-list"
+            ];
+            description = "Web addresses to fetch DNS block lists from.  ${moreDoc}";
+          };
+          qname-minimisation = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            example = true;
+            description = "Use qname minimisation (RFC 9156).  ${moreDoc}";
+          };
+          opportunistic-tls-authoritative = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            example = true;
+            description = ''
+              Use opportunistic TLS from recursive resolver to authoriative (RFC 9539).
+              ${moreDoc}
+            '';
+          };
+          https-port = lib.mkOption {
+            type = lib.types.port;
+            default = 443;
+            description = "The HTTPS port.  ${moreDoc}";
+          };
+          no-tls = lib.mkOption {
+            type = lib.types.bool;
+            default = cfg.settings.ca-seed == null;
+            defaultText = lib.literalExpression ''
+              config.services.dnsvizor.settings.ca-seed == null
+            '';
+            example = true;
+            description = ''
+              Disable TLS: web interface and DNS-over-TLS/DNS-over-HTTPS.
+              ${moreDoc}
+            '';
+          };
+          no-hosts = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            example = true;
+            description = ''
+              Don't read the synthesized /etc/hosts which contains only
+              {option}`services.dnsvizor.hostname`.
+              ${moreDoc}
+            '';
+          };
+          help = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            example = true;
+            description = "Show help instead of running the unikernel.  ${moreDoc}";
+          };
+        };
+      };
+      default = { };
+      description = "Configuration for the unikernel.  ${moreDoc}";
+    };
+
+    mainInterface = lib.mkOption {
+      type = lib.types.str;
+      example = "enp4s0";
+      description = "The main network interface of the host.";
+    };
+
+    openFirewall = lib.mkEnableOption "opening ports in the firewall for dnsvizor";
+
+    packetForwardingIsSecure = lib.mkOption {
+      type = lib.types.bool;
+      default = config.networking.firewall.enable && config.networking.firewall.filterForward;
+      defaultText = lib.literalExpression ''
+        config.networking.firewall.enable && config.networking.firewall.filterForward
+      '';
+      description = ''
+        Whether efforts have been taken to make sure packet forwarding is secure.
+      '';
+    };
+
+    unikernelInterface =
+      let
+        maxLength = 16; # see IFNAMSIZ of linux kernel
+      in
+      lib.mkOption {
+        type = lib.types.addCheck lib.types.str (s: lib.stringLength s < maxLength);
+        default = "tap-unikernel";
+        internal = true;
+        visible = false;
+        description = ''
+          The TAP interface used by the unikernel.
+          Its length should be less than ${builtins.toString maxLength}.
+        '';
+      };
+    ipv4Prefix = lib.mkOption {
+      type = lib.types.str;
+      default = lib.elemAt (lib.splitString "/" cfg.settings.ipv4) 0;
+      defaultText = lib.literalExpression ''
+        lib.elemAt (lib.splitString "/" config.services.dnsvizor.settings.ipv4) 0
+      '';
+      example = "10.0.0.2";
+      internal = true;
+      visible = false;
+      readOnly = true;
+      description = "The prefix of {option}`services.dnsvizor.settings.ipv4`.";
+    };
+    ipv4Suffix = lib.mkOption {
+      type = lib.types.str;
+      default = lib.elemAt (lib.splitString "/" cfg.settings.ipv4) 1;
+      defaultText = lib.literalExpression ''
+        lib.elemAt (lib.splitString "/" config.services.dnsvizor.settings.ipv4) 1
+      '';
+      example = "24";
+      internal = true;
+      visible = false;
+      readOnly = true;
+      description = "The suffix of {option}`services.dnsvizor.settings.ipv4`.";
+    };
+    ipv6Prefix = lib.mkOption {
+      type = lib.types.str;
+      default = lib.elemAt (lib.splitString "/" cfg.settings.ipv6) 0;
+      defaultText = lib.literalExpression ''
+        lib.elemAt (lib.splitString "/" config.services.dnsvizor.settings.ipv6) 0
+      '';
+      internal = true;
+      visible = false;
+      readOnly = true;
+      description = "The prefix of {option}`services.dnsvizor.settings.ipv6`.";
+    };
+    ipv6Suffix = lib.mkOption {
+      type = lib.types.str;
+      default = lib.elemAt (lib.splitString "/" cfg.settings.ipv6) 1;
+      defaultText = lib.literalExpression ''
+        lib.elemAt (lib.splitString "/" config.services.dnsvizor.settings.ipv6) 1
+      '';
+      internal = true;
+      visible = false;
+      readOnly = true;
+      description = "The suffix of {option}`services.dnsvizor.settings.ipv6`.";
+    };
+    ipv6Enabled = lib.mkOption {
+      type = lib.types.bool;
+      default = cfg.settings.ipv6 != null && cfg.settings.ipv4-only != "true";
+      defaultText = lib.literalExpression ''
+        config.services.dnsvizor.settings.ipv6 != null && config.services.dnsvizor.settings.ipv4-only != "true";
+      '';
+      internal = true;
+      visible = false;
+      readOnly = true;
+      description = "Whether IPv6 is enabled.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.dnsvizor = {
+      description = "dnsvizor recursive/stub DNS resolver and DHCP server";
+      documentation = [ "https://robur-coop.github.io/dnsvizor-handbook/" ];
+      wantedBy = [ "multi-user.target" ];
+      bindsTo = [ unikernelInterfaceSystemdUnit ];
+      after = [ unikernelInterfaceSystemdUnit ];
+      serviceConfig = {
+        ExecStart = ''
+          ${lib.getExe' pkgs.solo5 "solo5-hvt"} \
+            --mem=${builtins.toString cfg.memory} \
+            --net:service=${utils.escapeSystemdExecArg cfg.unikernelInterface} \
+            -- \
+            ${cfg.package}/dnsvizor.hvt \
+            ${utils.escapeSystemdExecArgs (lib.cli.toCommandLineGNU { } cfg.settings)}
+        '';
+        Restart = "on-failure";
+
+        # hardening
+        CapabilityBoundingSet = [ "" ];
+        DeviceAllow = [
+          "/dev/kvm rw"
+          "/dev/net/tun rw"
+        ];
+        DevicePolicy = "closed";
+        DynamicUser = true;
+        MemoryDenyWriteExecute = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        RestrictAddressFamilies = [ "AF_NETLINK" ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        SystemCallArchitectures = [ "native" ];
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@resources"
+        ];
+        SystemCallErrorNumber = "EPERM";
+        UMask = "0077";
+      };
+    };
+
+    networking.interfaces.${cfg.unikernelInterface} = {
+      virtual = true;
+      virtualType = "tap";
+      virtualOwner = null;
+      ipv4.addresses = [
+        {
+          address = cfg.settings.ipv4-gateway;
+          prefixLength = lib.toInt cfg.ipv4Suffix;
+        }
+      ];
+      ipv6.addresses = lib.optionals cfg.ipv6Enabled [
+        {
+          address = cfg.settings.ipv6-gateway;
+          prefixLength = lib.toInt cfg.ipv6Suffix;
+        }
+      ];
+    };
+
+    networking.nat = {
+      enable = true;
+      enableIPv6 = cfg.ipv6Enabled;
+      externalInterface = cfg.mainInterface;
+      internalInterfaces = [ cfg.unikernelInterface ];
+      forwardPorts =
+        let
+          mkRules =
+            proto: destinationIp:
+            map (port: {
+              destination = "${destinationIp}:${builtins.toString port}";
+              sourcePort = port;
+              inherit proto;
+            });
+          quoteIpv6 = ipv6: "[${ipv6}]";
+        in
+        mkRules "udp" cfg.ipv4Prefix allowedUDPPorts
+        ++ mkRules "tcp" cfg.ipv4Prefix allowedTCPPorts
+        ++ lib.optionals cfg.ipv6Enabled (
+          mkRules "udp" (quoteIpv6 cfg.ipv6Prefix) allowedUDPPorts
+          ++ mkRules "tcp" (quoteIpv6 cfg.ipv6Prefix) allowedTCPPorts
+        );
+    };
+
+    networking.firewall = {
+      filterForward = config.networking.nftables.enable; # this option lacks iptables impl
+      extraForwardRules = ''
+        ip saddr ${cfg.ipv4Prefix} iifname ${quote cfg.unikernelInterface} oifname ${quote cfg.mainInterface} accept
+        ${lib.optionalString cfg.ipv6Enabled "ip6 saddr ${cfg.ipv6Prefix} iifname ${quote cfg.unikernelInterface} oifname ${quote cfg.mainInterface} accept"}
+      '';
+    }
+    // lib.optionalAttrs cfg.openFirewall {
+      inherit allowedUDPPorts allowedTCPPorts;
+    };
+
+    assertions = [
+      {
+        assertion = !cfg.settings.no-tls -> cfg.settings.ca-seed != null;
+        message = "Set services.dnsvizor.settings.ca-seed if services.dnsvizor.settings.no-tls is not set.";
+      }
+      {
+        assertion = !(onlyOneIsNull cfg.settings.ipv6 cfg.settings.ipv6-gateway);
+        message = "services.dnsvizor.settings.{ipv6,ipv6-gateway} must be set together.";
+      }
+      {
+        assertion = cfg.settings.ipv6-only != "true";
+        message = "services.dnsvizor.settings.ipv6-only has not been implemented.";
+      }
+    ];
+
+    # TODO implement networking.firewall.filterForward for iptables in Nixpkgs.  then we can remove this warning
+    warnings = lib.optional (!cfg.packetForwardingIsSecure) ''
+      services.dnsvizor module enables packet forwarding.
+      A properly configured firewall or a trusted L2 on all network interfaces is required to prevent unauthorized access to the internal network.
+      A simple firewall will be added and configured for dnsvizor if you enable networking.firewall.enable, networking.firewall.filterForward and networking.nftables.enable.
+      If you build your own firewall, allow packets from ${cfg.unikernelInterface} to ${cfg.mainInterface}.
+      After a firewall is set up, set services.dnsvizor.packetForwardingIsSecure to true to disable this warning.
+    '';
+  };
+}

--- a/projects/DNSvizor/services/dnsvizor/tests/dns.nix
+++ b/projects/DNSvizor/services/dnsvizor/tests/dns.nix
@@ -1,0 +1,556 @@
+# To test dnsvizor running as a recursive DNS resolver, we setup a
+# root DNS server, a TLD DNS server and an authoritative DNS server.
+# To let dnsvizor query our root DNS server instead of real root DNS
+# servers, we set IPs of our root DNS server to real ones and add
+# routes to dnsvizor for those IPs.
+
+# To test dnsvizor running as a stub DNS resolver, we forward its
+# query to another DNS server, which typically should be a recursive
+# DNS resolver in production.  For simplicity, we forward dnsvizor
+# queries to the authoritative DNS server we setup in the recursive
+# DNS resolver test.
+
+# When cfg.openFirewall, we query dnsvizor DNS resolver from another
+# machine.  Otherwise, we query from the same machine running the
+# resolver.
+
+# IPv6 is preferred/tested when dnsvizor enables both IPv4 and IPv6.
+
+{
+  lib,
+  sources,
+  exampleName,
+  resolverKind,
+  useNetworkd,
+  useNftables,
+  ...
+}:
+
+assert builtins.elem resolverKind [
+  "stub"
+  "recursive"
+];
+assert builtins.isBool useNetworkd;
+assert builtins.isBool useNftables;
+
+let
+  # explicitly set vlan in two ways of network config (virtualisation.interfaces and virtualisation.vlans) to make sure all nodes are in the same vlan
+  vlan = 1;
+
+  commonDnsServerModule = {
+    services.knot = {
+      enable = true;
+      settings = {
+        server = {
+          listen = [ "0.0.0.0@53" ];
+        };
+        log.syslog.any = "info";
+        template.default = {
+          semantic-checks = true;
+        };
+      };
+    };
+    networking.firewall = {
+      allowedUDPPorts = [
+        53
+      ];
+      allowedTCPPorts = [
+        53
+        853 # openning it can speed up tests with opportunistic-tls-authoritative
+      ];
+    };
+  };
+
+  commonDnsResolverModule =
+    {
+      pkgs,
+      lib,
+      config,
+      ...
+    }:
+    let
+      cfg = config.services.dnsvizor;
+    in
+    {
+      imports = [
+        sources.modules.ngipkgs
+        sources.modules.services.dnsvizor
+      ];
+
+      virtualisation.interfaces.${cfg.mainInterface} = {
+        inherit vlan;
+        assignIP = true;
+      };
+
+      services.dnsvizor = {
+        settings = {
+          dns-blocklist-url =
+            let
+              ipAndFiles = [
+                {
+                  authority = cfg.settings.ipv4-gateway;
+                  path = "/dns-block-4";
+                }
+              ]
+              ++ lib.optional cfg.ipv6Enabled {
+                # dnsvizor errors without a port
+                authority = "${quoteIpv6 cfg.settings.ipv6-gateway}:80";
+                path = "/dns-block-6";
+              };
+              mkAddress = { authority, path }: "http://${authority}${path}";
+            in
+            lib.mkForce (map mkAddress ipAndFiles); # mkForce because already set in example
+        };
+      };
+
+      services.caddy = {
+        enable = true;
+        virtualHosts.dnsBlockLists = {
+          hostName = "http://";
+          extraConfig =
+            let
+              dnsBlockList4 = pkgs.writeTextDir "dns-block-4" ''
+                block1.url.example.com
+                block2.url.example.com
+              '';
+              dnsBlockList6 = pkgs.writeTextDir "dns-block-6" ''
+                block3.url.example.com
+                block4.url.example.com
+              '';
+              dnsBlockListDir = pkgs.symlinkJoin {
+                name = "dns-block-lists";
+                paths = [
+                  dnsBlockList4
+                  dnsBlockList6
+                ];
+              };
+            in
+            ''
+              root ${dnsBlockListDir}
+              file_server
+            '';
+          logFormat = ""; # let systemd also handle access log
+        };
+        logFormat = "level INFO";
+      };
+      networking.firewall.trustedInterfaces = [ cfg.unikernelInterface ];
+      systemd.services.dnsvizor = {
+        wants = [ "caddy.service" ];
+        after = [ "caddy.service" ];
+      };
+
+      networking.hosts = lib.optionalAttrs (cfg.settings.hostname != null) (
+        {
+          ${cfg.ipv4Prefix} = [ cfg.settings.hostname ];
+        }
+        // lib.optionalAttrs cfg.ipv6Enabled {
+          ${cfg.ipv6Prefix} = [ cfg.settings.hostname ];
+        }
+      );
+
+      networking = {
+        inherit useNetworkd;
+        nftables.enable = useNftables;
+      };
+
+      environment.systemPackages = [ pkgs.q ]; # DNS query tool used in testScript
+    };
+
+  rootDnsServerRealIpv4s = [
+    "198.41.0.4"
+    "170.247.170.2"
+    "192.33.4.12"
+    "199.7.91.13"
+    "192.203.230.10"
+    "192.5.5.241"
+    "192.112.36.4"
+    "198.97.190.53"
+    "192.36.148.17"
+    "192.58.128.30"
+    "193.0.14.129"
+    "199.7.83.42"
+    "202.12.27.33"
+  ];
+  rootDnsServerRealIpv6s = [
+    "2001:503:ba3e::2:30"
+    "2801:1b8:10::b"
+    "2001:500:2::c"
+    "2001:500:2d::d"
+    "2001:500:a8::e"
+    "2001:500:2f::f"
+    "2001:500:12::d0d"
+    "2001:500:1::53"
+    "2001:7fe::53"
+    "2001:503:c27::2:30"
+    "2001:7fd::1"
+    "2001:500:9f::42"
+    "2001:dc3::35"
+  ];
+
+  getIpv4 = node: node.networking.primaryIPAddress;
+  getIpv6 = node: node.networking.primaryIPv6Address;
+
+  quote = x: ''"${x}"'';
+  quoteIpv6 = ipv6: "[${ipv6}]";
+in
+{
+  name = "DNSvizor";
+
+  nodes = {
+    rootDnsServer =
+      { pkgs, nodes, ... }:
+      let
+        interface = "enp3s0";
+      in
+      {
+        imports = [ commonDnsServerModule ];
+
+        virtualisation.interfaces.${interface} = {
+          inherit vlan;
+          assignIP = true;
+        };
+
+        # emulate root dns resolver
+        networking.interfaces.${interface} = lib.mkIf (resolverKind == "recursive") {
+          ipv4.addresses = lib.forEach rootDnsServerRealIpv4s (address: {
+            inherit address;
+            prefixLength = 32;
+          });
+          ipv6.addresses = lib.forEach rootDnsServerRealIpv6s (address: {
+            inherit address;
+            prefixLength = 128;
+          });
+        };
+
+        services.knot.settings.zone.".".file = pkgs.writeText "zone" ''
+          @ SOA a.root-servers.net. nstld.verisign-grs.com. 2026010900 1800 900 604800 86400
+          @ NS a.root-servers.net
+          a.root-servers.net A 198.41.0.4
+          a.root-servers.net AAAA 2001:503:ba3e::2:30
+          com NS a.tld-servers.com
+          a.tld-servers.com A ${getIpv4 nodes.tldDnsServer}
+          a.tld-servers.com AAAA ${getIpv6 nodes.tldDnsServer}
+        '';
+      };
+
+    tldDnsServer =
+      { pkgs, nodes, ... }:
+      {
+        imports = [ commonDnsServerModule ];
+
+        virtualisation.vlans = [ vlan ];
+
+        services.knot.settings.zone."com".file = pkgs.writeText "zone" ''
+          @ SOA a.tld-servers.com. hostmaster.tld-servers.com. 1501732 900 1800 6048000 3600
+          @ NS a.tld-servers
+          a.tld-servers A ${getIpv4 nodes.tldDnsServer}
+          a.tld-servers AAAA ${getIpv6 nodes.tldDnsServer}
+          example NS ns1.example
+          ns1.example A ${getIpv4 nodes.authoritativeDnsServer}
+          ns1.example AAAA ${getIpv6 nodes.authoritativeDnsServer}
+        '';
+      };
+
+    authoritativeDnsServer =
+      { pkgs, nodes, ... }:
+      {
+        imports = [ commonDnsServerModule ];
+
+        virtualisation.vlans = [ vlan ];
+
+        services.knot.settings.zone."example.com".file = pkgs.writeText "zone" ''
+          @ SOA ns1.example.com. hostmaster.example.com. 2019031301 86400 7200 3600000 172800
+          @ NS ns1
+          ns1 A ${getIpv4 nodes.authoritativeDnsServer}
+          ns1 AAAA ${getIpv6 nodes.authoritativeDnsServer}
+          www A 192.168.4.1
+          www AAAA 2001:db8::1
+          block1.cli A 192.168.5.1
+          block2.cli A 192.168.5.2
+          block1.url A 192.168.6.1
+          block2.url A 192.168.6.2
+          block3.url A 192.168.6.3
+          block4.url A 192.168.6.4
+        '';
+      };
+
+    dnsResolver =
+      {
+        lib,
+        nodes,
+        config,
+        ...
+      }:
+      let
+        cfg = config.services.dnsvizor;
+      in
+      {
+        imports = [
+          commonDnsResolverModule
+          sources.examples.DNSvizor.${exampleName}
+        ];
+
+        # emulate root dns resolver
+        networking.interfaces.${cfg.mainInterface} = lib.mkIf (resolverKind == "recursive") {
+          ipv4.routes = lib.forEach rootDnsServerRealIpv4s (address: {
+            inherit address;
+            prefixLength = 32;
+            via = getIpv4 nodes.rootDnsServer;
+          });
+          ipv6.routes = lib.forEach rootDnsServerRealIpv6s (address: {
+            inherit address;
+            prefixLength = 128;
+            via = getIpv6 nodes.rootDnsServer;
+          });
+        };
+
+        services.dnsvizor = {
+          settings.dns-upstream =
+            let
+              ip =
+                if cfg.ipv6Enabled then
+                  quoteIpv6 (getIpv6 nodes.authoritativeDnsServer)
+                else
+                  getIpv4 nodes.authoritativeDnsServer;
+            in
+            # mkForce because already set in example
+            lib.mkIf (resolverKind == "stub") (lib.mkForce "udp:${ip}");
+        };
+      };
+
+    dnsClient =
+      { pkgs, nodes, ... }:
+      let
+        inherit (nodes) dnsResolver;
+        dnsResolverCfg = dnsResolver.services.dnsvizor;
+      in
+      {
+        virtualisation.vlans = [ vlan ];
+
+        environment.systemPackages = [ pkgs.q ]; # DNS query tool used in testScript
+
+        networking.hosts = lib.optionalAttrs (dnsResolverCfg.settings.hostname != null) (
+          {
+            ${getIpv4 dnsResolver} = [ dnsResolverCfg.settings.hostname ];
+          }
+          // lib.optionalAttrs dnsResolverCfg.ipv6Enabled {
+            ${getIpv6 dnsResolver} = [ dnsResolverCfg.settings.hostname ];
+          }
+        );
+      };
+  };
+
+  testScript =
+    { nodes, ... }:
+    let
+      inherit (nodes) dnsResolver;
+      dnsResolverCfg = dnsResolver.services.dnsvizor;
+      dnsResolverIpv4ForQuery =
+        if dnsResolverCfg.openFirewall then getIpv4 dnsResolver else dnsResolverCfg.ipv4Prefix;
+      dnsResolverIpv6ForQuery =
+        if dnsResolverCfg.openFirewall then getIpv6 dnsResolver else dnsResolverCfg.ipv6Prefix;
+      protocolPorts = [
+        {
+          protocol = "plain";
+          port = 53;
+        }
+      ]
+      ++ lib.optionals (!dnsResolverCfg.settings.no-tls) [
+        {
+          protocol = "tls";
+          port = 853;
+        }
+        {
+          protocol = "https";
+          port = dnsResolverCfg.settings.https-port;
+        }
+      ];
+      mkPythonCollection =
+        leftMark: rightMark:
+        lib.flip lib.pipe [
+          (lib.concatStringsSep ", ")
+          (x: "${leftMark} ${x} ${rightMark}")
+        ];
+      # [{name :: string, value :: string}] -> PythonDict
+      mkPythonDict = lib.flip lib.pipe [
+        (map ({ name, value }: "${name}: ${value}"))
+        (mkPythonCollection "{" "}")
+      ];
+      protocolPortsPython =
+        let
+          mkPair = { protocol, port }: lib.nameValuePair (quote protocol) (builtins.toString port);
+        in
+        mkPythonDict (map mkPair protocolPorts);
+      dnsResolverIpOrDomains = [
+        dnsResolverIpv4ForQuery
+      ]
+      ++ lib.optional dnsResolverCfg.ipv6Enabled (quoteIpv6 dnsResolverIpv6ForQuery)
+      ++ lib.optional (dnsResolverCfg.settings.hostname != null) dnsResolverCfg.settings.hostname;
+      # [string] -> PythonList
+      mkPythonList = mkPythonCollection "[" "]";
+      dnsResolverIpOrDomainsPython = mkPythonList (map quote dnsResolverIpOrDomains);
+      dnsQueryAndExpectedAnswers = [
+        {
+          query = "www.example.com";
+          queryType = "A";
+          expectedAnswer = "192.168.4.1";
+        }
+        {
+          query = "www.example.com";
+          queryType = "AAAA";
+          expectedAnswer = "2001:db8::1";
+        }
+        {
+          query = "block1.cli.example.com";
+          queryType = "A";
+          expectedAnswer = null;
+        }
+        {
+          query = "block2.cli.example.com";
+          queryType = "A";
+          expectedAnswer = null;
+        }
+        {
+          query = "block1.url.example.com";
+          queryType = "A";
+          expectedAnswer = null;
+        }
+        {
+          query = "block2.url.example.com";
+          queryType = "A";
+          expectedAnswer = null;
+        }
+      ]
+      ++ lib.optionals dnsResolverCfg.ipv6Enabled [
+        {
+          query = "block3.url.example.com";
+          queryType = "A";
+          expectedAnswer = null;
+        }
+        {
+          query = "block4.url.example.com";
+          queryType = "A";
+          expectedAnswer = null;
+        }
+      ]
+      ++ lib.optionals (dnsResolverCfg.settings.hostname != null && !dnsResolverCfg.settings.no-hosts) (
+        [
+          {
+            query = dnsResolverCfg.settings.hostname;
+            queryType = "A";
+            expectedAnswer = dnsResolverCfg.ipv4Prefix;
+          }
+        ]
+        ++ lib.optionals dnsResolverCfg.ipv6Enabled [
+          {
+            query = dnsResolverCfg.settings.hostname;
+            queryType = "AAAA";
+            expectedAnswer = dnsResolverCfg.ipv6Prefix;
+          }
+        ]
+      );
+      # [string] -> PythonTuple
+      mkPythonTuple = mkPythonCollection "(" ")";
+      dnsQueryAndExpectedAnswersPython =
+        let
+          quoteIfNonNull = x: if x == null then "None" else quote x;
+          mkList =
+            {
+              query,
+              queryType,
+              expectedAnswer,
+            }:
+            [
+              query
+              queryType
+              expectedAnswer
+            ];
+          mkTuple = attrset: mkPythonTuple (map quoteIfNonNull (mkList attrset));
+        in
+        mkPythonList (map mkTuple dnsQueryAndExpectedAnswers);
+      webInterfaceDomainOrIp =
+        if dnsResolverCfg.settings.hostname == null then
+          if dnsResolverCfg.ipv6Enabled then quoteIpv6 dnsResolverIpv6ForQuery else dnsResolverIpv4ForQuery
+        else
+          dnsResolverCfg.settings.hostname;
+    in
+    ''
+      if "${resolverKind}" == "stub":
+          dns_servers = [ authoritativeDnsServer ];
+      else:
+          dns_servers = [ rootDnsServer, tldDnsServer, authoritativeDnsServer ]
+      dns_resolver = dnsResolver
+      dns_client = ${if dnsResolverCfg.openFirewall then "dnsClient" else "dnsResolver"}
+
+      dns_resolver.start()
+      for dns_server in dns_servers:
+          dns_server.start()
+      dns_client.start()
+
+      for dns_server in dns_servers:
+          dns_server.wait_for_unit("multi-user.target")
+      dns_resolver.wait_for_unit("multi-user.target")
+      dns_client.wait_for_unit("multi-user.target")
+      for dns_server in dns_servers:
+          dns_server.wait_for_unit("knot.service")
+          dns_server.wait_until_succeeds('journalctl -u knot -g "zone file loaded"')
+      dns_resolver.wait_for_unit("dnsvizor.service")
+      dns_resolver.wait_until_succeeds('journalctl -u dnsvizor -g "${
+        if resolverKind == "stub" then "forwarding to" else "listening on"
+      }"')
+      # we assume the DNS block list is loaded after it is accessed on the web server
+      dns_resolver.wait_for_unit("caddy.service")
+      dns_resolver.wait_until_succeeds("journalctl -u caddy -g http.log.access")
+
+      dns_client.log("I am the DNS client")
+
+      with subtest("Web interface can be accessed"):
+          web_interface_url = "https://${webInterfaceDomainOrIp}"
+          if ${if dnsResolverCfg.settings.hostname == null then "True" else "False"}:
+              command = f"curl --insecure {web_interface_url}"
+          else:
+              self_signed_cert = "/tmp/self-signed-cert.pem"
+              dns_client.fail(f"curl --write-out %{{certs}} {web_interface_url} >{self_signed_cert}")
+              dns_client.succeed(f'grep "BEGIN CERTIFICATE" {self_signed_cert}')
+              command = f"curl --cacert {self_signed_cert} {web_interface_url}"
+          html = dns_client.succeed(command)
+          assert "DNSvizor" in html, "fail to check web interface"
+
+      def test_dns(dns_resolver_url, query, query_type, expected_answer):
+          query_command = " ".join([
+              "q",
+              "--format=json",
+              # self_signed_cert changes each time dnsvizor restarts
+              # to not make test flaky, we ignore TLS error instead of using self_signed_cert
+              "--tls-insecure-skip-verify",
+              f"@{dns_resolver_url}",
+              query_type,
+              query,
+          ])
+          import json
+          output = json.loads(dns_client.wait_until_succeeds(query_command))
+          actual_answer = output[0]['replies'][0]["answer"]
+          def check_answer(expected_answer, actual_answer):
+              if expected_answer is None:
+                  return expected_answer == actual_answer
+              else:
+                  if actual_answer is None:
+                      return False
+                  for answer in actual_answer:
+                      if answer[query_type.lower()] == expected_answer:
+                          return True
+                  return False
+          assert check_answer(expected_answer, actual_answer), f"expect {expected_answer}, got {actual_answer}"
+      for protocol, port in (${protocolPortsPython}).items():
+          for dns_resolver_ip_or_domain in ${dnsResolverIpOrDomainsPython}:
+              dns_resolver_url = f"{protocol}://{dns_resolver_ip_or_domain}:{port}"
+              with subtest(f"DNS query results from {dns_resolver_url} are correct"):
+                  for query, query_type, expected_answer in ${dnsQueryAndExpectedAnswersPython}:
+                      test_dns(dns_resolver_url, query, query_type, expected_answer)
+
+      with subtest("Systemd hardening works, exposure level is low"):
+          systemd_security_threshold = 49 # use a loose bound to make this test less flaky
+          output = dns_resolver.succeed(f"systemd-analyze security dnsvizor.service --threshold={systemd_security_threshold}")
+          dns_resolver.log(output)
+    '';
+}


### PR DESCRIPTION
This PR is self-contained and is **not** blocked by the DNSvizor packaging PR

I create project DNSvizor instead of working under [project MirageOS][1] because:
1. I think it is more reasonable to have one project for each MirageOS unikernel
2. Each project can only has one demo.  I do not think it makes much sense to demo all these unikernels together.  They are not tightly connected.

I am open to moving this into project MirageOS if that is indeed a better organization.

This PR depends on:
- https://github.com/NixOS/nixpkgs/pull/479944
  - thus https://github.com/ngi-nix/ngipkgs/pull/1983

## TODO / Future work

- Things marked with `TODO(linj)` are nice-to-have, but adding them needs more time.
- `TODO` comments are blocked by other things such as [upstream][3] or the [packaging][2].  When their blockers are fixed, they can be added in future PRs.

## Run tests

```
nix build -f . projects.DNSvizor.tests
```

[1]: https://github.com/ngi-nix/ngipkgs/pull/1762
[2]: https://github.com/ngi-nix/ngipkgs/pull/1907
[3]: https://github.com/robur-coop/dnsvizor/issues/117

---

almost `fix` #1958
fix #1957
fix #1959
fix #1960
fix #1961
fix #1956