### PR TITLE
refactor: separate formatter from git hooks

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -47,6 +47,8 @@ let
       fixups = self.call ./pkgs/overlays.nix { };
     };
 
+    formatter = self.call ./maintainers/formatter.nix { };
+
     optionsDoc = pkgs.nixosOptionsDoc {
       inherit (self.project-utils.eval-projects) options;
     };

--- a/flake.lock
+++ b/flake.lock
@@ -7,7 +7,9 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "treefmt-nix": "treefmt-nix"
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
       },
       "locked": {
         "lastModified": 1768103297,
@@ -287,7 +289,8 @@
         "pre-commit-hooks": "pre-commit-hooks",
         "sbt-derivation": "sbt-derivation",
         "sops-nix": "sops-nix",
-        "systems": "systems"
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix"
       }
     },
     "sbt-derivation": {
@@ -371,16 +374,15 @@
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
-          "buildbot-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1768031762,
-        "narHash": "sha256-b2gJDJfi+TbA7Hu2sKip+1mWqya0GJaWrrXQjpbOVTU=",
+        "lastModified": 1768158989,
+        "narHash": "sha256-67vyT1+xClLldnumAzCTBvU0jLZ1YBcf4vANRWP3+Ak=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "0c445aa21b01fd1d4bb58927f7b268568af87b20",
+        "rev": "e96d59dff5c0d7fddb9d113ba108f03c3ef99eca",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,10 +8,13 @@
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   inputs.pre-commit-hooks.inputs.nixpkgs.follows = "nixpkgs";
   inputs.pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
+  inputs.treefmt-nix.url = "github:numtide/treefmt-nix";
+  inputs.treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
   inputs.sbt-derivation.inputs.nixpkgs.follows = "nixpkgs";
   inputs.sbt-derivation.url = "github:zaninime/sbt-derivation";
   inputs.sops-nix.inputs.nixpkgs.follows = "nixpkgs";
   inputs.sops-nix.url = "github:Mic92/sops-nix";
+  inputs.buildbot-nix.inputs.treefmt-nix.follows = "treefmt-nix";
   inputs.buildbot-nix.inputs.nixpkgs.follows = "nixpkgs";
   inputs.buildbot-nix.url = "github:nix-community/buildbot-nix";
   inputs.nixdoc-to-github.flake = false;

--- a/maintainers/flake/checks.nix
+++ b/maintainers/flake/checks.nix
@@ -1,10 +1,9 @@
 {
   lib,
   flake,
-  system,
-  sources,
 
   checks,
+  formatter,
   hydrated-projects,
   ngipkgs,
   overview,
@@ -66,14 +65,7 @@ let
     concatMapAttrs checksForPackage nonBrokenPackages;
 
   checksForInfrastructure = {
-    "infra/pre-commit" = sources.pre-commit-hooks.lib.${system}.run {
-      src = ./.;
-      hooks = {
-        actionlint.enable = true;
-        editorconfig-checker.enable = true;
-        nixfmt-rfc-style.enable = true;
-      };
-    };
+    "infra/pre-commit" = formatter.hooks.pre-commit;
     "infra/makemake" = toplevel self.nixosConfigurations.makemake;
     "infra/overview" = overview;
   };

--- a/maintainers/flake/default.nix
+++ b/maintainers/flake/default.nix
@@ -43,17 +43,6 @@
       buildInputs = checks."infra/pre-commit".enabledPackages ++ default.shell.nativeBuildInputs;
     };
 
-    formatter = pkgs.writeShellApplication {
-      name = "formatter";
-      text = ''
-        # shellcheck disable=all
-        shell-hook () {
-          ${checks."infra/pre-commit".shellHook}
-        }
-
-        shell-hook
-        pre-commit run --all-files
-      '';
-    };
+    formatter = default.formatter.package;
   };
 }

--- a/maintainers/formatter.nix
+++ b/maintainers/formatter.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  pkgs,
+  sources,
+  system,
+  ...
+}:
+# TODO: document formatter and pre-commit hook
+lib.makeExtensible (self: {
+  treefmt = import sources.treefmt-nix;
+  pre-commit-hooks = sources.pre-commit-hooks.lib.${system};
+
+  config = {
+    projectRootFile = "flake.nix";
+
+    programs.actionlint.enable = true;
+    programs.nixfmt.enable = true;
+    programs.zizmor.enable = false;
+
+    settings.formatter.editorconfig-checker = {
+      command = pkgs.editorconfig-checker;
+      includes = [ "*" ];
+      priority = 9; # last
+    };
+  };
+
+  # could be useful for debugging
+  eval = self.treefmt.evalModule pkgs self.config;
+
+  # treefmt package
+  package = self.treefmt.mkWrapper pkgs self.config;
+
+  # development shell that contains all formatters
+  shell = self.eval.config.build.devShell;
+
+  hooks.pre-commit = self.pre-commit-hooks.run {
+    src = ../.;
+    hooks.treefmt.package = self.package;
+  };
+})

