### PR TITLE
refactor: coerce leaf test modules into derivations 

### DIFF
--- a/maintainers/types/default.nix
+++ b/maintainers/types/default.nix
@@ -5,6 +5,8 @@
 */
 {
   lib,
+  pkgs,
+  sources,
   ...
 }@args:
 let

--- a/maintainers/types/example.nix
+++ b/maintainers/types/example.nix
@@ -78,7 +78,7 @@ in
     };
     tests = mkOption {
       description = "at least one test for the example";
-      type = with types; attrsOf test;
+      type = with types; lazyAttrsOf test;
       default = { };
     };
     links = mkOption {

--- a/maintainers/types/module.nix
+++ b/maintainers/types/module.nix
@@ -125,7 +125,7 @@ in
       '';
     };
     examples = mkOption {
-      type = with types; attrsOf example;
+      type = with types; lazyAttrsOf example;
       description = ''
         Configurations that illustrate how to set up the ${type}.
 

--- a/maintainers/types/project.nix
+++ b/maintainers/types/project.nix
@@ -132,7 +132,7 @@ in
               we can still reduce granularity and move all examples to the application level.
             */
             examples = mkOption {
-              type = attrsOf example;
+              type = lazyAttrsOf example;
               description = "A configuration of an existing application module that illustrates how to use it";
               default = { };
             };
@@ -141,7 +141,7 @@ in
             #       Without this field, many applications will appear entirely untested although there's actually *some* assurance that *something* works.
             #       Eventually we want to move to documentable tests exclusively, and then remove this field, but this may take a very long time.
             tests = mkOption {
-              type = attrsOf test;
+              type = lazyAttrsOf test;
               default = { };
               description = "NixOS test that ensures project components behave as intended";
             };

--- a/maintainers/types/test.nix
+++ b/maintainers/types/test.nix
@@ -100,7 +100,7 @@ let
     else if test ? meta.broken && test.meta.broken then
       null
     else
-      pkgs.testers.runNixOSTest args;
+      lib.lazyDerivation { derivation = pkgs.testers.runNixOSTest args; };
 
   callTest =
     module:
@@ -128,7 +128,9 @@ in
       # This is because test nodes are eagerly evaluated to create the
       # driver's `vmStartScripts` (see `nixos/lib/testing/driver.nix` in
       # NixOS).
-      type = with types; nullOr (coercedTo (either deferredModule package) callTest (nullOr package));
+      type =
+        with types;
+        nullOr (coercedTo (either deferredModule package) callTest (nullOr deferredModule));
       default = null;
       description = "NixOS test module";
     };

--- a/maintainers/types/test.nix
+++ b/maintainers/types/test.nix
@@ -39,6 +39,9 @@
 */
 {
   lib,
+  pkgs,
+  sources,
+  config,
   ngiTypes,
   ...
 }:
@@ -52,6 +55,66 @@ let
   inherit (ngiTypes)
     problem
     ;
+
+  # TODO: move into `lib.nix`?
+  nixosTest =
+    test:
+    let
+      # Amenities for interactive tests
+      tools = {
+        environment.systemPackages = with pkgs; [
+          vim
+          tmux
+          jq
+        ];
+        # Use kmscon <https://www.freedesktop.org/wiki/Software/kmscon/>
+        # to provide a slightly nicer console.
+        # kmscon allows zooming with [Ctrl] + [+] and [Ctrl] + [-]
+        services.kmscon = {
+          enable = true;
+          autologinUser = "root";
+          fonts = [
+            {
+              name = "Hack";
+              package = pkgs.hack-font;
+            }
+          ];
+        };
+      };
+
+      debugging.interactive.nodes = lib.mapAttrs (_: _: tools) test.nodes;
+
+      args = {
+        imports = [
+          debugging
+          test
+        ];
+        # we need to extend pkgs with ngipkgs, so it can't be read-only
+        node.pkgsReadOnly = false;
+      };
+    in
+    if lib.isDerivation test then
+      lib.lazyDerivation { derivation = test; }
+    else if test == null || config.problem != null then
+      null
+    else if test ? meta.broken && test.meta.broken then
+      null
+    else
+      pkgs.testers.runNixOSTest args;
+
+  callTest =
+    module:
+    if lib.isString module || lib.isPath module then
+      nixosTest (
+        import module {
+          inherit pkgs lib sources;
+          inherit (pkgs) system;
+        }
+      )
+    else if module == null || config.problem != null then
+      null
+    else
+      nixosTest module;
 in
 
 {
@@ -65,7 +128,7 @@ in
       # This is because test nodes are eagerly evaluated to create the
       # driver's `vmStartScripts` (see `nixos/lib/testing/driver.nix` in
       # NixOS).
-      type = with types; nullOr (either deferredModule package);
+      type = with types; nullOr (coercedTo (either deferredModule package) callTest (nullOr package));
       default = null;
       description = "NixOS test module";
     };

