### PR TITLE
tests: let the module system merge interactive test configs

### DIFF
--- a/projects/tests.nix
+++ b/projects/tests.nix
@@ -33,14 +33,14 @@ let
           };
         };
       debugging.interactive.nodes = lib.mapAttrs (_: _: tools) test.nodes;
-      args = lib.mergeAttrsList [
-        debugging
-        test
-        {
-          # we need to extend pkgs with ngipkgs, so it can't be read-only
-          node.pkgsReadOnly = false;
-        }
-      ];
+      args = {
+        imports = [
+          debugging
+          test
+        ];
+        # we need to extend pkgs with ngipkgs, so it can't be read-only
+        node.pkgsReadOnly = false;
+      };
     in
     if lib.isDerivation test then test else pkgs.testers.runNixOSTest args;
 


### PR DESCRIPTION
Previously, if `interactive` was used in the test itself, these interactive test configs were silently ignored.

### How to verify this patch works?

Currently, when the test itself does not set `interactive`, it works as expected.

```shellSession
$ nix eval -f . hydrated-projects.Mox.nixos.tests.basic.config.interactive.nodes.machine.services.kmscon.enable
true
```

Now, add `interactive = { };` to `projects/Mox/services/mox/tests/basic.nix`.  The interactive test config is lost.

```shellSession
$ nix eval -f . hydrated-projects.Mox.nixos.tests.basic.config.interactive.nodes.machine.services.kmscon.enable
false
```

Now, apply this patch.  The interactive test config works again.
```shellSession
$ nix eval -f . hydrated-projects.Mox.nixos.tests.basic.config.interactive.nodes.machine.services.kmscon.enable
true
```
