### PR TITLE
Implement NixOS VM test for Arcan program example

### DIFF
--- a/projects/Arcan/default.nix
+++ b/projects/Arcan/default.nix
@@ -40,7 +40,7 @@
       examples.base = {
         module = ./example.nix;
         description = "testing documentation";
-        tests.basic.module = null;
+        tests.basic.module = ./tests/basic.nix;
       };
       links = {
         build = {

--- a/projects/Arcan/tests/basic.nix
+++ b/projects/Arcan/tests/basic.nix
@@ -1,0 +1,27 @@
+{
+  sources,
+  ...
+}:
+{
+  name = "Arcan";
+
+  nodes = {
+    machine =
+      { ... }:
+      {
+        imports = [
+          sources.modules.ngipkgs
+          sources.modules.programs.arcan
+          sources.examples.Arcan.base
+        ];
+      };
+  };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      start_all()
+
+      machine.succeed("arcan --help")
+    '';
+}


### PR DESCRIPTION
## Summary

`projects/Arcan/default.nix` had `tests.basic.module = null`, hiding the existing example from the overview page and leaving it unverified in CI.

Added `projects/Arcan/tests/basic.nix` — a minimal NixOS VM test that imports the program module and example, then runs `arcan --help` to verify the binary is present and executable. Wired the test into `default.nix` by replacing `null` with `./tests/basic.nix`.

## How to test

- `nix fmt` — should produce no diff
- `nix build .#checks.x86_64-linux.projects/Arcan/nixos/tests/basic`

## Related Issue

Closes ngi-nix/projects#1401

## Notes

nothing extra to note