### PR TITLE
ci: check formatting in pre-commit hook

### DIFF
--- a/maintainers/formatter.nix
+++ b/maintainers/formatter.nix
@@ -35,6 +35,7 @@ lib.makeExtensible (self: {
 
   hooks.pre-commit = self.pre-commit-hooks.run {
     src = ../.;
-    hooks.treefmt.package = self.package;
+    hooks.treefmt.enable = true;
+    hooks.treefmt.packageOverrides.treefmt = self.package;
   };
 })


### PR DESCRIPTION
When we split the formatter and the pre-commit hook, the former stopped working in the latter. This change re-enables it in the hook, but running `nix fmt` will still only format code.