### PR TITLE
fix: wrong optionsDoc for modules

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -49,10 +49,6 @@ let
 
     formatter = self.call ./maintainers/formatter.nix { };
 
-    optionsDoc = pkgs.nixosOptionsDoc {
-      inherit (self.project-utils.eval-projects) options;
-    };
-
     overview = self.import ./overview {
       self = flake;
       pkgs = pkgs.extend self.overlays.default;
@@ -88,6 +84,7 @@ let
     inherit (self.project-utils)
       checks
       hydrated-projects
+      optionsDoc
       ;
 
     projects = lib.mapAttrs (name: value: {


### PR DESCRIPTION
This also fixes the missing options regression in the overview.

<img width="472" height="364" alt="image" src="https://github.com/user-attachments/assets/209aec36-dc51-43ba-b636-88680af406cc" />