### PR TITLE
 Fix unfilled service name placeholder in Kazarma project definition

### DIFF
--- a/projects/Kazarma/default.nix
+++ b/projects/Kazarma/default.nix
@@ -34,7 +34,7 @@
 
   nixos.modules.services = {
     kazarma = {
-      name = "service name";
+      name = "Kazarma";
       module = ./services/kazarma/module.nix;
       examples."Enable kazarma" = {
         module = ./services/kazarma/examples/basic.nix;


### PR DESCRIPTION
## PR Descripton
  `projects/Kazarma/default.nix` was copied from the project template but the `name` field was never filled in — it still read `"service name"`. This
  string is used by the overview page (ngi.nixos.org) and generated documentation to label the module, so users saw "service name" instead of
  "Kazarma".

Changed `name = "service name"` to `name = "Kazarma"` to match the convention used by NodeBB (`"NodeBB"`) and Funkwhale (`"Funkwhale"`).

Fixes #2257 