### PR TITLE
tests: improve kmscon font for interactive tests

### DIFF
--- a/projects/tests.nix
+++ b/projects/tests.nix
@@ -24,6 +24,12 @@ let
           services.kmscon = {
             enable = true;
             autologinUser = "root";
+            fonts = [
+              {
+                name = "Hack";
+                package = pkgs.hack-font;
+              }
+            ];
           };
         };
       debugging.interactive.nodes = lib.mapAttrs (_: _: tools) test.nodes;


### PR DESCRIPTION
- tests: improve kmscon font for interactive tests

font before: ugly and cannot differentiate `m` and `n`!
<img width="2564" height="228" alt="ngi-vm-test-font-before" src="https://github.com/user-attachments/assets/7c2c51ab-cb1d-438f-b666-246b394dd0ca" />

font after
<img width="2564" height="228" alt="ngi-vm-test-font-after" src="https://github.com/user-attachments/assets/84c69563-903b-4af5-8d63-89d2e0602dec" />
