### PR TITLE
fix: use correct logfile names for update-all script

### DIFF
--- a/maintainers/shells/commands/maintainance/update-all.nix
+++ b/maintainers/shells/commands/maintainance/update-all.nix
@@ -51,7 +51,7 @@
         if ! update "${sources.nixpkgs}" "${lib.getExe nix-update}" "${name}" "$@"; then
           echo "${name}" >> "$TMPDIR/failed_updates.txt"
 
-          logfile="${drv.pname or drv.name or ""}.log"
+          logfile="${lib.getName drv}.log"
           if [[ -f "$logfile" ]]; then
             mv "$logfile" "$TMPDIR"
           fi


### PR DESCRIPTION
See:
https://github.com/NixOS/nixpkgs/blob/d38169be67184e867adf2a3e585721d4c2775b13/maintainers/scripts/update.nix#L243