### PR TITLE
kip: add meta block (description, homepage, license, maintainers) and update script

### DIFF
--- a/pkgs/by-name/kip/package.nix
+++ b/pkgs/by-name/kip/package.nix
@@ -23,6 +23,7 @@
   libressl,
   cacert,
   gnutls,
+  nix-update-script,
 }:
 let
   python-with-packages = python3.withPackages (
@@ -80,4 +81,14 @@ stdenv.mkDerivation (finalAttrs: {
   preBuild = ''
     patchShebangs test
   '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Keyful Identity Protocol — symmetric-key encryption and signing via an online KIP Service";
+    homepage = "https://gitlab.com/arpa2/kip";
+    license = lib.licenses.bsd2;
+    maintainers = [ ];
+    teams = with lib.teams; [ ngi ];
+  };
 })


### PR DESCRIPTION
## Description

Fixes ngi-nix/projects#1404
`pkgs/by-name/kip/package.nix` was missing the required `meta` block entirely, and had no update script.

### License verification

License confirmed as **BSD-2-Clause** from the upstream repository at https://gitlab.com/arpa2/kip.  
The SPDX identifier `BSD-2-Clause` is present in the source file headers (e.g. `include/arpa2/kip.h`).
