### PR TITLE
projects(BANG): init project metadata

### DIFF
--- a/projects/BANG/default.nix
+++ b/projects/BANG/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  pkgs,
+  sources,
+  ...
+}@args:
+
+{
+  metadata = {
+    summary = "A framework for processing binary files (like firmware). It consists of an unpacker that recursively unpacks and classifies/labels files and separate analysis programs that work on the results of the unpacker.";
+    subgrants.Review = [
+      "BANG-Kaitai"
+    ];
+    links = {
+      repo = {
+        text = "Source repository";
+        url = "https://github.com/armijnhemel/binaryanalysis-ng";
+      };
+      homepage = {
+        text = "Homepage";
+        url = "https://github.com/armijnhemel/binaryanalysis-ng";
+      };
+      docs = {
+        text = "Documentation";
+        url = "https://github.com/armijnhemel/binaryanalysis-ng#readme";
+      };
+    };
+  };
+}


### PR DESCRIPTION
### Summary

Adds BANG (Binary Analysis Next Generation) project entry with metadata.

BANG is a framework for processing binary files (like firmware). 
It consists of an unpacker that recursively unpacks and classifies/labels 
files and separate analysis programs that work on the results of the unpacker.

### NLnet funding

- https://nlnet.nl/project/BANG-Kaitai/ (Binary Analysis Fund, 2019-2022)

### Related issue

Closes ngi-nix/projects#1402