--- a/projects/CNSPRCY/default.nix
+++ b/projects/CNSPRCY/default.nix
@@ -20,19 +20,17 @@
   };
 
   nixos.modules.programs.cnsprcy = {
-    name = "cnsprcy";
     module = ./programs/cnsprcy/module.nix;
-    examples.basic = {
+    examples."Enable CNSPRCY program" = {
       module = ./programs/cnsprcy/examples/basic.nix;
       description = "Checks for cnspr executable";
       tests.basic.module = ./programs/cnsprcy/tests/basic.nix;
     };
   };
 
-  nixos.modules.services.cnsprcy = {
-    name = "cnsprcy";
+  nixos.modules.services.cnsprcy-server = {
     module = ./services/cnsprcy/module.nix;
-    examples.basic = {
+    examples."Enable CNSPRCY service" = {
       module = ./services/cnsprcy/examples/basic.nix;
       description = "Checks that cnsprcy systemd service is running";
       tests.basic.module = ./services/cnsprcy/tests/basic.nix;

--- a/projects/CNSPRCY/programs/cnsprcy/tests/basic.nix
+++ b/projects/CNSPRCY/programs/cnsprcy/tests/basic.nix
@@ -13,7 +13,7 @@
         imports = [
           sources.modules.ngipkgs
           sources.modules.programs.cnsprcy
-          sources.examples.CNSPRCY.basic
+          sources.examples.CNSPRCY."Enable CNSPRCY program"
         ];
       };
   };

--- a/projects/CNSPRCY/services/cnsprcy/tests/basic.nix
+++ b/projects/CNSPRCY/services/cnsprcy/tests/basic.nix
@@ -11,8 +11,8 @@
       {
         imports = [
           sources.modules.ngipkgs
-          sources.modules.services.cnsprcy
-          sources.examples.CNSPRCY.basic
+          sources.modules.services.cnsprcy-server
+          sources.examples.CNSPRCY."Enable CNSPRCY service"
         ];
         networking.firewall.enable = false;
       };
@@ -21,8 +21,8 @@
       {
         imports = [
           sources.modules.ngipkgs
-          sources.modules.services.cnsprcy
-          sources.examples.CNSPRCY.basic
+          sources.modules.services.cnsprcy-server
+          sources.examples.CNSPRCY."Enable CNSPRCY service"
         ];
         networking.firewall.enable = false;
       };

--- a/projects/kbin/default.nix
+++ b/projects/kbin/default.nix
@@ -26,10 +26,10 @@
   };
 
   nixos.modules.services = {
-    kbin = {
+    kbin-service = {
       name = "kbin";
       module = ./services/kbin/module.nix;
-      examples.basic = {
+      examples.basic-service = {
         module = ./services/kbin/examples/basic.nix;
         description = "";
         tests.basic.module = ./services/kbin/tests/basic.nix;

--- a/projects/kbin/services/kbin/tests/basic.nix
+++ b/projects/kbin/services/kbin/tests/basic.nix
@@ -21,8 +21,8 @@ in
       {
         imports = [
           sources.modules.ngipkgs
-          sources.modules.services.kbin
-          sources.examples.kbin.basic
+          sources.modules.services.kbin-service
+          sources.examples.kbin.basic-service
         ];
 
         services.phpfpm.pools.kbin = {


### PR DESCRIPTION
which is much simpler than collecting all the modules and converting them later on. The result is also easier to work with since it's either null or a derivation, as opposed to it potentially being a path or a module.

For now, tests are still passed to [`projects/tests.nix`](https://github.com/ngi-nix/ngipkgs/blob/912fdeb04b02fb9c4560ce5d32d597e9992195c3/projects/tests.nix), which is fine since they should already be derivations. We will clean this up when we migrate away from `hydrated-projects`.