--- a/maintainers/shells/default.nix
+++ b/maintainers/shells/default.nix
@@ -1,11 +1,21 @@
 {
   lib,
   pkgs,
-  ngipkgs,
   nixdoc-to-github,
+
+  # toplevel attributes
+  ngipkgs,
+  formatter,
   ...
 }:
 pkgs.mkShellNoCC {
+  inputsFrom = [
+    # Include all formatter packages. Format with:
+    # $ treefmt
+    # $ nix fmt
+    formatter.shell
+  ];
+
   packages = [
     # live overview watcher
     (pkgs.devmode.override {

--- a/pkgs/by-name/bonfire/deps/.editorconfig
+++ b/pkgs/by-name/bonfire/deps/.editorconfig
@@ -1,0 +1,7 @@
+[*.hash]
+charset = unset
+end_of_line = unset
+insert_final_newline = unset
+trim_trailing_whitespace = unset
+indent_size = unset
+indent_style = unset

--- a/pkgs/by-name/bonfire/extensions/community/fetchFromGitHub.nix
+++ b/pkgs/by-name/bonfire/extensions/community/fetchFromGitHub.nix
@@ -1,4 +1,4 @@
-{fetchFromGitHub, ...}:
+{ fetchFromGitHub, ... }:
 fetchFromGitHub {
   owner = "bonfire-networks";
   repo = "community";

--- a/pkgs/by-name/bonfire/extensions/cooperation/fetchFromGitHub.nix
+++ b/pkgs/by-name/bonfire/extensions/cooperation/fetchFromGitHub.nix
@@ -1,4 +1,4 @@
-{fetchFromGitHub, ...}:
+{ fetchFromGitHub, ... }:
 fetchFromGitHub {
   owner = "bonfire-networks";
   repo = "cooperation";

--- a/pkgs/by-name/bonfire/extensions/coordination/fetchFromGitHub.nix
+++ b/pkgs/by-name/bonfire/extensions/coordination/fetchFromGitHub.nix
@@ -1,4 +1,4 @@
-{fetchFromGitHub, ...}:
+{ fetchFromGitHub, ... }:
 fetchFromGitHub {
   owner = "bonfire-networks";
   repo = "coordination";

--- a/pkgs/by-name/bonfire/extensions/ember/fetchFromGitHub.nix
+++ b/pkgs/by-name/bonfire/extensions/ember/fetchFromGitHub.nix
@@ -1,4 +1,4 @@
-{fetchFromGitHub, ...}:
+{ fetchFromGitHub, ... }:
 fetchFromGitHub {
   owner = "bonfire-networks";
   repo = "ember";

--- a/pkgs/by-name/bonfire/extensions/open_science/fetchFromGitHub.nix
+++ b/pkgs/by-name/bonfire/extensions/open_science/fetchFromGitHub.nix
@@ -1,4 +1,4 @@
-{fetchFromGitHub, ...}:
+{ fetchFromGitHub, ... }:
 fetchFromGitHub {
   owner = "bonfire-networks";
   repo = "open_science";

--- a/pkgs/by-name/bonfire/extensions/social/fetchFromGitHub.nix
+++ b/pkgs/by-name/bonfire/extensions/social/fetchFromGitHub.nix
@@ -1,4 +1,4 @@
-{fetchFromGitHub, ...}:
+{ fetchFromGitHub, ... }:
 fetchFromGitHub {
   owner = "bonfire-networks";
   repo = "social";

--- a/pkgs/by-name/bonfire/generic.nix
+++ b/pkgs/by-name/bonfire/generic.nix
@@ -490,17 +490,17 @@ beamPkgs.mixRelease (finalAttrs: {
               cat >>config/config.exs <<EOF
 
               config :autumn,
-                     Autumn.Native,
-                     skip_compilation?: true,
-                     load_from: {:autumn, "priv/native/libautumnus_nif"}
+                      Autumn.Native,
+                      skip_compilation?: true,
+                      load_from: {:autumn, "priv/native/libautumnus_nif"}
               config :mdex,
-                     MDEx.Native,
-                     skip_compilation?: true,
-                     load_from: {:mdex, "priv/native/libcomrak_nif"}
+                      MDEx.Native,
+                      skip_compilation?: true,
+                      load_from: {:mdex, "priv/native/libcomrak_nif"}
               config :mjml,
-                     Mjml.Native,
-                     skip_compilation?: true,
-                     load_from: {:mjml, "priv/native/libmjml_nif"}
+                      Mjml.Native,
+                      skip_compilation?: true,
+                      load_from: {:mjml, "priv/native/libmjml_nif"}
               EOF
             ''
           ]
@@ -611,8 +611,8 @@ beamPkgs.mixRelease (finalAttrs: {
     (lib.concatMapStringsSep "\n" (dep: ''
       rm -rf deps/${dep}
       cp --no-preserve=mode -r \
-         ${finalAttrs.passthru.mixNixDeps.${dep}.src} \
-         deps/${dep}
+        ${finalAttrs.passthru.mixNixDeps.${dep}.src} \
+        deps/${dep}
       pushd deps/${dep}/assets
       yarnOfflineCache="${finalAttrs.passthru.yarnOfflineCaches.${dep}.package}" \
       PATH="${lib.makeBinPath [ yarn ]}:$PATH" \
@@ -624,8 +624,8 @@ beamPkgs.mixRelease (finalAttrs: {
     (lib.concatMapStringsSep "\n" (dep: ''
       rm -rf deps/${dep}
       cp --no-preserve=mode -r \
-         ${finalAttrs.passthru.mixNixDeps.${dep}.src} \
-         deps/${dep}
+        ${finalAttrs.passthru.mixNixDeps.${dep}.src} \
+        deps/${dep}
       pushd deps/${dep}/assets
       yarnOfflineCache="${finalAttrs.passthru.yarnBerryOfflineCaches.${dep}.package}" \
       missingHashes="${finalAttrs.passthru.yarnBerryOfflineCaches.${dep}.package.missingHashes}" \

--- a/pkgs/by-name/bonfire/update.nix
+++ b/pkgs/by-name/bonfire/update.nix
@@ -5,7 +5,6 @@
   nix,
   nurl,
   writeShellApplication,
-  writeTextDir,
   callPackage,
 }:
 let
@@ -40,14 +39,17 @@ in
 
       # Description: update pkgs/by-name/bonfire/${FLAVOUR}/deps.nix
       # using deps_nix.
+      # bash
       ''
-        deps=$(nix -L --show-trace --extra-experimental-features "nix-command" \
-                   build \
-                   --option sandbox relaxed \
-                   --no-link --print-out-paths \
-                   --repair \
-                   -f . \
-                   bonfire.${FLAVOUR}.passthru.update.package )
+        deps=$(
+            nix -L --show-trace --extra-experimental-features "nix-command" \
+                build \
+                --option sandbox relaxed \
+                --no-link --print-out-paths \
+                --repair \
+                -f . \
+                bonfire.${FLAVOUR}.passthru.update.package
+        )
         cp -f "$deps" pkgs/by-name/bonfire/extensions/${FLAVOUR}/deps.nix
       ''
 

--- a/profiles/pkgs/development/beam-modules/mix-update.nix
+++ b/profiles/pkgs/development/beam-modules/mix-update.nix
@@ -39,22 +39,23 @@ package.overrideAttrs (
         # Applies: manuals/Contributor/Why_to/develop/a_package/using_Elixir/with_deps_nix.md
         ''
           substituteInPlace mix.exs \
-            --replace-fail '${deps_nix_injection_pattern}' \
-                           '${deps_nix_injection_pattern} [{ :deps_nix, git: "https://github.com/code-supply/deps_nix" }] ++'
+              --replace-fail \
+                '${deps_nix_injection_pattern}' \
+                '${deps_nix_injection_pattern} [{ :deps_nix, git: "https://github.com/code-supply/deps_nix" }] ++'
         ''
         # Explanation: re-enable downloading of well-known precompiled Rust libs.
         ''
           mkdir -p config
           cat >>config/config.exs <<EOF
           config :autumn,
-                 Autumn.Native,
-                 skip_compilation?: true
+                  Autumn.Native,
+                  skip_compilation?: true
           config :mdex,
-                 MDEx.Native,
-                 skip_compilation?: true
+                  MDEx.Native,
+                  skip_compilation?: true
           config :mjml,
-                 Mjml.Native,
-                 skip_compilation?: true
+                  Mjml.Native,
+                  skip_compilation?: true
           EOF
         ''
       ];

--- a/projects/Funkwhale/services/funkwhale/module.nix
+++ b/projects/Funkwhale/services/funkwhale/module.nix
@@ -209,7 +209,7 @@ in
 
         # Set `cfg.settings` environment variables.
         ${lib.concatMapAttrsStringSep "\n" (
-          name: value: ''export ${name}=${lib.escapeShellArg value}''
+          name: value: "export ${name}=${lib.escapeShellArg value}"
         ) cfg.settings}
 
         # Set secret environment variables.

--- a/projects/Kazarma/services/kazarma/examples/basic.nix
+++ b/projects/Kazarma/services/kazarma/examples/basic.nix
@@ -51,7 +51,7 @@ in
     enable = true;
     username = "username";
     servername = "servername";
-    passwordFile = pkgs.writeText ''honk-password'' "password";
+    passwordFile = pkgs.writeText "honk-password" "password";
   };
 
   services.matrix-synapse = {


### PR DESCRIPTION
This should also fix inconsistencies with formatter versions. Test with:

```shellSession
$ nix fmt
$ nix-shell --run treefmt
```

**Note:** before this change, `nix fmt` wouldn't fail, even though some files weren't correctly formatted.

Closes: https://github.com/ngi-nix/ngipkgs/issues/1880
Closes: https://github.com/ngi-nix/ngipkgs/pull/864