### PR TITLE
infra(makemake): reduce nix-eval-jobs workers count

### DIFF
--- a/infra/makemake/buildbot.nix
+++ b/infra/makemake/buildbot.nix
@@ -38,6 +38,9 @@ in
         auth.authToken.file = config.sops.secrets."cachix".path;
       };
       showTrace = true;
+
+      # reduce nix-eval-jobs workers count to avoid OOM
+      evalWorkerCount = 12;
     };
 
     buildbot-nix.worker = {


### PR DESCRIPTION
It increases the evaluation time on makemake by 2.5mins

Before:
real    2m48.862s
After:
real    5m25.314s

This is not ideal and hopefully a temporary workaround until we think of a better solution, but required for unblocking #2251 #2227