### PR TITLE
ci(makemake): use locked version of nixos-rebuild

### DIFF
--- a/.github/workflows/makemake.yaml
+++ b/.github/workflows/makemake.yaml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SSH_KEY: ${{ secrets.SSH_KEY }}
+      FLAKE_REF_ROOT: github:${{ github.repository }}/${{ github.sha }}
       FLAKE_REF_SHORT: github:${{ github.repository }}/${{ github.sha }}#makemake
       FLAKE_REF_TOPLEVEL: github:${{ github.repository }}/${{ github.sha }}#nixosConfigurations.makemake.config.system.build.toplevel
       SSH_HOST: root@makemake.ngi.nixos.org
@@ -29,7 +30,7 @@ jobs:
 
       - name: Build
         run: |
-          nix run nixpkgs#nixos-rebuild -- build \
+          nix run --inputs-from "$FLAKE_REF_ROOT" nixpkgs#nixos-rebuild -- build \
             --flake "$FLAKE_REF_SHORT" \
             --build-host "$SSH_HOST" \
             --target-host "$SSH_HOST"
@@ -41,7 +42,7 @@ jobs:
 
       - name: Deploy
         run: |
-          nix run nixpkgs#nixos-rebuild -- switch \
+          nix run --inputs-from "$FLAKE_REF_ROOT" nixpkgs#nixos-rebuild -- switch \
             --flake "$FLAKE_REF_SHORT" \
             --build-host "$SSH_HOST" \
             --target-host "$SSH_HOST"


### PR DESCRIPTION
While investigating <https://github.com/ngi-nix/infra/issues/5>, I realized we're using an unlocked reference to `nixpkgs`, which gives us some non-repeatable behavior in CI.

`--inputs-from` is a nice trick here: we now benefit from whatever locked version of nixpkgs we have in our `flake.lock`. I checked our other github workflows and didn't find any other `nix run` incantations that would benefit from this.

A side effect of this is that it works around
<https://github.com/ngi-nix/infra/issues/5>, as we'll revert to a version of nixpkgs that predates
<https://github.com/NixOS/nixpkgs/commit/f23bab46664a3a511fa10d3dcdfb8a9322b14502>.