### PR TITLE
project/DNSvizor: relax hardening option RestrictAddressFamilies

### DIFF
--- a/projects/DNSvizor/services/dnsvizor/module.nix
+++ b/projects/DNSvizor/services/dnsvizor/module.nix
@@ -363,7 +363,10 @@ in
         ProtectKernelModules = true;
         ProtectKernelTunables = true;
         ProtectProc = "invisible";
-        RestrictAddressFamilies = [ "AF_NETLINK" ];
+        RestrictAddressFamilies = [
+          "AF_NETLINK"
+          "AF_INET"
+        ];
         RestrictNamespaces = true;
         RestrictRealtime = true;
         SystemCallArchitectures = [ "native" ];


### PR DESCRIPTION
This is needed by solo5-0.10.0

fixes https://github.com/ngi-nix/ngipkgs/pull/2056#issuecomment-3872704439