### PR TITLE
fix: docs/project.md generation via nixdoc-to-github

### DIFF
--- a/maintainers/docs/project.md
+++ b/maintainers/docs/project.md
@@ -1,5 +1,6 @@
 # NGI Project Types
-This is a reference document that describes the structure of an NGI project as defined in [projects/types.nix](https://github.com/ngi-nix/ngipkgs/blob/main/projects/types.nix) and how to implement each of its components.
+
+This is a reference document that describes the structure of an NGI project as defined in [maintainers/types](https://github.com/ngi-nix/ngipkgs/tree/main/maintainers/types) and how to implement each of its components.
 
 To implement a full project, please refer to [`CONTRIBUTING.md`](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md) and the [project template](https://github.com/ngi-nix/ngipkgs/blob/main/maintainers/templates/project/default.nix).
 
@@ -132,9 +133,9 @@ Binary files (raw, firmware, schematics, ...).
 > ```
 >
 
-## `lib.program`
+## `lib.module`
 
-Software that runs in a shell.
+NixOS module, either for a program that runs in the shell, or a service that runs in the background.
 
 > **Example**
 >
@@ -147,6 +148,23 @@ Software that runs in a shell.
 >       module = ./programs/PROGRAM_NAME/examples/basic.nix;
 >       description = "Basic configuration example for PROGRAM_NAME";
 >       tests.basic.module = ./programs/PROGRAM_NAME/tests/basic.nix;
+>     };
+>   };
+> }
+> ```
+>
+
+> **Example**
+>
+> ```nix
+> { ... }@args:
+> {
+>   nixos.modules.services.SERVICE_NAME = {
+>     module = ./services/SERVICE_NAME/module.nix;
+>     examples."Enable SERVICE_NAME" = {
+>       module = ./services/SERVICE_NAME/examples/basic.nix;
+>       description = "Basic configuration example for SERVICE_NAME";
+>       tests.basic.module = ./services/SERVICE_NAME/tests/basic.nix;
 >     };
 >   };
 > }
@@ -185,76 +203,16 @@ Where `module.nix` contains:
 }
 ```
 
-> [!TIP]
-> You can use the [NixOS Search](https://search.nixos.org/options?channel=unstable) to check if modules exist upstream.
-
-> [!NOTE]
-> - Each program must include at least one example, so users get an idea of what to do with it (see [example](#libexample)).
-> - Examples must be tested (see [test](#libtest)).
-
-After implementing the program, run the [checks](#checks) to make sure that everything is correct.
-
-## `lib.service`
-
-Software that runs as a background process.
-
-> **Example**
->
-> ```nix
-> { ... }@args:
-> {
->   nixos.modules.services.SERVICE_NAME = {
->     module = ./services/SERVICE_NAME/module.nix;
->     examples."Enable SERVICE_NAME" = {
->       module = ./services/SERVICE_NAME/examples/basic.nix;
->       description = "Basic configuration example for SERVICE_NAME";
->       tests.basic.module = ./services/SERVICE_NAME/tests/basic.nix;
->     };
->   };
-> }
-> ```
->
-
-For modules that reside in NixOS, use:
-
-```nix
-{ lib, ... }:
-{
-  nixos.modules.services.SERVICE_NAME.module = lib.moduleLocFromOptionString "services.SERVICE_NAME";
-}
-```
-
-If you want to extend such modules, you can import them in a new module:
-
-```nix
-{
-  nixos.modules.services.SERVICE_NAME.module = ./module.nix;
-}
-```
-
-Where `module.nix` contains:
-
-```nix
-{ lib, ... }:
-{
-  imports = [
-    (lib.moduleLocFromOptionString "services.SERVICE_NAME")
-  ];
-
-  options.services.SERVICE_NAME = {
-    extraOption = lib.mkEnableOption "extra option";
-  };
-}
-```
+The same applies to services as well for the examples, above.
 
 > [!TIP]
 > You can use the [NixOS Search](https://search.nixos.org/options?channel=unstable) to check if modules exist upstream.
 
 > [!NOTE]
-> - Each service must include at least one example, so users get an idea of what to do with it (see [example](#libexample)).
+> - Each module must include at least one example, so users get an idea of what to do with it (see [example](#libexample)).
 > - Examples must be tested (see [test](#libtest)).
 
-After implementing the service, run the [checks](#checks) to make sure that everything is correct.
+After implementing the module, run the [checks](#checks) to make sure that everything is correct.
 
 ## `lib.example`
 
@@ -363,7 +321,21 @@ For the latter, it could be something like:
 > [!TIP]
 > [Example](#libexample) modules can also be used for demos, if they clearly describe how the application should be configured and used.
 
-After implementing the demo, run the [checks](#checks) to make sure that everything is correct.
+After implementing the demo, run the following commands to test it:
+
+- With classic Nix:
+
+  ```shellSession
+  nix-build -A demos.PROJECT_NAME
+  ```
+
+- With flakes:
+
+  ```shellSession
+  nix run .#demos.PROJECT_NAME
+  ```
+
+Then, run the [checks](#checks) to make sure that everything is correct.
 
 ## `lib.test`
 
@@ -403,5 +375,4 @@ Tests with issues need to be labeled as broken, with a clear description of the 
 > '';
 > ```
 >
-
 

--- a/maintainers/shells/default.nix
+++ b/maintainers/shells/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   pkgs,
-  nixdoc-to-github,
+  callPackage,
 
   # toplevel attributes
   ngipkgs,
@@ -111,11 +111,6 @@ pkgs.mkShellNoCC {
     })
 
     # nix-shell --run nixdoc-to-github
-    (nixdoc-to-github.lib.nixdoc-to-github.run {
-      description = "NGI Project Types";
-      category = "";
-      file = "${toString ../../projects/types.nix}";
-      output = "${toString ../../maintainers/docs/project.md}";
-    })
+    (callPackage ./nixdoc-to-github.nix { })
   ];
 }

--- a/maintainers/shells/nixdoc-to-github.nix
+++ b/maintainers/shells/nixdoc-to-github.nix
@@ -1,0 +1,76 @@
+# nix-shell --run nixdoc-to-github
+{
+  lib,
+  gnused,
+  gitMinimal,
+  runCommand,
+  writeShellScriptBin,
+
+  nixdoc-to-github,
+}:
+let
+  mkDocPart =
+    file:
+    nixdoc-to-github.lib.nixdoc-to-github.run {
+      description = "\\\`lib.${file.name}\\\`";
+      category = "";
+      file = file.path; # copied to store
+      output = "\${out:-}";
+    };
+
+  docPart =
+    file:
+    runCommand "docpart-${file.name}"
+      {
+        nativeBuildInputs = [ gnused ];
+      }
+      ''
+        source ${lib.getExe (mkDocPart file)}
+
+        # remove a lib.default header
+        sed -i 's/^# `lib.default`$//g' $out
+
+        # decrease h2 to h3
+        sed -i 's/^## .*$/#&/g' $out
+
+        # decrease h1 to h2
+        sed -i 's/^# `lib.*$/#&\n/g' $out
+
+        # remove extra newline at the end
+        head -c -1 $out >tmp && mv tmp $out
+      '';
+
+  cmd =
+    let
+      projectRoot = "$(${lib.getExe gitMinimal} rev-parse --show-toplevel)";
+      outFile = "$projectRoot/maintainers/docs/project.md";
+      typesDir = ../types;
+
+      types = [
+        "default"
+        "project"
+        "metadata"
+        "subgrant"
+        "link"
+        "binary"
+        "module"
+        "example"
+        "demo"
+        "test"
+      ];
+
+      files = map (fileName: {
+        name = fileName;
+        path = typesDir + "/${fileName}.nix";
+      }) types;
+    in
+    writeShellScriptBin "nixdoc-to-github" ''
+      projectRoot=${projectRoot}
+      outFile=${outFile}
+      echo "# NGI Project Types" >"$outFile"
+      ${lib.concatLines (lib.map (file: "cat ${docPart file} >>\"$outFile\"") files)}
+    '';
+in
+cmd.overrideAttrs {
+  meta.description = "convert NGI-project types' nixdoc to GitHub markdown";
+}

--- a/maintainers/types/default.nix
+++ b/maintainers/types/default.nix
@@ -1,3 +1,8 @@
+/**
+  This is a reference document that describes the structure of an NGI project as defined in [maintainers/types](https://github.com/ngi-nix/ngipkgs/tree/main/maintainers/types) and how to implement each of its components.
+
+  To implement a full project, please refer to [`CONTRIBUTING.md`](https://github.com/ngi-nix/ngipkgs/blob/main/CONTRIBUTING.md) and the [project template](https://github.com/ngi-nix/ngipkgs/blob/main/maintainers/templates/project/default.nix).
+*/
 {
   lib,
   ...

--- a/overview/content-types/option-list.nix
+++ b/overview/content-types/option-list.nix
@@ -36,7 +36,7 @@ in
             >${join "." self.prefix}</span>
           ''
           + optionalString (self.module == null) ''
-            <a href="https://github.com/ngi-nix/ngipkgs/blob/main/maintainers/docs/project.md#libprogram">Implement missing module</a>
+            <a href="https://github.com/ngi-nix/ngipkgs/blob/main/maintainers/docs/project.md#libmodule">Implement missing module</a>
           '';
         in
         optionalString (self.project-options != [ ] || self.module == null) ''


### PR DESCRIPTION
After the recent restructuring of projects/types.nix, the nixdoc-to-github uitlity cannot create the project.md anymore

this fixes that in a way where `nix-shell --run nixdoc-to-github` still works, but it has to be run that exact way.

I've tried a naive `cat *.nix` into a single types.nix and tried to use nixdoc-to-github on that but did not produce a valid doc. So I had to do this ugly hack instead.