### PR TITLE
Fix meta.url → meta.homepage in mcaptcha and add NGI team

### DIFF
--- a/pkgs/by-name/mcaptcha/package.nix
+++ b/pkgs/by-name/mcaptcha/package.nix
@@ -184,10 +184,11 @@ let
       buildInputs = [ openssl ];
 
       meta = {
-        url = "https://mcaptcha.org/";
+        homepage = "https://mcaptcha.org/";
         description = "mCaptcha is proof-of-work based captcha system that is privacy focused and fully automated.";
         license = lib.licenses.agpl3Plus;
         mainProgram = "mcaptcha";
+        teams = with lib.teams; [ ngi ];
       };
     };
 in


### PR DESCRIPTION
## Summary
  `pkgs/by-name/mcaptcha/package.nix` had `url = "https://mcaptcha.org/"` in its `meta` block.
  `url` is not a Nixpkgs meta attribute — the correct key is `homepage`.
  With `meta.url`, tools like `nix search` and the overview page at ngi.nixos.org showed no homepage for mCaptcha.

  Two changes in this PR:
  - Renamed `meta.url` to `meta.homepage`
  - Added `meta.teams = with lib.teams; [ ngi ]` which was missing entirely

  `meta.maintainers` is not added here — that is handled systematically in a separate issue covering all packages missing maintainers.

## Related Issue
Fixes #2258 
