### PR TITLE
Add missing meta.homepage to mcaptcha-cache, dnsvizor and firefox-meta-press

### DIFF
--- a/pkgs/by-name/dnsvizor/package.nix
+++ b/pkgs/by-name/dnsvizor/package.nix
@@ -27,6 +27,10 @@ libMirage.builds {
     '';
   };
   overrideAttrs = finalAttrs: previousAttrs: {
+    meta = {
+      homepage = "https://github.com/robur-coop/dnsvizor";
+      teams = with lib.teams; [ ngi ];
+    };
     buildInputs = previousAttrs.buildInputs or [ ] ++ [
       # Some targets, such as hvt, need static GMP (or MPIR)
       (

--- a/pkgs/by-name/firefox-meta-press/package.nix
+++ b/pkgs/by-name/firefox-meta-press/package.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   wrapFirefox,
   firefox-devedition-unwrapped,
   fetchFirefoxAddon,
@@ -12,6 +13,10 @@ let
       passthru = previousAttrs.passthru // {
         requireSigning = false;
         allowAddonSideload = true;
+      };
+      meta = previousAttrs.meta // {
+        homepage = "https://www.meta-press.es";
+        teams = with lib.teams; [ ngi ];
       };
     })
   );

--- a/pkgs/by-name/mcaptcha-cache/package.nix
+++ b/pkgs/by-name/mcaptcha-cache/package.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   rustPlatform,
   fetchFromGitHub,
 }:
@@ -22,4 +23,9 @@ rustPlatform.buildRustPackage {
 
   # error[E0425]: cannot find function `register_commands` in module `$crate::commands`
   doCheck = false;
+
+  meta = {
+    homepage = "https://github.com/mCaptcha/cache";
+    teams = with lib.teams; [ ngi ];
+  };
 }


### PR DESCRIPTION
## Summary

Three packages were missing `meta.homepage` and `meta.teams`, making
them invisible to `nix search` and blank on the overview page.

- `mcaptcha-cache`: added `lib` to function args, added `meta.homepage` pointing to `https://github.com/mCaptcha/cache` and `meta.teams`
- `dnsvizor`: added `meta.homepage` and `meta.teams` inside  `overrideAttrs` (required by the `libMirage.builds`infrastructure)
- `firefox-meta-press`: added `lib` to function args, added  `meta.homepage` and `meta.teams` directly inside the `wrapFirefox`  attribute set

## How to test

- `nix fmt` — should produce no diff
- `nix build .#checks.x86_64-linux.packages/mcaptcha-cache`
- `nix build .#checks.x86_64-linux.packages/dnsvizor`
- `nix build .#checks.x86_64-linux.packages/firefox-meta-press`

## Related Issue

Closes #2263 

## Notes

`nix fmt` and `nix build` could not be run locally as Nix is not yet installed on this machine. Please run CI checks before merging. `meta.maintainers` is intentionally omitted — will be addressed in a separate dedicated sweep across all NGI packages.