### PR TITLE
pysfcgal: init at 2.2.0

### DIFF
--- a/pkgs/by-name/pysfcgal/package.nix
+++ b/pkgs/by-name/pysfcgal/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  python3,
+  fetchFromGitLab,
+  sfcgal,
+}:
+
+python3.pkgs.buildPythonPackage (finalAttrs: {
+  pname = "pysfcgal";
+  version = "2.2.0";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    owner = "sfcgal";
+    repo = "pysfcgal";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/G6yC7u2CYM7D9xO2IOB8+AjWc4ErzTIdvHmwGRxXBc=";
+  };
+
+  strictDeps = true;
+
+  buildInputs = [
+    sfcgal
+  ];
+
+  build-system = with python3.pkgs; [
+    setuptools
+    wheel
+  ];
+
+  dependencies = with python3.pkgs; [
+    cffi
+  ];
+
+  pythonImportsCheck = [
+    "pysfcgal"
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytestCheckHook
+  ];
+
+  checkInputs = with python3.pkgs; [
+    icontract
+  ];
+
+  preCheck = ''
+    rm -rf pysfcgal
+  '';
+
+  disabledTests = [
+    "test_wrap_geom_segfault"
+  ];
+
+  meta = {
+    description = "Python wrapper for SFCGAL";
+    homepage = "https://gitlab.com/sfcgal/pysfcgal";
+    changelog = "https://gitlab.com/sfcgal/pysfcgal/-/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.gpl3Plus;
+    teams = with lib.teams; [
+      geospatial
+      ngi
+    ];
+  };
+})


### PR DESCRIPTION
closes #2051 

Have disabled a test which fails

<details><summary>Details</summary>

```
___________________________ test_wrap_geom_segfault ____________________________

    def test_wrap_geom_segfault():
        segfault_code = """
    from pysfcgal.sfcgal import Triangle
    triangle = Triangle([(0, 0, 0), (1, 0, 0), (0, 1, 0)])
    for t in [triangle, triangle]:
        triangle = Triangle.from_sfcgal_geometry(triangle._geom)
        """
        proc = run(f"python3 -c '{segfault_code}'", shell=True, stdout=PIPE, stderr=PIPE)
        possibles_error_msg = [
            b"Segmentation fault (core dumped)\n",
            b'Segmentation fault\n'
        ]
>       assert proc.stderr in possibles_error_msg
E       assert b'' in [b'Segmentation fault (core dumped)\n', b'Segmentation fault\n']
E        +  where b'' = CompletedProcess(args="python3 -c '\nfrom pysfcgal.sfcgal import Triangle\ntriangle = Triangle([(0, 0, 0), (1, 0, 0), ...iangle]:\n    triangle = Tri>

tests/test_coredump.py:20: AssertionError
=========================== short test summary info ============================
FAILED tests/test_coredump.py::test_wrap_geom_segfault - assert b'' in [b'Segmentation fault (core dumped)\n', b'Segmentation fault\n']
======================== 1 failed, 235 passed in 6.91s =========================
function is not fully implemented (orientation, covering and intersections of interior shells missingWKT parse error ())
```

</details>

cc @autra
