### PR TITLE
Mobilizon: add metadata links

### DIFF
--- a/projects/Mobilizon/default.nix
+++ b/projects/Mobilizon/default.nix
@@ -17,6 +17,20 @@
         "Mobilizon"
       ];
     };
+    links = {
+      homepage = {
+        text = "Homepage";
+        url = "https://mobilizon.org/";
+      };
+      docs = {
+        text = "Documentation";
+        url = "https://docs.mobilizon.org/";
+      };
+      source = {
+        text = "Source Code";
+        url = "https://framagit.org/framasoft/mobilizon";
+      };
+    };
   };
 
   nixos.modules.services = {


### PR DESCRIPTION
## Summary

`projects/Mobilizon/default.nix` was missing `metadata.links` — the
homepage and source URLs shown on the overview site. Added both
following the same pattern used in `projects/Funkwhale/default.nix`.

## How to test

- `nix fmt -- --fail-on-change` — should pass
- `nix build .#checks.x86_64-linux.projects/Mobilizon/nixos/tests/basic`
  — existing test should still pass

Part of https://github.com/ngi-nix/projects/issues/161


Closes #2283 

## Notes

The upstream module reference, example, and test were already present
from a previous commit. This PR only adds the missing metadata links.